### PR TITLE
fix(rib): service readiness throughout policy replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   queued policy changes and other mutations; the shared statistics deadline and
   complete-result requirements are unchanged.
 
+- Service RIB readiness probes throughout synchronous export-policy
+  replacement and rollback, including construction, per-peer work, and
+  cleanup. Ordinary queries remain fenced, and readiness replies retain the
+  exact Loc-RIB count and the existing transition-age limit.
+
 ### Upgrade notes
 
 - Consumers of `GetPolicyStats` or `rbgp policy stats` should use the installed

--- a/crates/rib/src/adj_rib_out.rs
+++ b/crates/rib/src/adj_rib_out.rs
@@ -55,6 +55,64 @@ pub struct AdjRibOut {
     rtc_routes: HashMap<RtcRibRouteKey, RtcRibRoute>,
 }
 
+pub(crate) fn retire_hash_map<K, V, S>(
+    map: &mut std::collections::HashMap<K, V, S>,
+    checkpoint: &mut impl FnMut(),
+) {
+    let mut entries = map.drain();
+    for entry in entries.by_ref() {
+        checkpoint();
+        drop(entry);
+        checkpoint();
+    }
+    checkpoint();
+    drop(entries);
+    checkpoint();
+}
+
+pub(crate) fn release_hash_map<K, V, S: Default>(
+    map: &mut std::collections::HashMap<K, V, S>,
+    checkpoint: &mut impl FnMut(),
+) {
+    retire_hash_map(map, checkpoint);
+    let retired = std::mem::take(map);
+    checkpoint();
+    drop(retired);
+    checkpoint();
+}
+
+/// Rebuild a route-bearing map before a known batch of inserts so no commit
+/// insert triggers a rehash. Entries move one at a time, keeping ownership
+/// and the map's keys intact.
+pub(crate) fn reserve_hash_map<K: Eq + std::hash::Hash, V>(
+    map: &mut HashMap<K, V>,
+    additional: usize,
+    checkpoint: &mut impl FnMut(),
+) {
+    let required = map
+        .len()
+        .checked_add(additional)
+        .expect("Adj-RIB-Out map exceeds addressable capacity");
+    if map.capacity() >= required {
+        return;
+    }
+
+    let old = std::mem::take(map);
+    let mut replacement = HashMap::with_capacity_and_hasher(required, rustc_hash::FxBuildHasher);
+    let mut entries = old.into_iter();
+    for (key, value) in entries.by_ref() {
+        checkpoint();
+        let previous = replacement.insert(key, value);
+        debug_assert!(previous.is_none(), "moved map entry must be unique");
+        drop(previous);
+        checkpoint();
+    }
+    checkpoint();
+    drop(entries);
+    checkpoint();
+    *map = replacement;
+}
+
 impl AdjRibOut {
     /// Create a new empty Adj-RIB-Out for the given peer.
     #[must_use]
@@ -95,29 +153,74 @@ impl AdjRibOut {
 
     /// Insert or replace an advertised route.
     pub fn insert(&mut self, route: Route) {
+        self.insert_with(route, &mut || {});
+    }
+
+    /// Insert or replace an advertised route with checkpoints around index
+    /// walks and possible allocation edges.
+    pub(crate) fn insert_with(&mut self, route: Route, checkpoint: &mut impl FnMut()) {
         let path_id = route.path_id;
+        checkpoint();
         let ids = self.prefix_path_ids.entry_or_default(route.prefix);
-        if let Some((_, handle)) = ids.iter().find(|(id, _)| *id == path_id) {
-            self.routes.set(*handle, route);
+        checkpoint();
+        let handle = ids.iter().find_map(|(id, handle)| {
+            checkpoint();
+            (*id == path_id).then_some(*handle)
+        });
+        if let Some(handle) = handle {
+            checkpoint();
+            self.routes.set(handle, route);
+            checkpoint();
         } else {
+            checkpoint();
             let handle = self.routes.insert(route);
+            checkpoint();
             ids.push((path_id, handle));
+            checkpoint();
         }
     }
 
     /// Withdraw a route by prefix and path ID. Returns `true` if it existed.
     pub fn withdraw(&mut self, prefix: &Prefix, path_id: u32) -> bool {
-        let Some(ids) = self.prefix_path_ids.get_mut(prefix) else {
-            return false;
+        self.withdraw_with(prefix, path_id, &mut || {})
+    }
+
+    /// Withdraw a route with checkpoints around index walks and retired values.
+    pub(crate) fn withdraw_with(
+        &mut self,
+        prefix: &Prefix,
+        path_id: u32,
+        checkpoint: &mut impl FnMut(),
+    ) -> bool {
+        let (handle, remove_prefix) = {
+            let Some(ids) = self.prefix_path_ids.get_mut(prefix) else {
+                return false;
+            };
+            let pos = ids.iter().position(|(id, _)| {
+                checkpoint();
+                *id == path_id
+            });
+            let Some(pos) = pos else {
+                return false;
+            };
+            checkpoint();
+            let (_, handle) = ids.swap_remove(pos);
+            checkpoint();
+            (handle, ids.is_empty())
         };
-        let Some(pos) = ids.iter().position(|(id, _)| *id == path_id) else {
-            return false;
-        };
-        let (_, handle) = ids.swap_remove(pos);
-        if ids.is_empty() {
-            self.prefix_path_ids.remove(prefix);
+        if remove_prefix {
+            checkpoint();
+            let retired = self.prefix_path_ids.remove(prefix);
+            debug_assert!(retired.is_some(), "withdrawn prefix must still be present");
+            drop(retired);
+            checkpoint();
         }
-        self.routes.remove(handle).is_some()
+        checkpoint();
+        let retired = self.routes.remove(handle);
+        let removed = retired.is_some();
+        drop(retired);
+        checkpoint();
+        removed
     }
 
     /// Look up a route by prefix and path ID.
@@ -209,6 +312,22 @@ impl AdjRibOut {
         self.prefix_path_ids = FamilyPrefixMap::default();
     }
 
+    /// Retire and release unicast state with checkpoints around every route,
+    /// index entry, and final backing allocation.
+    pub(crate) fn release_unicast_with(&mut self, checkpoint: &mut impl FnMut()) {
+        self.routes.release_with(checkpoint);
+        self.prefix_path_ids.release_with(checkpoint);
+    }
+
+    /// Reserve the unicast route slab for a known outbound batch.
+    pub(crate) fn reserve_unicast_with(
+        &mut self,
+        additional: usize,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        self.routes.reserve_with(additional, checkpoint);
+    }
+
     /// Release unused unicast route-slab tail capacity while preserving
     /// logical slot indices, route handles, occupancy, the free list, the
     /// prefix index, and every non-unicast family.
@@ -232,6 +351,18 @@ impl AdjRibOut {
         self.vpn_key_path_ids = HashMap::default();
     }
 
+    /// Retire and release VPN state while leaving every other family intact.
+    pub(crate) fn release_vpn_with(&mut self, checkpoint: &mut impl FnMut()) {
+        release_hash_map(&mut self.vpn_routes, checkpoint);
+        release_hash_map(&mut self.vpn_key_path_ids, checkpoint);
+    }
+
+    /// Reserve both VPN advertised-route indexes for a known outbound batch.
+    pub(crate) fn reserve_vpn_with(&mut self, additional: usize, checkpoint: &mut impl FnMut()) {
+        reserve_hash_map(&mut self.vpn_routes, additional, checkpoint);
+        reserve_hash_map(&mut self.vpn_key_path_ids, additional, checkpoint);
+    }
+
     #[cfg(test)]
     pub(crate) fn bench_vpn_capacities(&self) -> (usize, usize) {
         (self.vpn_routes.capacity(), self.vpn_key_path_ids.capacity())
@@ -252,6 +383,20 @@ impl AdjRibOut {
         self.rtc_routes.clear();
     }
 
+    /// Retire every advertised family while retaining its backing allocations.
+    pub(crate) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        self.routes.retire_with(checkpoint);
+        self.prefix_path_ids.retire_with(checkpoint);
+        retire_hash_map(&mut self.flowspec_routes, checkpoint);
+        retire_hash_map(&mut self.evpn_routes, checkpoint);
+        retire_hash_map(&mut self.bgpls_routes, checkpoint);
+        retire_hash_map(&mut self.vpn_routes, checkpoint);
+        retire_hash_map(&mut self.vpn_key_path_ids, checkpoint);
+        retire_hash_map(&mut self.labeled_routes, checkpoint);
+        retire_hash_map(&mut self.labeled_key_path_ids, checkpoint);
+        retire_hash_map(&mut self.rtc_routes, checkpoint);
+    }
+
     /// Return the number of advertised routes.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -266,6 +411,18 @@ impl AdjRibOut {
     #[must_use]
     pub fn bench_route_capacity(&self) -> usize {
         self.routes.capacity()
+    }
+
+    /// Return live unicast routes, raw slab slots (including holes), and
+    /// slab capacity for replacement-shape instrumentation.
+    #[cfg(feature = "bench-internals")]
+    #[must_use]
+    pub(crate) fn bench_unicast_storage_shape(&self) -> (usize, usize, usize) {
+        (
+            self.routes.len(),
+            self.routes.slot_count(),
+            self.routes.capacity(),
+        )
     }
 
     /// Return the number of exact prefixes in the secondary unicast index.
@@ -290,6 +447,15 @@ impl AdjRibOut {
     }
 
     // --- FlowSpec methods ---
+
+    /// Reserve the `FlowSpec` advertised-route map for a known outbound batch.
+    pub(crate) fn reserve_flowspec_with(
+        &mut self,
+        additional: usize,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        reserve_hash_map(&mut self.flowspec_routes, additional, checkpoint);
+    }
 
     /// Insert or replace an advertised `FlowSpec` route.
     pub fn insert_flowspec(&mut self, route: FlowSpecRoute) {
@@ -325,6 +491,11 @@ impl AdjRibOut {
 
     // --- EVPN methods (RFC 7432) ---
 
+    /// Reserve the EVPN advertised-route map for a known outbound batch.
+    pub(crate) fn reserve_evpn_with(&mut self, additional: usize, checkpoint: &mut impl FnMut()) {
+        reserve_hash_map(&mut self.evpn_routes, additional, checkpoint);
+    }
+
     /// Insert or replace an advertised EVPN route.
     pub fn insert_evpn(&mut self, route: EvpnRibRoute) {
         self.evpn_routes.insert(route.key(), route);
@@ -353,6 +524,11 @@ impl AdjRibOut {
     }
 
     // --- BGP-LS methods (ADR-0077 outbound reflection substrate) ---
+
+    /// Reserve the BGP-LS advertised-route map for a known outbound batch.
+    pub(crate) fn reserve_bgpls_with(&mut self, additional: usize, checkpoint: &mut impl FnMut()) {
+        reserve_hash_map(&mut self.bgpls_routes, additional, checkpoint);
+    }
 
     /// Insert or replace an advertised BGP-LS route.
     pub fn insert_bgpls(&mut self, route: BgpLsRibRoute) {
@@ -434,6 +610,16 @@ impl AdjRibOut {
 
     // --- Labeled-unicast methods (ADR-0077 outbound reflection substrate) ---
 
+    /// Reserve both labeled-unicast advertised-route indexes for a known batch.
+    pub(crate) fn reserve_labeled_with(
+        &mut self,
+        additional: usize,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        reserve_hash_map(&mut self.labeled_routes, additional, checkpoint);
+        reserve_hash_map(&mut self.labeled_key_path_ids, additional, checkpoint);
+    }
+
     /// Insert or replace an advertised labeled route.
     pub fn insert_labeled(&mut self, route: LabeledRibRoute) {
         let key = route.key();
@@ -485,6 +671,11 @@ impl AdjRibOut {
     }
 
     // --- RT-Constrain methods (RFC 4684 outbound reflection substrate) ---
+
+    /// Reserve the RT-Constrain advertised-route map for a known outbound batch.
+    pub(crate) fn reserve_rtc_with(&mut self, additional: usize, checkpoint: &mut impl FnMut()) {
+        reserve_hash_map(&mut self.rtc_routes, additional, checkpoint);
+    }
 
     /// Insert or replace an advertised RTC route.
     pub fn insert_rtc(&mut self, route: RtcRibRoute) {
@@ -814,6 +1005,29 @@ mod tests {
     }
 
     #[test]
+    fn checkpointed_unicast_mutations_visit_path_ids() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        let prefix = prefix_a();
+        let mut checkpoints = 0;
+
+        rib.insert_with(make_route(prefix, 1), &mut || checkpoints += 1);
+        rib.insert_with(make_route(prefix, 2), &mut || checkpoints += 1);
+
+        assert!(checkpoints >= 11);
+        assert_eq!(rib.path_ids_for_prefix(&prefix).as_slice(), [1, 2]);
+
+        checkpoints = 0;
+        assert!(rib.withdraw_with(&prefix, 2, &mut || checkpoints += 1));
+        assert!(checkpoints >= 6);
+        assert_eq!(rib.path_ids_for_prefix(&prefix).as_slice(), [1]);
+
+        checkpoints = 0;
+        assert!(rib.withdraw_with(&prefix, 1, &mut || checkpoints += 1));
+        assert!(checkpoints >= 7);
+        assert!(rib.path_ids_for_prefix(&prefix).is_empty());
+    }
+
+    #[test]
     fn index_handles_duplicate_insert() {
         let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
         let p = prefix_a();
@@ -891,6 +1105,24 @@ mod tests {
     }
 
     #[test]
+    fn release_unicast_with_checkpoints_keeps_other_families() {
+        let mut rib = AdjRibOut::with_capacity(IpAddr::V4(Ipv4Addr::LOCALHOST), 8);
+        rib.insert(make_route(prefix_a(), 1));
+        rib.insert(make_route(prefix_a(), 2));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(19), 1));
+        let mut checkpoints = 0;
+
+        rib.release_unicast_with(&mut || checkpoints += 1);
+
+        assert!(checkpoints > 0);
+        assert_eq!(rib.len(), 0);
+        assert!(rib.path_ids_for_prefix(&prefix_a()).is_empty());
+        assert_eq!(rib.vpn_len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
     fn clear_vpn_keeps_capacity_and_other_families() {
         let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
         for octet in 1..=64 {
@@ -925,6 +1157,51 @@ mod tests {
         assert_eq!(rib.bench_vpn_capacities(), (0, 0));
         assert!(rib.get(&prefix_a(), 0).is_some());
         assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn release_vpn_with_checkpoints_keeps_other_families() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 2, 0], 24, 100), 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(20), 1));
+        let mut checkpoints = 0;
+
+        rib.release_vpn_with(&mut || checkpoints += 1);
+
+        assert!(checkpoints > 0);
+        assert_eq!(rib.vpn_len(), 0);
+        assert!(
+            rib.vpn_path_ids_for_key(&vpn_nlri([10, 0, 1, 0], 24, 100).key())
+                .is_empty()
+        );
+        assert_eq!(rib.len(), 1);
+        assert_eq!(rib.bgpls_len(), 1);
+    }
+
+    #[test]
+    fn retire_with_checkpoints_every_populated_family() {
+        let mut rib = AdjRibOut::new(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        rib.insert(make_route(prefix_a(), 0));
+        rib.insert_flowspec(crate::test_support::make_flowspec_route(Ipv4Addr::new(
+            10, 0, 0, 1,
+        )));
+        rib.insert_vpn(make_vpn_route(vpn_nlri([10, 0, 1, 0], 24, 100), 1));
+        rib.insert_labeled(make_labeled_route([10, 0, 2, 0], 24, 0, 1));
+        rib.insert_bgpls(make_bgpls_route(BgpLsFamily::LinkState, bgpls_nlri(21), 1));
+        rib.insert_rtc(make_rtc_route(101, 1));
+        let mut checkpoints = 0;
+
+        rib.retire_with(&mut || checkpoints += 1);
+
+        assert!(checkpoints >= 34, "every populated family is checkpointed");
+        assert_eq!(rib.len(), 0);
+        assert_eq!(rib.flowspec_len(), 0);
+        assert_eq!(rib.vpn_len(), 0);
+        assert_eq!(rib.labeled_len(), 0);
+        assert_eq!(rib.bgpls_len(), 0);
+        assert_eq!(rib.rtc_len(), 0);
     }
 
     #[test]

--- a/crates/rib/src/manager/distribution/bgpls.rs
+++ b/crates/rib/src/manager/distribution/bgpls.rs
@@ -16,7 +16,6 @@ impl RibManager {
     #[expect(
         clippy::fn_params_excessive_bools,
         clippy::too_many_arguments,
-        clippy::too_many_lines,
         reason = "BGP-LS staging mirrors EVPN distribution context for RR/export parity"
     )]
     pub(in crate::manager) fn stage_bgpls_routes(
@@ -41,8 +40,63 @@ impl RibManager {
         bgpls_withdraw: &mut Vec<crate::route::BgpLsRouteKey>,
         force: bool,
     ) {
+        Self::stage_bgpls_routes_with_checkpoint(
+            loc_rib,
+            rib_out,
+            peer_is_rr_client,
+            keys,
+            target_peer,
+            target_peer_asn,
+            target_peer_group,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            metrics,
+            policy_stats,
+            target_peer_label,
+            bgpls_announce,
+            bgpls_withdraw,
+            force,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::fn_params_excessive_bools,
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "BGP-LS staging mirrors EVPN distribution context for RR/export parity"
+    )]
+    pub(in crate::manager) fn stage_bgpls_routes_with_checkpoint(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<crate::route::BgpLsRouteKey>,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        bgpls_announce: &mut Vec<crate::route::BgpLsRibRoute>,
+        bgpls_withdraw: &mut Vec<crate::route::BgpLsRouteKey>,
+        force: bool,
+        checkpoint: &mut impl FnMut(),
+    ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         for key in keys {
+            checkpoint();
             let family = key.family.to_afi_safi();
             if !sendable.is_some_and(|f| f.contains(&family)) {
                 if rib_out.get_bgpls(key).is_some() {
@@ -162,8 +216,10 @@ impl RibManager {
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
+            checkpoint();
             let (result, evaluation) =
                 rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+            checkpoint();
             record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
             if result.action != rustbgpd_policy::PolicyAction::Permit {
                 if rib_out.get_bgpls(key).is_some() {
@@ -174,10 +230,12 @@ impl RibManager {
 
             let mut modified = best.clone();
             if !result.modifications.is_empty() {
+                checkpoint();
                 let nh = rustbgpd_policy::apply_modifications(
                     std::sync::Arc::make_mut(&mut modified.attributes),
                     &result.modifications,
                 );
+                checkpoint();
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
@@ -200,7 +258,9 @@ impl RibManager {
             {
                 continue;
             }
+            checkpoint();
             bgpls_announce.push(modified);
+            checkpoint();
         }
     }
 

--- a/crates/rib/src/manager/distribution/evpn.rs
+++ b/crates/rib/src/manager/distribution/evpn.rs
@@ -157,7 +157,6 @@ impl RibManager {
     #[expect(
         clippy::fn_params_excessive_bools,
         clippy::too_many_arguments,
-        clippy::too_many_lines,
         reason = "EVPN staging mirrors unicast distribution context for policy parity"
     )]
     pub(in crate::manager) fn stage_evpn_routes(
@@ -177,12 +176,57 @@ impl RibManager {
         evpn_withdraw: &mut Vec<rustbgpd_wire::EvpnRouteKey>,
         force: bool,
     ) {
+        Self::stage_evpn_routes_with_checkpoint(
+            loc_rib,
+            rib_out,
+            peer_is_rr_client,
+            keys,
+            target,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            evpn_announce,
+            evpn_withdraw,
+            force,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::fn_params_excessive_bools,
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "EVPN staging mirrors unicast distribution context for policy parity"
+    )]
+    pub(in crate::manager) fn stage_evpn_routes_with_checkpoint(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<rustbgpd_wire::EvpnRouteKey>,
+        target: &mut super::ExportTarget<'_>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        evpn_announce: &mut Vec<crate::route::EvpnRibRoute>,
+        evpn_withdraw: &mut Vec<rustbgpd_wire::EvpnRouteKey>,
+        force: bool,
+        checkpoint: &mut impl FnMut(),
+    ) {
         let (target_peer, target_peer_asn, target_peer_group) = target.ctx_peer();
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let evpn_family = (Afi::L2Vpn, Safi::Evpn);
         let peer_supports_evpn = sendable.is_some_and(|f| f.contains(&evpn_family));
 
         for key in keys {
+            checkpoint();
             if !peer_supports_evpn {
                 target.gate(
                     "family",
@@ -429,7 +473,9 @@ impl RibManager {
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
+            checkpoint();
             let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+            checkpoint();
             target.record_eval(&evaluation, best.peer);
             if let Some(trace) = target.trace() {
                 trace.policy_label = export_pol.map(|chain| {
@@ -480,10 +526,12 @@ impl RibManager {
             // next-hop). Skip the deep attribute clone when nothing changes.
             let mut modified = best.clone();
             if !result.modifications.is_empty() {
+                checkpoint();
                 let nh = rustbgpd_policy::apply_modifications(
                     std::sync::Arc::make_mut(&mut modified.attributes),
                     &result.modifications,
                 );
+                checkpoint();
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
@@ -533,7 +581,9 @@ impl RibManager {
             if identical {
                 continue;
             }
+            checkpoint();
             evpn_announce.push(modified);
+            checkpoint();
         }
     }
 

--- a/crates/rib/src/manager/distribution/export_memo.rs
+++ b/crates/rib/src/manager/distribution/export_memo.rs
@@ -55,6 +55,36 @@ struct MemoEntry {
 }
 
 impl ExportMemo {
+    #[cfg(feature = "bench-internals")]
+    pub(in crate::manager) fn record_replacement_capacities(&self, manager: &super::RibManager) {
+        manager.replacement_capacity(
+            "export_memo_entries",
+            self.entries.len(),
+            self.entries.capacity(),
+        );
+        for entry in self.entries.values() {
+            manager.replacement_checkpoint(false);
+            manager.replacement_capacity(
+                "export_memo_modified",
+                entry.modified.len(),
+                entry.modified.capacity(),
+            );
+        }
+    }
+
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        for (_, mut entry) in self.entries.drain() {
+            checkpoint();
+            while let Some(modified) = entry.modified.pop() {
+                drop(modified);
+                checkpoint();
+            }
+            drop(entry);
+            checkpoint();
+        }
+        crate::adj_rib_out::release_hash_map(&mut self.entries, checkpoint);
+    }
+
     fn entry(&mut self, attrs: &Arc<Vec<PathAttribute>>) -> &mut MemoEntry {
         self.entries
             .entry(Arc::as_ptr(attrs) as usize)

--- a/crates/rib/src/manager/distribution/flowspec.rs
+++ b/crates/rib/src/manager/distribution/flowspec.rs
@@ -175,7 +175,6 @@ impl RibManager {
     /// for initial table dump and ROUTE-REFRESH responses.
     #[expect(
         clippy::too_many_arguments,
-        clippy::too_many_lines,
         reason = "FlowSpec staging keeps the family-local export ladder together"
     )]
     pub(in crate::manager) fn stage_flowspec_rules(
@@ -199,8 +198,60 @@ impl RibManager {
         fs_announce: &mut Vec<crate::route::FlowSpecRoute>,
         fs_withdraw: &mut Vec<FlowSpecKey>,
     ) {
+        Self::stage_flowspec_rules_with_checkpoint(
+            loc_rib,
+            rib_out,
+            peer_is_rr_client,
+            keys,
+            target_peer,
+            target_peer_asn,
+            target_peer_group,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            metrics,
+            policy_stats,
+            target_peer_label,
+            fs_announce,
+            fs_withdraw,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "FlowSpec staging keeps the family-local export ladder together"
+    )]
+    pub(in crate::manager) fn stage_flowspec_rules_with_checkpoint(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<FlowSpecKey>,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        fs_announce: &mut Vec<crate::route::FlowSpecRoute>,
+        fs_withdraw: &mut Vec<FlowSpecKey>,
+        checkpoint: &mut impl FnMut(),
+    ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         for key in keys {
+            checkpoint();
             if let Some(best) = loc_rib.get_flowspec(key) {
                 let fs_family = (best.afi, Safi::FlowSpec);
                 if !sendable.is_some_and(|f| f.contains(&fs_family)) {
@@ -317,8 +368,10 @@ impl RibManager {
                     local_pref: best.local_pref_attr(),
                     med: best.med_attr(),
                 };
+                checkpoint();
                 let (result, evaluation) =
                     rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+                checkpoint();
                 record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
                 if result.action == rustbgpd_policy::PolicyAction::Permit {
                     let mut modified = best.clone();
@@ -329,10 +382,12 @@ impl RibManager {
                         // otherwise insert a legacy NEXT_HOP path attribute.
                         modifications.set_next_hop = None;
                         if !modifications.is_empty() {
+                            checkpoint();
                             let next_hop = rustbgpd_policy::apply_modifications(
                                 &mut modified.attributes,
                                 &modifications,
                             );
+                            checkpoint();
                             debug_assert!(next_hop.is_none());
                         }
                     }
@@ -342,7 +397,9 @@ impl RibManager {
                         }
                         continue;
                     }
+                    checkpoint();
                     fs_announce.push(modified);
+                    checkpoint();
                 } else if rib_out.get_flowspec(key).is_some() {
                     fs_withdraw.push(key.clone());
                 }

--- a/crates/rib/src/manager/distribution/labeled.rs
+++ b/crates/rib/src/manager/distribution/labeled.rs
@@ -76,10 +76,6 @@ impl RibManager {
     /// the ORR vantage comparator when a vantage is resolved — and staged
     /// with outbound path IDs `1..=N`. Otherwise the single best is staged
     /// with `path_id = 0`.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "labeled staging mirrors the VPN multipath/single-best distribution context for RR/export parity"
-    )]
     pub(in crate::manager) fn stage_labeled_routes(
         context: &crate::manager::VpnLabeledStagingContext<'_>,
         keys: &HashSet<Prefix>,
@@ -87,6 +83,29 @@ impl RibManager {
         labeled_announce: &mut Vec<LabeledRibRoute>,
         labeled_withdraw: &mut Vec<LabeledRibRouteKey>,
     ) {
+        Self::stage_labeled_routes_with_checkpoint(
+            context,
+            keys,
+            target,
+            labeled_announce,
+            labeled_withdraw,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "labeled staging mirrors the VPN multipath/single-best distribution context for RR/export parity"
+    )]
+    pub(in crate::manager) fn stage_labeled_routes_with_checkpoint(
+        context: &crate::manager::VpnLabeledStagingContext<'_>,
+        keys: &HashSet<Prefix>,
+        target: &mut super::ExportTarget<'_>,
+        labeled_announce: &mut Vec<LabeledRibRoute>,
+        labeled_withdraw: &mut Vec<LabeledRibRouteKey>,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        let checkpoint = std::cell::RefCell::new(checkpoint);
         let &crate::manager::VpnLabeledStagingContext {
             loc_rib,
             ribs,
@@ -108,6 +127,7 @@ impl RibManager {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let split_horizon_peer = target.split_horizon_peer();
         for key in keys {
+            checkpoint.borrow_mut()();
             let family = labeled_afi_safi(key);
             // Path IDs currently advertised for this identity — the diff
             // baseline for every withdraw decision below.
@@ -115,6 +135,7 @@ impl RibManager {
             let withdraw_existing = |labeled_withdraw: &mut Vec<LabeledRibRouteKey>,
                                      existing: &[u32]| {
                 for &path_id in existing {
+                    checkpoint.borrow_mut()();
                     labeled_withdraw.push(LabeledRibRouteKey {
                         prefix: *key,
                         path_id,
@@ -170,8 +191,12 @@ impl RibManager {
                 // rank it, and stage the top N with path IDs 1..=N.
                 let mut candidates: Vec<&LabeledRibRoute> = ribs
                     .values()
-                    .flat_map(|rib| rib.iter_labeled_for_prefix(key))
+                    .flat_map(|rib| {
+                        checkpoint.borrow_mut()();
+                        rib.iter_labeled_for_prefix(key)
+                    })
                     .filter(|candidate| {
+                        checkpoint.borrow_mut()();
                         split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &labeled_suppression_probe(candidate),
@@ -187,6 +212,7 @@ impl RibManager {
                 // cost to each candidate's next-hop (comparator swap only).
                 match orr_ctx {
                     Some((orr_topology, orr_spf)) => candidates.sort_by(|a, b| {
+                        checkpoint.borrow_mut()();
                         labeled_tiebreak_orr(
                             a,
                             b,
@@ -194,7 +220,10 @@ impl RibManager {
                             orr_spf.cost_to(orr_topology, b.next_hop),
                         )
                     }),
-                    None => candidates.sort_by(|a, b| crate::loc_rib::labeled_tiebreak(a, b)),
+                    None => candidates.sort_by(|a, b| {
+                        checkpoint.borrow_mut()();
+                        crate::loc_rib::labeled_tiebreak(a, b)
+                    }),
                 }
 
                 let mut next_rank: u32 = 1;
@@ -204,6 +233,7 @@ impl RibManager {
                     key_send_max as usize
                 };
                 for candidate in &candidates {
+                    checkpoint.borrow_mut()();
                     if (next_rank as usize) > limit {
                         break;
                     }
@@ -268,7 +298,9 @@ impl RibManager {
                         local_pref: candidate.local_pref_attr(),
                         med: candidate.med_attr(),
                     };
+                    checkpoint.borrow_mut()();
                     let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+                    checkpoint.borrow_mut()();
                     target.record_eval(&evaluation, candidate.peer);
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
                         continue;
@@ -276,6 +308,7 @@ impl RibManager {
 
                     let mut modified = (*candidate).clone();
                     if !result.modifications.is_empty() {
+                        checkpoint.borrow_mut()();
                         let nh = rustbgpd_policy::apply_modifications(
                             std::sync::Arc::make_mut(&mut modified.attributes),
                             &result.modifications,
@@ -283,6 +316,7 @@ impl RibManager {
                         if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                             modified.next_hop = addr;
                         }
+                        checkpoint.borrow_mut()();
                     }
                     if super::no_advertise_export_suppressed(modified.communities()) {
                         continue;
@@ -298,6 +332,7 @@ impl RibManager {
                             .get_labeled(&out_key)
                             .is_none_or(|existing| !labeled_routes_equal(existing, &modified))
                     {
+                        checkpoint.borrow_mut()();
                         labeled_announce.push(modified);
                     }
                     next_rank += 1;
@@ -306,6 +341,7 @@ impl RibManager {
                 // Withdraw previously advertised path IDs outside the new
                 // 1..next_rank set (including a stale single-best 0 entry).
                 for &path_id in existing_path_ids {
+                    checkpoint.borrow_mut()();
                     if path_id == 0 || path_id >= next_rank {
                         labeled_withdraw.push(LabeledRibRouteKey {
                             prefix: *key,
@@ -325,8 +361,12 @@ impl RibManager {
             let best = if let Some((orr_topology, orr_spf)) = orr_ctx {
                 let winner = ribs
                     .values()
-                    .flat_map(|rib| rib.iter_labeled_for_prefix(key))
+                    .flat_map(|rib| {
+                        checkpoint.borrow_mut()();
+                        rib.iter_labeled_for_prefix(key)
+                    })
                     .filter(|candidate| {
+                        checkpoint.borrow_mut()();
                         split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &labeled_suppression_probe(candidate),
@@ -337,6 +377,7 @@ impl RibManager {
                             )
                     })
                     .min_by(|a, b| {
+                        checkpoint.borrow_mut()();
                         labeled_tiebreak_orr(
                             a,
                             b,
@@ -546,7 +587,9 @@ impl RibManager {
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
+            checkpoint.borrow_mut()();
             let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+            checkpoint.borrow_mut()();
             target.record_eval(&evaluation, best.peer);
             if let Some(trace) = target.trace() {
                 trace.policy_label = export_pol.map(|chain| {
@@ -593,6 +636,7 @@ impl RibManager {
 
             let mut modified = best.clone();
             if !result.modifications.is_empty() {
+                checkpoint.borrow_mut()();
                 let nh = rustbgpd_policy::apply_modifications(
                     std::sync::Arc::make_mut(&mut modified.attributes),
                     &result.modifications,
@@ -600,6 +644,7 @@ impl RibManager {
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
+                checkpoint.borrow_mut()();
             }
             if super::no_advertise_export_suppressed(modified.communities()) {
                 target.gate(
@@ -641,6 +686,7 @@ impl RibManager {
                         },
                     );
                 }
+                checkpoint.borrow_mut()();
                 labeled_announce.push(modified);
             } else if let Some(trace) = target.trace() {
                 trace.staged_next_hop = Some(modified.next_hop);
@@ -659,6 +705,7 @@ impl RibManager {
             // Clean up stale multi-path entries if this identity was
             // previously advertised via Add-Path and is now single-best.
             for &path_id in existing_path_ids {
+                checkpoint.borrow_mut()();
                 if path_id != 0 {
                     labeled_withdraw.push(LabeledRibRouteKey {
                         prefix: *key,

--- a/crates/rib/src/manager/distribution/mod.rs
+++ b/crates/rib/src/manager/distribution/mod.rs
@@ -71,6 +71,15 @@ impl<P> Default for UnicastDistributionResult<P> {
     }
 }
 
+impl<P> UnicastDistributionResult<P> {
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        super::retire_vec(&mut self.announce, checkpoint);
+        super::retire_vec(&mut self.withdraw, checkpoint);
+        super::retire_vec(&mut self.next_hop_override, checkpoint);
+        super::retire_vec(&mut self.policy_filtered, checkpoint);
+    }
+}
+
 /// Maximum wire-equivalence cohorts retained for one update group.
 ///
 /// Eight covers the small set of negotiated/profile variants expected inside
@@ -165,6 +174,31 @@ pub(in crate::manager) struct AlignedUnicastPayload {
 }
 
 impl OutboundCommitBatch {
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        checkpoint();
+        drop(std::mem::take(&mut self.unicast.announce));
+        checkpoint();
+        drop(std::mem::take(&mut self.unicast.next_hop_override));
+        checkpoint();
+        super::retire_vec(&mut self.withdraw, checkpoint);
+        super::retire_vec(&mut self.end_of_rib, checkpoint);
+        super::retire_vec(&mut self.refresh_markers, checkpoint);
+        super::retire_vec(&mut self.flowspec_announce, checkpoint);
+        super::retire_vec(&mut self.flowspec_withdraw, checkpoint);
+        super::retire_vec(&mut self.evpn_announce, checkpoint);
+        super::retire_vec(&mut self.evpn_withdraw, checkpoint);
+        super::retire_vec(&mut self.bgpls_announce, checkpoint);
+        super::retire_vec(&mut self.bgpls_withdraw, checkpoint);
+        super::retire_vec(&mut self.vpn_announce, checkpoint);
+        super::retire_vec(&mut self.vpn_withdraw, checkpoint);
+        super::retire_vec(&mut self.labeled_announce, checkpoint);
+        super::retire_vec(&mut self.labeled_withdraw, checkpoint);
+        super::retire_vec(&mut self.rtc_announce, checkpoint);
+        super::retire_vec(&mut self.rtc_withdraw, checkpoint);
+        drop(self.shared_group_encode.take());
+        checkpoint();
+    }
+
     #[track_caller]
     pub(in crate::manager) fn with_unicast(
         announce: Arc<[crate::route::Route]>,
@@ -215,6 +249,7 @@ impl SharedUnicastProbeCache {
         announce: &Arc<[crate::route::Route]>,
         next_hop_override: &Arc<[Option<rustbgpd_policy::NextHopAction>]>,
         target: &dyn crate::update::ExactExportSnapshot,
+        checkpoint: &mut impl FnMut(),
     ) -> Option<Vec<Result<crate::update::ExactExportResult, crate::update::ExactExportError>>>
     {
         self.groups
@@ -222,9 +257,10 @@ impl SharedUnicastProbeCache {
             .iter()
             .filter(|entry| Self::entry_matches_payload(entry, announce, next_hop_override))
             .find_map(|entry| {
-                let results = target.reuse_successful_probes(
+                let results = target.reuse_successful_probes_with_checkpoint(
                     entry.source_snapshot.as_ref(),
                     &entry.encoded_lengths,
+                    checkpoint,
                 )?;
                 (results.len() == entry.encoded_lengths.len()).then_some(results)
             })
@@ -260,13 +296,20 @@ impl SharedUnicastProbeCache {
         announce: Arc<[crate::route::Route]>,
         next_hop_override: Arc<[Option<rustbgpd_policy::NextHopAction>]>,
         source_snapshot: Arc<dyn crate::update::ExactExportSnapshot>,
-        encoded_lengths: Vec<usize>,
+        mut encoded_lengths: Vec<usize>,
+        checkpoint: &mut impl FnMut(),
     ) {
         let group_entries = self.groups.entry(group_id).or_default();
         if group_entries.len() >= MAX_SHARED_UNICAST_PROBE_COHORTS {
+            super::retire_vec(&mut encoded_lengths, checkpoint);
             return;
         }
-        let encoded_maximum = encoded_lengths.iter().copied().max().unwrap_or(0);
+        let encoded_maximum = encoded_lengths
+            .iter()
+            .inspect(|_| checkpoint())
+            .copied()
+            .max()
+            .unwrap_or(0);
         group_entries.push(SharedUnicastProbeCacheEntry {
             announce,
             next_hop_override,
@@ -275,6 +318,20 @@ impl SharedUnicastProbeCache {
             encoded_maximum,
         });
     }
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        for (_, mut entries) in self.groups.drain() {
+            checkpoint();
+            while let Some(mut entry) = entries.pop() {
+                super::retire_vec(&mut entry.encoded_lengths, checkpoint);
+                checkpoint();
+                drop(entry);
+                checkpoint();
+            }
+            drop(entries);
+            checkpoint();
+        }
+        crate::adj_rib_out::release_hash_map(&mut self.groups, checkpoint);
+    }
 }
 
 #[inline(never)]
@@ -282,11 +339,12 @@ fn probe_exact_export_announcements(
     peer: IpAddr,
     snapshot: &dyn crate::update::ExactExportSnapshot,
     candidates: &[crate::update::ExactExportCandidate<'_>],
+    checkpoint: &mut dyn FnMut(),
 ) -> (
     Vec<Result<crate::update::ExactExportResult, crate::update::ExactExportError>>,
     bool,
 ) {
-    let batch_results = snapshot.probe_announcements(candidates);
+    let mut batch_results = snapshot.probe_announcements_with_checkpoint(candidates, checkpoint);
     let cardinality_correct = batch_results.len() == candidates.len();
     if cardinality_correct {
         return (batch_results, true);
@@ -297,10 +355,18 @@ fn probe_exact_export_announcements(
         actual = batch_results.len(),
         "exact export batch probe violated its result cardinality contract — falling back to fail-closed scalar probes"
     );
+    checkpoint();
+    while let Some(result) = batch_results.pop() {
+        drop(result);
+        checkpoint();
+    }
+    drop(batch_results);
+    checkpoint();
     (
         candidates
             .iter()
             .copied()
+            .inspect(|_| checkpoint())
             .map(|candidate| snapshot.probe_announcement(candidate))
             .collect(),
         false,
@@ -360,12 +426,20 @@ pub(super) struct DestinationPrestage {
     reply: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
 }
 
+impl DestinationPrestage {
+    pub(super) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        super::retire_vec(&mut self.prefixes, checkpoint);
+        self.memo.retire_with(checkpoint);
+    }
+}
+
 /// One actor-owned, pre-emission clean policy transition. The RIB run loop
 /// advances exactly one bounded phase step and yields before polling it again;
 /// ordinary mutation traffic remains queued until the terminal
 /// `CommitMembers` batch completes.
 pub(super) struct PendingCleanPolicyTransition {
     replacements: Vec<PeerExportPolicyReplacement>,
+    original_member_count: usize,
     reply: Option<
         tokio::sync::oneshot::Sender<Result<crate::update::ExportPolicyCohortOutcome, String>>,
     >,
@@ -440,6 +514,57 @@ enum CleanPolicyTransitionPhase {
     },
 }
 
+impl CleanPolicyTransitionPhase {
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        match self {
+            Self::Classify { seen, .. } => super::retire_hash_set(seen, &mut || checkpoint(false)),
+            Self::StageDestination { prefixes, memo, .. } => {
+                if let Some(prefixes) = prefixes {
+                    super::retire_vec(prefixes, &mut || checkpoint(false));
+                }
+                memo.retire_with(&mut || checkpoint(false));
+            }
+            Self::BuildInventory {
+                keys, inventory, ..
+            } => {
+                if let Some(keys) = keys {
+                    super::retire_vec(keys, &mut || checkpoint(false));
+                }
+                inventory.retire_with(checkpoint);
+            }
+            Self::ProbeAndPrepare {
+                inventory,
+                probe_cache,
+                prepared,
+                active_probe,
+                ..
+            } => {
+                if let Some(probe) = active_probe {
+                    super::retire_vec(&mut probe.encoded_lengths, &mut || checkpoint(false));
+                }
+                super::retire_vec(prepared, &mut || checkpoint(false));
+                probe_cache.retire_with(&mut || checkpoint(false));
+                inventory.retire_with(checkpoint);
+            }
+            Self::Validate {
+                inventory,
+                prepared,
+                ..
+            }
+            | Self::CommitMembers {
+                inventory,
+                prepared,
+                ..
+            } => {
+                super::retire_vec(prepared, &mut || checkpoint(false));
+                inventory.retire_with(checkpoint);
+            }
+        }
+        checkpoint(true);
+    }
+}
+
 struct CleanPolicyTransitionProbe {
     peer: IpAddr,
     session_id: u64,
@@ -484,6 +609,7 @@ impl PendingCleanPolicyTransition {
         >,
     ) -> Self {
         Self {
+            original_member_count: replacements.len(),
             replacements,
             reply,
             started_at: tokio::time::Instant::now(),
@@ -502,7 +628,14 @@ impl PendingCleanPolicyTransition {
     }
 
     pub(super) fn member_count(&self) -> usize {
-        self.replacements.len()
+        self.original_member_count
+    }
+
+    pub(super) fn retire_inputs(&mut self, manager: &RibManager) {
+        super::retire_vec(&mut self.replacements, &mut || {
+            manager.replacement_checkpoint(false);
+        });
+        manager.replacement_checkpoint(true);
     }
 
     /// IDs held while classification or a later transition phase is parked.
@@ -597,7 +730,12 @@ impl PendingCleanPolicyTransition {
         &mut self,
         manager: &mut RibManager,
     ) -> Result<(), String> {
-        self.phase = None;
+        manager.with_replacement_readiness_age(self.elapsed(), |manager| {
+        if let Some(mut phase) = self.phase.take() {
+            phase.retire_with(&mut |force| manager.replacement_checkpoint_at("retirement", force));
+            drop(phase);
+        }
+        manager.replacement_checkpoint_at("retirement", true);
         let result = if let Some(destination) = self.created_destination.take()
             && !manager.discard_uncommitted_policy_transition_group(destination)
         {
@@ -608,7 +746,9 @@ impl PendingCleanPolicyTransition {
             Ok(())
         };
         manager.reclaim_unused_update_group_policies();
+        self.retire_inputs(manager);
         result
+        })
     }
 }
 
@@ -735,6 +875,7 @@ mod shared_unicast_probe_cache_tests {
                     rechecks: Arc::new(AtomicUsize::new(0)),
                 }),
                 vec![64],
+                &mut || {},
             );
         }
         assert_eq!(cache.groups[&7].len(), MAX_SHARED_UNICAST_PROBE_COHORTS);
@@ -748,6 +889,7 @@ mod shared_unicast_probe_cache_tests {
                 rechecks: Arc::new(AtomicUsize::new(0)),
             }),
             vec![64],
+            &mut || {},
         );
         assert_eq!(
             cache.groups[&7].len(),
@@ -765,6 +907,7 @@ mod shared_unicast_probe_cache_tests {
                     rechecks: Arc::new(AtomicUsize::new(0)),
                 }),
                 vec![64],
+                &mut || {},
             );
         }
         assert_eq!(cache.groups.len(), 65);
@@ -782,7 +925,13 @@ mod shared_unicast_probe_cache_tests {
         };
         assert!(
             cache
-                .reuse_grouped_exact_export_ceiling(7, &announce, &next_hop_override, &target)
+                .reuse_grouped_exact_export_ceiling(
+                    7,
+                    &announce,
+                    &next_hop_override,
+                    &target,
+                    &mut || {}
+                )
                 .is_none()
         );
         assert_eq!(
@@ -792,7 +941,13 @@ mod shared_unicast_probe_cache_tests {
         );
         assert!(
             cache
-                .reuse_grouped_exact_export_ceiling(100, &announce, &next_hop_override, &target,)
+                .reuse_grouped_exact_export_ceiling(
+                    100,
+                    &announce,
+                    &next_hop_override,
+                    &target,
+                    &mut || {}
+                )
                 .is_none()
         );
         assert_eq!(
@@ -1398,6 +1553,11 @@ impl RibManager {
         &mut self,
         mut pending: PendingCleanPolicyTransition,
     ) -> CleanPolicyTransitionAdvance {
+        self.with_replacement_readiness_age(pending.elapsed(), |manager| {
+        let readiness = manager.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
         let phase = pending
             .phase
             .take()
@@ -1419,8 +1579,9 @@ impl RibManager {
                 "clean export-policy transition exceeded its pre-commit ownership budget; \
                  handing the cohort to the authoritative per-peer path"
             );
-            // Dropping the phase releases any reserved outbound permits.
-            drop(phase);
+            // Retain the phase until the fenced fallback cleanup retires its
+            // buffers and releases every reserved outbound permit.
+            pending.phase = Some(phase);
             return CleanPolicyTransitionAdvance::Fallback(pending);
         }
         match phase {
@@ -1430,35 +1591,41 @@ impl RibManager {
                 mut transition,
             } => {
                 if pending.replacements.len() < 2 {
-                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                    pending.phase = Some(CleanPolicyTransitionPhase::Classify { cursor, seen, transition });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
                 // Budgeted stride loop (see the probe phase below): fixed
                 // 8-member classification polls cost ~88 fenced polls at 700
                 // members; stride until the poll budget elapses instead.
                 let poll_start = std::time::Instant::now();
                 loop {
+                    checkpoint();
                     let end = (cursor + super::POLICY_TRANSITION_MEMBER_SLICE)
                         .min(pending.replacements.len());
                     for replacement in &pending.replacements[cursor..end] {
+                        checkpoint();
                         if !seen.insert(replacement.peer)
-                            || !self.clean_policy_transition_peer_ready(replacement.peer)
+                            || !manager.clean_policy_transition_peer_ready(replacement.peer)
                         {
+                            pending.phase = Some(CleanPolicyTransitionPhase::Classify { cursor, seen, transition });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         }
-                        let Some(pair) = self.clean_policy_transition_destination(
+                        let Some(pair) = manager.clean_policy_transition_destination(
                             replacement.peer,
                             replacement.export_policy.as_ref(),
                         ) else {
+                            pending.phase = Some(CleanPolicyTransitionPhase::Classify { cursor, seen, transition });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         };
                         if transition.is_some_and(|expected| expected != pair) {
+                            pending.phase = Some(CleanPolicyTransitionPhase::Classify { cursor, seen, transition });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         }
                         transition = Some(pair);
                     }
                     cursor = end;
                     if cursor == pending.replacements.len()
-                        || poll_start.elapsed() >= self.flush_poll_budget
+                        || poll_start.elapsed() >= manager.flush_poll_budget
                     {
                         break;
                     }
@@ -1471,7 +1638,8 @@ impl RibManager {
                     });
                 } else {
                     let Some((source, destination)) = transition else {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                        pending.phase = Some(CleanPolicyTransitionPhase::Classify { cursor, seen, transition });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                     };
                     // The cohort's destination is now known: consume the
                     // completed-prestage record. A match hands ownership to
@@ -1479,11 +1647,13 @@ impl RibManager {
                     // staging phase marks it for fallback cleanup); a
                     // mismatch means the prepared group will never be
                     // adopted — discard it now, by the exact staged gid.
-                    if let Some(prepared) = self.prepared_destination.take()
+                    if let Some(prepared) = manager.prepared_destination.take()
                         && prepared != destination
                     {
-                        let _ = self.discard_uncommitted_policy_transition_group(prepared);
+                        let _ = manager.discard_uncommitted_policy_transition_group(prepared);
                     }
+                    super::retire_hash_set(&mut seen, &mut || checkpoint());
+                    manager.replacement_checkpoint(true);
                     pending.phase = Some(CleanPolicyTransitionPhase::StageDestination {
                         source,
                         destination,
@@ -1502,13 +1672,13 @@ impl RibManager {
                 mut memo,
             } => {
                 if prefixes.is_none() {
-                    match self.begin_policy_transition_group(
+                    match manager.begin_policy_transition_group(
                         destination,
                         pending.replacements[0].peer,
                         pending.replacements[0].export_policy.as_ref(),
                     ) {
                         super::update_groups::PolicyTransitionGroupStart::Maintained => {
-                            if self
+                            if manager
                                 .group_ribs
                                 .get(&destination)
                                 .is_some_and(|group| group.members.is_empty())
@@ -1553,20 +1723,21 @@ impl RibManager {
                 // route-slices until the poll budget elapses.
                 let poll_start = std::time::Instant::now();
                 loop {
+                    checkpoint();
                     let end = super::policy_transition_slice_end(
                         cursor,
                         snapshot.len(),
                         super::POLICY_TRANSITION_ROUTE_SLICE,
                     );
                     if cursor < end {
-                        self.stage_policy_transition_group_chunk(
+                        manager.stage_policy_transition_group_chunk(
                             destination,
                             &snapshot[cursor..end],
                             &mut memo,
                         );
                         cursor = end;
                     }
-                    if cursor == snapshot.len() || poll_start.elapsed() >= self.flush_poll_budget {
+                    if cursor == snapshot.len() || poll_start.elapsed() >= manager.flush_poll_budget {
                         break;
                     }
                 }
@@ -1579,6 +1750,13 @@ impl RibManager {
                         memo,
                     });
                 } else {
+                    #[cfg(feature = "bench-internals")]
+                    memo.record_replacement_capacities(manager);
+                    memo.retire_with(&mut || manager.replacement_checkpoint_at("retirement", false));
+                    if let Some(prefixes) = prefixes.as_mut() {
+                        super::retire_vec(prefixes, &mut || manager.replacement_checkpoint_at("retirement", false));
+                    }
+                    manager.replacement_checkpoint(true);
                     debug!(
                         destination,
                         maintained = false,
@@ -1606,9 +1784,10 @@ impl RibManager {
             } => {
                 if keys.is_none() {
                     let Some(snapshot) =
-                        self.begin_clean_policy_transition_inventory(source, destination)
+                        manager.begin_clean_policy_transition_inventory(source, destination)
                     else {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                        pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory { source, destination, keys, cursor, inventory });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                     };
                     keys = Some(snapshot);
                     pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory {
@@ -1626,8 +1805,8 @@ impl RibManager {
                 // ASN so rs-control members can ride the shared cohort.
                 let mut rs_asns = pending
                     .replacements
-                    .iter()
-                    .filter_map(|replacement| self.peer_rs_control.get(&replacement.peer).copied())
+                    .iter().inspect(|_| checkpoint())
+                    .filter_map(|replacement| manager.peer_rs_control.get(&replacement.peer).copied())
                     .collect::<Vec<u32>>();
                 rs_asns.sort_unstable();
                 rs_asns.dedup();
@@ -1635,12 +1814,13 @@ impl RibManager {
                 // inventory by route-slices until the poll budget elapses.
                 let poll_start = std::time::Instant::now();
                 loop {
+                    checkpoint();
                     let end = super::policy_transition_slice_end(
                         cursor,
                         snapshot.len(),
                         super::POLICY_TRANSITION_ROUTE_SLICE,
                     );
-                    if self
+                    if manager
                         .extend_clean_policy_transition_inventory(
                             source,
                             destination,
@@ -1650,10 +1830,11 @@ impl RibManager {
                         )
                         .is_none()
                     {
-                        return CleanPolicyTransitionAdvance::Fallback(pending);
+                        pending.phase = Some(CleanPolicyTransitionPhase::BuildInventory { source, destination, keys, cursor, inventory });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                     }
                     cursor = end;
-                    if cursor == snapshot.len() || poll_start.elapsed() >= self.flush_poll_budget {
+                    if cursor == snapshot.len() || poll_start.elapsed() >= manager.flush_poll_budget {
                         break;
                     }
                 }
@@ -1666,7 +1847,12 @@ impl RibManager {
                         inventory,
                     });
                 } else {
-                    let inventory = inventory.finish();
+                    if let Some(keys) = keys.as_mut() {
+                        super::retire_vec(keys, &mut || manager.replacement_checkpoint_at("retirement", false));
+                    }
+                    super::retire_vec(&mut rs_asns, &mut || checkpoint());
+                    manager.replacement_checkpoint(true);
+                    let inventory = inventory.finish(&mut |force| manager.replacement_checkpoint(force));
                     debug!(
                         announce_len = inventory.announce.len(),
                         elapsed_ms =
@@ -1707,6 +1893,7 @@ impl RibManager {
                 // polls, a measured ~1.1 s of wall at 700 members).
                 let poll_start = std::time::Instant::now();
                 loop {
+                    checkpoint();
                     if let Some(mut probe) = active_probe.take() {
                         let end = super::policy_transition_slice_end(
                             probe.cursor,
@@ -1714,8 +1901,8 @@ impl RibManager {
                             super::POLICY_TRANSITION_ROUTE_SLICE,
                         );
                         let candidates = inventory.announce[probe.cursor..end]
-                            .iter()
-                            .zip(inventory.next_hop_override[probe.cursor..end].iter())
+                            .iter().inspect(|_| checkpoint())
+                            .zip(inventory.next_hop_override[probe.cursor..end].iter().inspect(|_| checkpoint()))
                             .map(|(route, next_hop_override)| {
                                 crate::update::ExactExportCandidate::Unicast {
                                     route,
@@ -1727,13 +1914,16 @@ impl RibManager {
                             probe.peer,
                             probe.snapshot.as_ref(),
                             &candidates,
+                            &mut || manager.replacement_checkpoint(true),
                         );
-                        if !cardinality_correct || results.iter().any(Result::is_err) {
+                        if !cardinality_correct || results.iter().inspect(|_| checkpoint()).any(Result::is_err) {
+                            active_probe = Some(probe);
+                            pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         }
                         full_probe_count = full_probe_count.saturating_add(results.len());
                         probe.encoded_lengths.extend(
-                            results.into_iter().filter_map(|result| {
+                            results.into_iter().inspect(|_| checkpoint()).filter_map(|result| {
                                 result.ok().map(|accepted| accepted.encoded_len)
                             }),
                         );
@@ -1746,8 +1936,7 @@ impl RibManager {
                                 Arc::clone(&inventory.announce),
                                 Arc::clone(&inventory.next_hop_override),
                                 Arc::clone(&probe.snapshot),
-                                probe.encoded_lengths,
-                            );
+                                probe.encoded_lengths, &mut || checkpoint());
                             prepared.push(PreparedCleanPolicyTransitionPeer {
                                 peer: probe.peer,
                                 session_id: probe.session_id,
@@ -1761,17 +1950,20 @@ impl RibManager {
                     } else if cursor < pending.replacements.len() {
                         let replacement = &pending.replacements[cursor];
                         let peer = replacement.peer;
-                        let Some(session_id) = self.outbound_session_ids.get(&peer).copied() else {
+                        let Some(session_id) = manager.outbound_session_ids.get(&peer).copied() else {
+                            pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         };
-                        let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
+                        let Some(sender) = manager.outbound_peers.get(&peer).cloned() else {
+                            pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
                             return CleanPolicyTransitionAdvance::Fallback(pending);
                         };
                         let permit = if inventory.announce.is_empty() {
                             None
                         } else {
                             let Ok(permit) = sender.clone().try_reserve_owned() else {
-                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                                pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                             };
                             Some(permit)
                         };
@@ -1787,12 +1979,14 @@ impl RibManager {
                             });
                             cursor += 1;
                         } else {
-                            let Some(encoder) = self.peer_export_encoders.get(&peer) else {
-                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                            let Some(encoder) = manager.peer_export_encoders.get(&peer) else {
+                                pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                             };
                             let snapshot = encoder.snapshot();
                             if snapshot.owner_id() != encoder.owner_id() {
-                                return CleanPolicyTransitionAdvance::Fallback(pending);
+                                pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                             }
                             let reuse = probe_cache.reuse_grouped_exact_export_maximum(
                                 destination,
@@ -1811,7 +2005,8 @@ impl RibManager {
                             );
                             if let Some(maximum) = reuse {
                                 if maximum.is_err() {
-                                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                                    pending.phase = Some(CleanPolicyTransitionPhase::ProbeAndPrepare { source, destination, inventory, cursor, probe_cache, prepared, active_probe, full_probe_count });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                                 }
                                 prepared.push(PreparedCleanPolicyTransitionPeer {
                                     peer,
@@ -1839,12 +2034,14 @@ impl RibManager {
                     if cursor == pending.replacements.len() && active_probe.is_none() {
                         break;
                     }
-                    if poll_start.elapsed() >= self.flush_poll_budget {
+                    if poll_start.elapsed() >= manager.flush_poll_budget {
                         break;
                     }
                 }
 
                 if cursor == pending.replacements.len() && active_probe.is_none() {
+                    probe_cache.retire_with(&mut || manager.replacement_checkpoint_at("retirement", false));
+                    manager.replacement_checkpoint(true);
                     debug!(
                         full_probe_count,
                         elapsed_ms =
@@ -1879,23 +2076,23 @@ impl RibManager {
                 prepared,
                 full_probe_count,
             } => {
-                let all_current = prepared.iter().all(|member| {
-                    self.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
-                        && self.outbound_peers.get(&member.peer).is_some_and(|sender| {
+                let all_current = prepared.iter().inspect(|_| checkpoint()).all(|member| {
+                    manager.outbound_session_ids.get(&member.peer).copied() == Some(member.session_id)
+                        && manager.outbound_peers.get(&member.peer).is_some_and(|sender| {
                             sender.same_channel(&member.sender) && !sender.is_closed()
                         })
-                        && self
+                        && manager
                             .live_sessions
                             .get(&member.peer)
                             .and_then(|sessions| sessions.last())
                             .is_some_and(|session| session.session_id == member.session_id)
-                        && self.clean_policy_transition_peer_ready(member.peer)
-                        && self.clean_policy_transition_destination(
+                        && manager.clean_policy_transition_peer_ready(member.peer)
+                        && manager.clean_policy_transition_destination(
                             member.peer,
                             member.export_policy.as_ref(),
                         ) == Some((source, destination))
                         && member.snapshot.as_ref().is_none_or(|snapshot| {
-                            self.peer_export_encoders
+                            manager.peer_export_encoders
                                 .get(&member.peer)
                                 .is_some_and(|encoder| {
                                     let current = encoder.snapshot();
@@ -1906,7 +2103,8 @@ impl RibManager {
                         && (inventory.announce.is_empty() == member.permit.is_none())
                 });
                 if !all_current {
-                    return CleanPolicyTransitionAdvance::Fallback(pending);
+                    pending.phase = Some(CleanPolicyTransitionPhase::Validate { source, destination, inventory, prepared, full_probe_count });
+                            return CleanPolicyTransitionAdvance::Fallback(pending);
                 }
                 debug!(
                     elapsed_ms = u64::try_from(pending.elapsed().as_millis()).unwrap_or(u64::MAX),
@@ -1926,7 +2124,7 @@ impl RibManager {
             CleanPolicyTransitionPhase::CommitMembers {
                 source,
                 destination,
-                inventory,
+                mut inventory,
                 mut prepared,
                 full_probe_count,
                 cursor,
@@ -1946,15 +2144,17 @@ impl RibManager {
                 let poll_start = std::time::Instant::now();
                 let mut flushed = 0_usize;
                 loop {
+                    checkpoint();
                     let batch = super::COMMIT_MEMBERS_PER_POLL.min(prepared.len());
                     for member in prepared.drain(..batch) {
-                        self.commit_clean_policy_transition_member(
+                        checkpoint();
+                        manager.commit_clean_policy_transition_member(
                             member.peer,
                             source,
                             destination,
                         );
-                        self.clear_policy_filtered_routes_for_peer(member.peer);
-                        self.apply_clean_policy_transition_counters(member.peer, &inventory);
+                        manager.clear_policy_filtered_routes_for_peer(member.peer);
+                        manager.apply_clean_policy_transition_counters(member.peer, &inventory);
                         if let Some(permit) = member.permit {
                             permit.send(OutboundRouteUpdate {
                                 exact_export_snapshot: member.snapshot,
@@ -1965,15 +2165,15 @@ impl RibManager {
                                 ..OutboundRouteUpdate::default()
                             });
                         }
-                        let advertised = self.grouped_advertised_count(member.peer).unwrap_or(0);
-                        self.metrics.set_adj_rib_out_prefixes(
+                        let advertised = manager.grouped_advertised_count(member.peer).unwrap_or(0);
+                        manager.metrics.set_adj_rib_out_prefixes(
                             &member.peer.to_string(),
                             "all",
                             gauge_val(advertised),
                         );
                     }
                     flushed += batch;
-                    if prepared.is_empty() || poll_start.elapsed() >= self.flush_poll_budget {
+                    if prepared.is_empty() || poll_start.elapsed() >= manager.flush_poll_budget {
                         break;
                     }
                 }
@@ -1995,13 +2195,13 @@ impl RibManager {
                 // peer manager treats it as flush-complete before launching
                 // remainder per-peer applies and rollback restores.
                 let materialized_routes = inventory.announce.len();
-                self.finish_clean_policy_transition_commit();
+                manager.finish_clean_policy_transition_commit();
                 // Match the authoritative single-peer replacement seam: a
                 // successful policy transaction also owns the global retry
                 // opportunity for dirty peers. Without this pass, unrelated
                 // withdrawal residue can remain queued until the timer even
                 // though the caller has already observed a successful commit.
-                self.distribute_changes(&HashSet::new(), &HashSet::new());
+                manager.distribute_changes(&HashSet::new(), &HashSet::new());
                 debug!(
                     source_group = source,
                     destination_group = destination,
@@ -2012,23 +2212,27 @@ impl RibManager {
                 );
                 #[cfg(any(test, feature = "bench-internals"))]
                 {
-                    self.policy_transition_stats.plan_builds =
-                        self.policy_transition_stats.plan_builds.saturating_add(1);
-                    self.policy_transition_stats.full_exact_probes = self
+                    manager.policy_transition_stats.plan_builds =
+                        manager.policy_transition_stats.plan_builds.saturating_add(1);
+                    manager.policy_transition_stats.full_exact_probes = manager
                         .policy_transition_stats
                         .full_exact_probes
                         .saturating_add(full_probe_count);
-                    self.policy_transition_stats.route_shell_materializations = self
+                    manager.policy_transition_stats.route_shell_materializations = manager
                         .policy_transition_stats
                         .route_shell_materializations
                         .saturating_add(materialized_routes);
                 }
-                if let Some(reply) = pending.take_reply() {
-                    let _ = reply.send(Ok(crate::update::ExportPolicyCohortOutcome::Committed));
-                }
+                inventory.retire_with(&mut |force| manager.replacement_checkpoint_at("retirement", force));
+                super::retire_vec(&mut prepared, &mut || checkpoint());
+                manager.replacement_checkpoint(true);
+                drop(shared_encode);
+                manager.replacement_checkpoint(true);
                 CleanPolicyTransitionAdvance::Committed(pending)
             }
         }
+
+        })
     }
 
     /// Synchronous driver used only by the benchmark seam. Production owns
@@ -2095,20 +2299,49 @@ impl RibManager {
         if pristine_otc_reconcile {
             return;
         }
-        let mut blocked_by_prefix: HashMap<Prefix, HashMap<u32, crate::route::Route>> =
-            HashMap::new();
-        for route in blocked_routes {
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        let route_bound = blocked_routes.len();
+        let prefix_bound = route_bound.min(affected_prefixes.len());
+        let mut counts = HashMap::<Prefix, usize>::with_capacity(prefix_bound);
+        checkpoint();
+        for route in &blocked_routes {
+            checkpoint();
             if affected_prefixes.contains(&route.prefix) {
-                blocked_by_prefix
-                    .entry(route.prefix)
-                    .or_default()
-                    .insert(route.path_id, route);
+                *counts.entry(route.prefix).or_default() += 1;
             }
         }
+        let mut blocked_by_prefix: HashMap<Prefix, HashMap<u32, crate::route::Route>> =
+            HashMap::with_capacity(counts.len());
+        for (prefix, count) in counts.drain() {
+            checkpoint();
+            blocked_by_prefix.insert(prefix, HashMap::with_capacity(count));
+        }
+        crate::adj_rib_out::release_hash_map(&mut counts, &mut checkpoint);
+        let mut routes = blocked_routes.into_iter();
+        for route in routes.by_ref() {
+            checkpoint();
+            if let Some(blocked) = blocked_by_prefix.get_mut(&route.prefix) {
+                drop(blocked.insert(route.path_id, route));
+            }
+        }
+        drop(routes);
+        checkpoint();
 
         let current = self.peer_otc_blocked.entry(peer).or_default();
         let pending = self.pending_otc_blocked.entry(peer).or_default();
+        super::update_groups::ensure_map_capacity_with_checkpoint(
+            current,
+            current.len().saturating_add(prefix_bound),
+            &mut checkpoint,
+        );
+        super::update_groups::ensure_map_capacity_with_checkpoint(
+            pending,
+            pending.len().saturating_add(route_bound),
+            &mut checkpoint,
+        );
         for prefix in affected_prefixes {
+            checkpoint();
             #[cfg(test)]
             {
                 self.adj_rib_out_commit_stats.otc_reconcile_prefix_visits = self
@@ -2116,29 +2349,41 @@ impl RibManager {
                     .otc_reconcile_prefix_visits
                     .saturating_add(1);
             }
-            let old = current.remove(prefix).unwrap_or_default();
+            let mut old = current.remove(prefix).unwrap_or_default();
             let blocked = blocked_by_prefix.remove(prefix).unwrap_or_default();
-            let next: HashSet<u32> = blocked.keys().copied().collect();
-
-            for path_id in old.difference(&next) {
-                pending.remove(&(*prefix, *path_id));
+            let mut next = HashSet::with_capacity(blocked.len());
+            for path_id in blocked.keys() {
+                checkpoint();
+                next.insert(*path_id);
             }
-            for (path_id, route) in blocked {
-                if !old.contains(&path_id) || pending.contains_key(&(*prefix, path_id)) {
-                    pending.insert((*prefix, path_id), route);
+            for path_id in &old {
+                checkpoint();
+                if !next.contains(path_id) {
+                    drop(pending.remove(&(*prefix, *path_id)));
                 }
             }
+            let mut blocked = blocked.into_iter();
+            for (path_id, route) in blocked.by_ref() {
+                checkpoint();
+                if !old.contains(&path_id) || pending.contains_key(&(*prefix, path_id)) {
+                    drop(pending.insert((*prefix, path_id), route));
+                }
+            }
+            drop(blocked);
+            checkpoint();
+            super::retire_hash_set(&mut old, &mut checkpoint);
             if !next.is_empty() {
                 current.insert(*prefix, next);
             }
         }
-
+        crate::adj_rib_out::release_hash_map(&mut blocked_by_prefix, &mut checkpoint);
         if current.is_empty() {
             self.peer_otc_blocked.remove(&peer);
         }
         if pending.is_empty() {
             self.pending_otc_blocked.remove(&peer);
         }
+        self.replacement_checkpoint(true);
     }
 
     pub(super) fn try_send_and_commit_outbound_update_with_group_prior(
@@ -2164,11 +2409,156 @@ impl RibManager {
     pub(super) fn try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
         &mut self,
         peer: IpAddr,
-        batch: OutboundCommitBatch,
-        group_prior: HashSet<crate::update::ExactExportKey>,
+        mut batch: OutboundCommitBatch,
+        mut group_prior: HashSet<crate::update::ExactExportKey>,
         mut shared_unicast_precommit: Option<SharedUnicastPrecommit<'_>>,
         otc_reconcile_prefixes: Option<&HashSet<Prefix>>,
     ) -> bool {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
+        #[cfg(feature = "bench-internals")]
+        let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
+            && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
+        // Every arm below is provably false without an active family gate.
+        // The deferral object intentionally retains released-family history,
+        // so `Option::is_some` is too broad after startup convergence: guard
+        // on the O(1) active map instead and skip every route-vector scan.
+        let gated = self
+            .selection_deferral
+            .as_ref()
+            .is_some_and(super::selection_deferral::SelectionDeferral::has_active_gates)
+            && (batch
+                .unicast
+                .announce
+                .iter()
+                .inspect(|_| checkpoint())
+                .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
+                || batch
+                    .withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
+                || batch
+                    .end_of_rib
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|family| self.selection_convergence_held(*family))
+                || batch
+                    .refresh_markers
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|(afi, safi, _)| self.selection_convergence_held((*afi, *safi)))
+                || batch
+                    .flowspec_announce
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
+                || batch
+                    .flowspec_withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
+                || ((!batch.evpn_announce.is_empty() || !batch.evpn_withdraw.is_empty())
+                    && self.selection_deferred((Afi::L2Vpn, Safi::Evpn)))
+                || batch
+                    .bgpls_announce
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|route| self.selection_deferred(route.family.to_afi_safi()))
+                || batch
+                    .bgpls_withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|key| self.selection_deferred(key.family.to_afi_safi()))
+                || batch
+                    .vpn_announce
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|route| self.selection_deferred(route.afi_safi()))
+                || batch
+                    .vpn_withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|key| self.selection_deferred(key.afi_safi()))
+                || batch
+                    .labeled_announce
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|route| self.selection_deferred(route.afi_safi()))
+                || batch
+                    .labeled_withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|key| self.selection_deferred(key.afi_safi()))
+                || ((!batch.rtc_announce.is_empty() || !batch.rtc_withdraw.is_empty())
+                    && self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi())));
+        if gated {
+            warn!(%peer, "outbound transaction intersected an active RFC 4724 selection gate; failing closed");
+            batch.retire_with(&mut || checkpoint());
+            super::retire_hash_set(&mut group_prior, &mut || checkpoint());
+            self.replacement_checkpoint(true);
+            return false;
+        }
+        let Some(tx) = self.outbound_peers.get(&peer).cloned() else {
+            batch.retire_with(&mut || checkpoint());
+            super::retire_hash_set(&mut group_prior, &mut || checkpoint());
+            self.replacement_checkpoint(true);
+            return false;
+        };
+
+        let local_role = self.peer_local_roles.get(&peer).copied().flatten();
+        if let Some(prefixes) = otc_reconcile_prefixes {
+            let blocked = batch
+                .unicast
+                .announce
+                .iter()
+                .inspect(|_| checkpoint())
+                .filter(|route| {
+                    batch.announce_source_exclusion != Some(route.peer)
+                        && otc_egress_blocked(route, local_role)
+                })
+                .cloned()
+                .collect();
+            self.reconcile_peer_otc_blocked(peer, prefixes, blocked);
+        }
+        let Ok(permit) = tx.try_reserve() else {
+            batch.retire_with(&mut || checkpoint());
+            super::retire_hash_set(&mut group_prior, &mut || checkpoint());
+            self.replacement_checkpoint(true);
+            return false;
+        };
+        // Validate the trust boundary before consuming any durable pending
+        // state (OTC diagnostics or the rejected-route overlay). A failed
+        // precommit leaves those structures intact for the retry.
+        let has_candidate_route_payload = !batch.unicast.announce.is_empty()
+            || !batch.withdraw.is_empty()
+            || !batch.flowspec_announce.is_empty()
+            || !batch.flowspec_withdraw.is_empty()
+            || !batch.evpn_announce.is_empty()
+            || !batch.evpn_withdraw.is_empty()
+            || !batch.bgpls_announce.is_empty()
+            || !batch.bgpls_withdraw.is_empty()
+            || !batch.vpn_announce.is_empty()
+            || !batch.vpn_withdraw.is_empty()
+            || !batch.labeled_announce.is_empty()
+            || !batch.labeled_withdraw.is_empty()
+            || !batch.rtc_announce.is_empty()
+            || !batch.rtc_withdraw.is_empty();
+        let exact_export_snapshot = if has_candidate_route_payload {
+            let Some(encoder) = self.peer_export_encoders.get(&peer) else {
+                warn!(%peer, "route-bearing outbound update has no exact export encoder — refusing Adj-RIB-Out commit");
+                batch.retire_with(&mut || checkpoint());
+                super::retire_hash_set(&mut group_prior, &mut || checkpoint());
+                self.replacement_checkpoint(true);
+                return false;
+            };
+            Some(encoder.snapshot())
+        } else {
+            None
+        };
+
         let OutboundCommitBatch {
             unicast:
                 AlignedUnicastPayload {
@@ -2194,106 +2584,6 @@ impl RibManager {
             mut rtc_announce,
             mut rtc_withdraw,
         } = batch;
-        #[cfg(feature = "bench-internals")]
-        let bench_per_client_best_resync = self.peer_per_client_best.contains(&peer)
-            && (self.dirty_peers.contains(&peer) || self.force_outbound_peers.contains(&peer));
-        // Every arm below is provably false without an active family gate.
-        // The deferral object intentionally retains released-family history,
-        // so `Option::is_some` is too broad after startup convergence: guard
-        // on the O(1) active map instead and skip every route-vector scan.
-        let gated = self
-            .selection_deferral
-            .as_ref()
-            .is_some_and(super::selection_deferral::SelectionDeferral::has_active_gates)
-            && (announce
-                .iter()
-                .any(|route| self.selection_deferred(prefix_family(&route.prefix)))
-                || withdraw
-                    .iter()
-                    .any(|(prefix, _)| self.selection_deferred(prefix_family(prefix)))
-                || end_of_rib
-                    .iter()
-                    .any(|family| self.selection_convergence_held(*family))
-                || refresh_markers
-                    .iter()
-                    .any(|(afi, safi, _)| self.selection_convergence_held((*afi, *safi)))
-                || flowspec_announce
-                    .iter()
-                    .any(|route| self.selection_deferred((route.afi, Safi::FlowSpec)))
-                || flowspec_withdraw
-                    .iter()
-                    .any(|key| self.selection_deferred((key.afi, Safi::FlowSpec)))
-                || ((!evpn_announce.is_empty() || !evpn_withdraw.is_empty())
-                    && self.selection_deferred((Afi::L2Vpn, Safi::Evpn)))
-                || bgpls_announce
-                    .iter()
-                    .any(|route| self.selection_deferred(route.family.to_afi_safi()))
-                || bgpls_withdraw
-                    .iter()
-                    .any(|key| self.selection_deferred(key.family.to_afi_safi()))
-                || vpn_announce
-                    .iter()
-                    .any(|route| self.selection_deferred(route.afi_safi()))
-                || vpn_withdraw
-                    .iter()
-                    .any(|key| self.selection_deferred(key.afi_safi()))
-                || labeled_announce
-                    .iter()
-                    .any(|route| self.selection_deferred(route.afi_safi()))
-                || labeled_withdraw
-                    .iter()
-                    .any(|key| self.selection_deferred(key.afi_safi()))
-                || ((!rtc_announce.is_empty() || !rtc_withdraw.is_empty())
-                    && self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi())));
-        if gated {
-            warn!(%peer, "outbound transaction intersected an active RFC 4724 selection gate; failing closed");
-            return false;
-        }
-        let Some(tx) = self.outbound_peers.get(&peer).cloned() else {
-            return false;
-        };
-
-        let local_role = self.peer_local_roles.get(&peer).copied().flatten();
-        if let Some(prefixes) = otc_reconcile_prefixes {
-            let blocked = announce
-                .iter()
-                .filter(|route| {
-                    announce_source_exclusion != Some(route.peer)
-                        && otc_egress_blocked(route, local_role)
-                })
-                .cloned()
-                .collect();
-            self.reconcile_peer_otc_blocked(peer, prefixes, blocked);
-        }
-        let Ok(permit) = tx.try_reserve() else {
-            return false;
-        };
-        // Validate the trust boundary before consuming any durable pending
-        // state (OTC diagnostics or the rejected-route overlay). A failed
-        // precommit leaves those structures intact for the retry.
-        let has_candidate_route_payload = !announce.is_empty()
-            || !withdraw.is_empty()
-            || !flowspec_announce.is_empty()
-            || !flowspec_withdraw.is_empty()
-            || !evpn_announce.is_empty()
-            || !evpn_withdraw.is_empty()
-            || !bgpls_announce.is_empty()
-            || !bgpls_withdraw.is_empty()
-            || !vpn_announce.is_empty()
-            || !vpn_withdraw.is_empty()
-            || !labeled_announce.is_empty()
-            || !labeled_withdraw.is_empty()
-            || !rtc_announce.is_empty()
-            || !rtc_withdraw.is_empty();
-        let exact_export_snapshot = if has_candidate_route_payload {
-            let Some(encoder) = self.peer_export_encoders.get(&peer) else {
-                warn!(%peer, "route-bearing outbound update has no exact export encoder — refusing Adj-RIB-Out commit");
-                return false;
-            };
-            Some(encoder.snapshot())
-        } else {
-            None
-        };
 
         // A grouped member's unicast advertised state is group-owned
         // (design §2: NO per-peer unicast storage) — skip the per-peer
@@ -2311,7 +2601,7 @@ impl RibManager {
         // egress enforcement here (ADR-0126 Decision 5), matching the
         // ungrouped per-client-best path.
         if !unicast_otc_prechecked
-            && announce.iter().any(|route| {
+            && announce.iter().inspect(|_| checkpoint()).any(|route| {
                 announce_source_exclusion != Some(route.peer)
                     && otc_egress_blocked(route, local_role)
             })
@@ -2329,11 +2619,17 @@ impl RibManager {
             let mut permitted_next_hops = Vec::with_capacity(next_hop_override.len());
             // Preserve the caller's withdrawal order while making duplicate
             // detection constant-time for large policy reload/resync batches.
-            let mut withdrawn_keys: HashSet<(Prefix, u32)> = withdraw.iter().copied().collect();
+            let mut withdrawn_keys: HashSet<(Prefix, u32)> =
+                withdraw.iter().inspect(|_| checkpoint()).copied().collect();
             // `announce` is a shared slice, so the permitted subset has to be
             // copied into a fresh one; blocked routes are inspected in place
             // and never cloned.
-            for (route, next_hop) in announce.iter().zip(next_hop_override.iter()) {
+            for (route, next_hop) in announce
+                .iter()
+                .inspect(|_| checkpoint())
+                .zip(next_hop_override.iter().inspect(|_| checkpoint()))
+            {
+                checkpoint();
                 if announce_source_exclusion == Some(route.peer) {
                     // Keep the shared slice aligned; transport suppresses
                     // this route before encoding for this member.
@@ -2381,6 +2677,7 @@ impl RibManager {
             .pending_otc_blocked
             .get(&peer)
             .into_iter()
+            .inspect(|_| checkpoint())
             .flat_map(HashMap::values)
             .cloned()
             .collect();
@@ -2499,17 +2796,48 @@ impl RibManager {
             } else {
                 announce
                     .iter()
-                    .zip(next_hop_override.iter())
+                    .inspect(|_| checkpoint())
+                    .zip(next_hop_override.iter().inspect(|_| checkpoint()))
                     .map(|(route, next_hop)| ExactExportCandidate::Unicast {
                         route,
                         next_hop_override: next_hop.as_ref(),
                     })
-                    .chain(flowspec_announce.iter().map(ExactExportCandidate::FlowSpec))
-                    .chain(evpn_announce.iter().map(ExactExportCandidate::Evpn))
-                    .chain(bgpls_announce.iter().map(ExactExportCandidate::BgpLs))
-                    .chain(vpn_announce.iter().map(ExactExportCandidate::Vpn))
-                    .chain(labeled_announce.iter().map(ExactExportCandidate::Labeled))
-                    .chain(rtc_announce.iter().map(ExactExportCandidate::Rtc))
+                    .chain(
+                        flowspec_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::FlowSpec),
+                    )
+                    .chain(
+                        evpn_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::Evpn),
+                    )
+                    .chain(
+                        bgpls_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::BgpLs),
+                    )
+                    .chain(
+                        vpn_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::Vpn),
+                    )
+                    .chain(
+                        labeled_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::Labeled),
+                    )
+                    .chain(
+                        rtc_announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(ExactExportCandidate::Rtc),
+                    )
                     .collect::<Vec<_>>()
             };
             let reused_results = (!candidates.is_empty() && cache_eligible)
@@ -2520,6 +2848,7 @@ impl RibManager {
                             &announce,
                             &next_hop_override,
                             snapshot.as_ref(),
+                            &mut || checkpoint(),
                         )
                     })
                 })
@@ -2548,11 +2877,19 @@ impl RibManager {
                         .exact_probe_candidates
                         .saturating_add(candidates.len());
                 }
-                let (results, cardinality_correct) =
-                    probe_exact_export_announcements(peer, snapshot.as_ref(), &candidates);
-                if cache_eligible && cardinality_correct && results.iter().all(Result::is_ok) {
+                let (results, cardinality_correct) = probe_exact_export_announcements(
+                    peer,
+                    snapshot.as_ref(),
+                    &candidates,
+                    &mut || self.replacement_checkpoint(true),
+                );
+                if cache_eligible
+                    && cardinality_correct
+                    && results.iter().inspect(|_| checkpoint()).all(Result::is_ok)
+                {
                     let encoded_lengths = results
                         .iter()
+                        .inspect(|_| checkpoint())
                         .filter_map(|result| result.as_ref().ok().map(|result| result.encoded_len))
                         .collect();
                     if let Some(precommit) = shared_unicast_precommit.as_mut() {
@@ -2562,6 +2899,7 @@ impl RibManager {
                             Arc::clone(&next_hop_override),
                             Arc::clone(snapshot),
                             encoded_lengths,
+                            &mut || checkpoint(),
                         );
                     }
                 }
@@ -2581,6 +2919,7 @@ impl RibManager {
                         || {
                             probe_results
                                 .iter()
+                                .inspect(|_| checkpoint())
                                 .filter(|result| {
                                     result.as_ref().is_ok_and(|result| result.encoded_len > 0)
                                 })
@@ -2600,7 +2939,10 @@ impl RibManager {
                     && shared_unicast_precommit
                         .as_ref()
                         .is_some_and(|precommit| precommit.lazy_group_prior.is_some())
-                    && probe_results.iter().all(Result::is_ok)
+                    && probe_results
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .all(Result::is_ok)
                     && !self.peer_unexportable.contains_key(&peer));
             #[cfg(test)]
             let fast_path = {
@@ -2624,10 +2966,12 @@ impl RibManager {
                 // and only when a failed probe can actually owe a withdrawal.
                 let candidate_keys = candidates
                     .iter()
+                    .inspect(|_| checkpoint())
                     .map(ExactExportCandidate::key)
                     .collect::<Vec<_>>();
                 let source_excluded = candidates
                     .iter()
+                    .inspect(|_| checkpoint())
                     .map(|candidate| {
                         matches!(
                             candidate,
@@ -2636,7 +2980,10 @@ impl RibManager {
                         )
                     })
                     .collect::<Vec<_>>();
-                let has_probe_failure = probe_results.iter().any(Result::is_err);
+                let has_probe_failure = probe_results
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(Result::is_err);
                 let mut previously_advertised = group_prior;
                 if has_probe_failure {
                     if let Some(lazy) = shared_unicast_precommit
@@ -2649,6 +2996,7 @@ impl RibManager {
                         previously_advertised.extend(
                             candidate_keys
                                 .iter()
+                                .inspect(|_| checkpoint())
                                 .filter(|key| adj_rib_out_contains_exact_key(rib_out, key))
                                 .cloned(),
                         );
@@ -2667,39 +3015,63 @@ impl RibManager {
                 let mut offset = 0;
                 let unicast_keep = &keep[offset..offset + family_lengths[0]];
                 offset += family_lengths[0];
-                if unicast_keep.iter().any(|keep| !keep) {
+                if unicast_keep
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .any(|keep| !keep)
+                {
                     let permitted_routes = announce
                         .iter()
+                        .inspect(|_| checkpoint())
                         .cloned()
-                        .zip(unicast_keep.iter().copied())
+                        .zip(unicast_keep.iter().inspect(|_| checkpoint()).copied())
                         .filter_map(|(route, keep)| keep.then_some(route))
                         .collect::<Vec<_>>();
                     let permitted_next_hops = next_hop_override
                         .iter()
+                        .inspect(|_| checkpoint())
                         .cloned()
-                        .zip(unicast_keep.iter().copied())
+                        .zip(unicast_keep.iter().inspect(|_| checkpoint()).copied())
                         .filter_map(|(next_hop, keep)| keep.then_some(next_hop))
                         .collect::<Vec<_>>();
                     announce = permitted_routes.into();
                     next_hop_override = permitted_next_hops.into();
                 }
 
-                let mut flowspec_keep = keep[offset..offset + family_lengths[1]].iter().copied();
+                let mut flowspec_keep = keep[offset..offset + family_lengths[1]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 flowspec_announce.retain(|_| flowspec_keep.next().unwrap_or(false));
                 offset += family_lengths[1];
-                let mut evpn_keep = keep[offset..offset + family_lengths[2]].iter().copied();
+                let mut evpn_keep = keep[offset..offset + family_lengths[2]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 evpn_announce.retain(|_| evpn_keep.next().unwrap_or(false));
                 offset += family_lengths[2];
-                let mut bgpls_keep = keep[offset..offset + family_lengths[3]].iter().copied();
+                let mut bgpls_keep = keep[offset..offset + family_lengths[3]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 bgpls_announce.retain(|_| bgpls_keep.next().unwrap_or(false));
                 offset += family_lengths[3];
-                let mut vpn_keep = keep[offset..offset + family_lengths[4]].iter().copied();
+                let mut vpn_keep = keep[offset..offset + family_lengths[4]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 vpn_announce.retain(|_| vpn_keep.next().unwrap_or(false));
                 offset += family_lengths[4];
-                let mut labeled_keep = keep[offset..offset + family_lengths[5]].iter().copied();
+                let mut labeled_keep = keep[offset..offset + family_lengths[5]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 labeled_announce.retain(|_| labeled_keep.next().unwrap_or(false));
                 offset += family_lengths[5];
-                let mut rtc_keep = keep[offset..offset + family_lengths[6]].iter().copied();
+                let mut rtc_keep = keep[offset..offset + family_lengths[6]]
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied();
                 rtc_announce.retain(|_| rtc_keep.next().unwrap_or(false));
                 debug_assert_eq!(offset + family_lengths[6], keep.len());
 
@@ -2708,15 +3080,40 @@ impl RibManager {
                     // against the withdrawals staged above. Mirror the OTC
                     // block's HashSet so duplicate detection stays
                     // constant-time for large resync batches.
-                    let withdrawn: HashSet<_> = withdraw.iter().copied().collect();
-                    let flowspec_withdrawn: HashSet<_> =
-                        flowspec_withdraw.iter().cloned().collect();
-                    let evpn_withdrawn: HashSet<_> = evpn_withdraw.iter().copied().collect();
-                    let bgpls_withdrawn: HashSet<_> = bgpls_withdraw.iter().cloned().collect();
-                    let vpn_withdrawn: HashSet<_> = vpn_withdraw.iter().cloned().collect();
-                    let labeled_withdrawn: HashSet<_> = labeled_withdraw.iter().copied().collect();
-                    let rtc_withdrawn: HashSet<_> = rtc_withdraw.iter().cloned().collect();
+                    let mut withdrawn: HashSet<_> =
+                        withdraw.iter().inspect(|_| checkpoint()).copied().collect();
+                    let mut flowspec_withdrawn: HashSet<_> = flowspec_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .cloned()
+                        .collect();
+                    let mut evpn_withdrawn: HashSet<_> = evpn_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .copied()
+                        .collect();
+                    let mut bgpls_withdrawn: HashSet<_> = bgpls_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .cloned()
+                        .collect();
+                    let mut vpn_withdrawn: HashSet<_> = vpn_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .cloned()
+                        .collect();
+                    let mut labeled_withdrawn: HashSet<_> = labeled_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .copied()
+                        .collect();
+                    let mut rtc_withdrawn: HashSet<_> = rtc_withdraw
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .cloned()
+                        .collect();
                     for key in decision.owed_withdrawals {
+                        checkpoint();
                         match key {
                             ExactExportKey::Unicast(prefix, path_id) => {
                                 if !withdrawn.contains(&(prefix, path_id)) {
@@ -2755,8 +3152,24 @@ impl RibManager {
                             }
                         }
                     }
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut flowspec_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut evpn_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut bgpls_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut vpn_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut labeled_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
+                    super::retire_hash_set(&mut rtc_withdrawn, &mut || checkpoint());
+                    self.replacement_checkpoint(true);
                 }
                 for (key, error) in decision.new_rejections {
+                    checkpoint();
                     self.metrics.record_exact_export_rejection(
                         &peer.to_string(),
                         key.family_label(),
@@ -2866,50 +3279,125 @@ impl RibManager {
                 .adj_ribs_out
                 .entry(peer)
                 .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
+            if readiness.is_some() {
+                if grouped_unicast_count.is_none() {
+                    let additional = announce
+                        .iter()
+                        .filter(|route| {
+                            checkpoint();
+                            rib_out.get(&route.prefix, route.path_id).is_none()
+                        })
+                        .count();
+                    rib_out.reserve_unicast_with(additional, &mut || checkpoint());
+                }
+                let additional = flowspec_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_flowspec(&route.selection_key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_flowspec_with(additional, &mut || checkpoint());
+                let additional = evpn_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_evpn(&route.key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_evpn_with(additional, &mut || checkpoint());
+                let additional = bgpls_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_bgpls(&route.key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_bgpls_with(additional, &mut || checkpoint());
+                let additional = vpn_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_vpn(&route.key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_vpn_with(additional, &mut || checkpoint());
+                let additional = labeled_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_labeled(&route.key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_labeled_with(additional, &mut || checkpoint());
+                let additional = rtc_announce
+                    .iter()
+                    .filter(|route| {
+                        checkpoint();
+                        rib_out.get_rtc(&route.key()).is_none()
+                    })
+                    .count();
+                rib_out.reserve_rtc_with(additional, &mut || checkpoint());
+                super::replacement_readiness_checkpoint(&readiness, true);
+            }
             if grouped_unicast_count.is_none() {
-                for route in announce.iter() {
-                    rib_out.insert(route.clone());
+                for route in announce.iter().inspect(|_| checkpoint()) {
+                    super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
+                    rib_out.insert_with(route.clone(), &mut || checkpoint());
                 }
                 for (prefix, path_id) in &withdraw {
-                    rib_out.withdraw(prefix, *path_id);
+                    super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
+                    rib_out.withdraw_with(prefix, *path_id, &mut || checkpoint());
                 }
             }
             for route in &flowspec_announce {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.insert_flowspec(route.clone());
             }
             for key in &flowspec_withdraw {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.remove_flowspec(key);
             }
             for route in &evpn_announce {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.insert_evpn(route.clone());
             }
             for key in &evpn_withdraw {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.remove_evpn(key);
             }
             for route in &bgpls_announce {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.insert_bgpls(route.clone());
             }
             for key in &bgpls_withdraw {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.remove_bgpls(key);
             }
             if grouped_vpn_count.is_none() {
                 for route in &vpn_announce {
+                    super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                     rib_out.insert_vpn(route.clone());
                 }
                 for key in &vpn_withdraw {
+                    super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                     rib_out.remove_vpn(key);
                 }
             }
             for route in &labeled_announce {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.insert_labeled(route.clone());
             }
             for key in &labeled_withdraw {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.remove_labeled(key);
             }
             for route in &rtc_announce {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.insert_rtc(route.clone());
             }
             for key in &rtc_withdraw {
+                super::replacement_readiness_checkpoint_at(&readiness, "family_commit", false);
                 rib_out.remove_rtc(key);
             }
             if unicast_changed {
@@ -2979,6 +3467,7 @@ impl RibManager {
 
         if let Some(pending) = self.pending_otc_blocked.get_mut(&peer) {
             for route in &otc_blocked {
+                checkpoint();
                 pending.remove(&(route.prefix, route.path_id));
             }
             if pending.is_empty() {
@@ -3034,42 +3523,44 @@ impl RibManager {
         peer: IpAddr,
         export_policy: Option<PolicyChain>,
     ) -> Result<(), RibCommandError> {
-        if !self.outbound_peers.contains_key(&peer) {
-            return Err(RibCommandError::not_found(format!(
-                "peer {peer} not registered for outbound updates"
-            )));
-        }
+        self.with_replacement_readiness(|manager| {
+            if !manager.outbound_peers.contains_key(&peer) {
+                return Err(RibCommandError::not_found(format!(
+                    "peer {peer} not registered for outbound updates"
+                )));
+            }
 
-        // A content-equal replacement keeps the installed chain
-        // INSTANCE, not just the group key: an update group's staging
-        // handle shares the installed instance's ADR-0096 term-hit
-        // counters (`PolicyChain::share`), so swapping in a fresh
-        // (zeroed) content-equal instance would freeze what the
-        // term-hits query reports while evaluations keep landing on
-        // the group's old instance. The peer manager already skips
-        // content-equal reinstalls at the fan-out; this guards the
-        // seam itself for any other sender.
-        if self.peer_export_policies.get(&peer) != Some(&export_policy) {
-            self.peer_export_policies.insert(peer, export_policy);
-        }
-        // Update-group membership recompute on the policy replacement
-        // seam (per-peer gRPC edits, ADR-0076 live-impact txns, and
-        // SIGHUP rpol overlays all funnel through this handler).
-        // Content-equality keying makes a reinstall of an identical
-        // chain key-stable — no regroup, and (key-stable fast path) NO
-        // resync either: a grouped member's staged output is a pure
-        // function of the key, so re-emitting would be a no-op flood.
-        // Everything else — regrouped members (one-shot baseline diff)
-        // and ungrouped peers (per-peer equality-suppressed diff) —
-        // takes the dirty resync exactly as before.
-        let before = self.grouped_member_of(peer);
-        self.recompute_update_group(peer);
-        let key_stable = before.is_some() && before == self.grouped_member_of(peer);
-        if !key_stable {
-            self.mark_outbound_dirty(peer);
-        }
-        self.distribute_changes(&HashSet::new(), &HashSet::new());
-        Ok(())
+            // A content-equal replacement keeps the installed chain
+            // INSTANCE, not just the group key: an update group's staging
+            // handle shares the installed instance's ADR-0096 term-hit
+            // counters (`PolicyChain::share`), so swapping in a fresh
+            // (zeroed) content-equal instance would freeze what the
+            // term-hits query reports while evaluations keep landing on
+            // the group's old instance. The peer manager already skips
+            // content-equal reinstalls at the fan-out; this guards the
+            // seam itself for any other sender.
+            if manager.peer_export_policies.get(&peer) != Some(&export_policy) {
+                manager.peer_export_policies.insert(peer, export_policy);
+            }
+            // Update-group membership recompute on the policy replacement
+            // seam (per-peer gRPC edits, ADR-0076 live-impact txns, and
+            // SIGHUP rpol overlays all funnel through this handler).
+            // Content-equality keying makes a reinstall of an identical
+            // chain key-stable — no regroup, and (key-stable fast path) NO
+            // resync either: a grouped member's staged output is a pure
+            // function of the key, so re-emitting would be a no-op flood.
+            // Everything else — regrouped members (one-shot baseline diff)
+            // and ungrouped peers (per-peer equality-suppressed diff) —
+            // takes the dirty resync exactly as before.
+            let before = manager.grouped_member_of(peer);
+            manager.recompute_update_group(peer);
+            let key_stable = before.is_some() && before == manager.grouped_member_of(peer);
+            if !key_stable {
+                manager.mark_outbound_dirty(peer);
+            }
+            manager.distribute_changes(&HashSet::new(), &HashSet::new());
+            Ok(())
+        })
     }
 
     pub(super) fn handle_replace_peer_export_policy(
@@ -3091,37 +3582,51 @@ impl RibManager {
             Result<crate::update::ExportPolicyCohortOutcome, String>,
         >,
     ) {
-        if replacements.is_empty() {
-            let _ = reply.send(Ok(crate::update::ExportPolicyCohortOutcome::Committed));
-            return;
+        let terminal = self.with_replacement_readiness(|manager| {
+            let readiness = manager.replacement_readiness.clone();
+            let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+            let mut replacements = replacements;
+            let error = replacements
+                .iter()
+                .inspect(|_| checkpoint())
+                .find(|replacement| !manager.outbound_peers.contains_key(&replacement.peer))
+                .map(|replacement| {
+                    format!(
+                        "peer {} not registered for outbound updates",
+                        replacement.peer
+                    )
+                })
+                .or_else(|| {
+                    manager.pending_clean_policy_transition.as_ref().map(|_| {
+                        "internal RIB sequencing error: policy transition already in progress"
+                            .to_string()
+                    })
+                });
+            if replacements.is_empty() || error.is_some() {
+                let result = if replacements.is_empty() {
+                    Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+                } else {
+                    Err(error.expect("nonempty rejected batch has an error"))
+                };
+                super::retire_vec(&mut replacements, &mut || checkpoint());
+                manager.replacement_checkpoint(true);
+                return Some((reply, result));
+            }
+            if let Some(mut prestage) = manager.pending_destination_prestage.take() {
+                let _ = manager.discard_uncommitted_policy_transition_group(prestage.destination);
+                #[cfg(feature = "bench-internals")]
+                prestage.memo.record_replacement_capacities(manager);
+                prestage.retire_with(&mut || checkpoint());
+                manager.replacement_checkpoint(true);
+            }
+            manager.metrics.set_rib_policy_transition_in_progress(true);
+            manager.pending_clean_policy_transition =
+                Some(PendingCleanPolicyTransition::new(replacements, Some(reply)));
+            None
+        });
+        if let Some((reply, result)) = terminal {
+            let _ = reply.send(result);
         }
-        if let Some(replacement) = replacements
-            .iter()
-            .find(|replacement| !self.outbound_peers.contains_key(&replacement.peer))
-        {
-            let _ = reply.send(Err(format!(
-                "peer {} not registered for outbound updates",
-                replacement.peer
-            )));
-            return;
-        }
-        if self.pending_clean_policy_transition.is_some() {
-            let _ = reply.send(Err(
-                "internal RIB sequencing error: policy transition already in progress".to_string(),
-            ));
-            return;
-        }
-        // A still-running destination preparation cannot be trusted
-        // mid-walk: discard the partial group so the transition stages the
-        // destination deterministically on its ordinary `Created` path.
-        // (The peer manager awaits the prepare reply before sending the
-        // transition, so this is a belt-and-braces guard.)
-        if let Some(prestage) = self.pending_destination_prestage.take() {
-            let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
-        }
-        self.metrics.set_rib_policy_transition_in_progress(true);
-        self.pending_clean_policy_transition =
-            Some(PendingCleanPolicyTransition::new(replacements, Some(reply)));
     }
 
     pub(super) fn handle_replace_peer_export_policies_authoritatively(
@@ -3139,6 +3644,16 @@ impl RibManager {
                 replacements = replacements.len(),
                 "skipping abandoned authoritative export-policy batch: caller dropped the reply"
             );
+            self.with_replacement_readiness(|manager| {
+                let mut replacements = replacements;
+                while let Some(replacement) = replacements.pop() {
+                    manager.replacement_checkpoint(true);
+                    drop(replacement);
+                }
+                manager.replacement_checkpoint(true);
+                drop(replacements);
+                manager.replacement_checkpoint(true);
+            });
             return;
         }
         let _ = reply.send(self.apply_export_policy_replacements_synchronously(replacements));
@@ -3167,41 +3682,60 @@ impl RibManager {
     /// newest-first execution order and make every departed peer explicit.
     pub(in crate::manager) fn restore_export_policy_replacements_synchronously(
         &mut self,
-        replacements: Vec<PeerExportPolicyReplacement>,
+        mut replacements: Vec<PeerExportPolicyReplacement>,
     ) -> Result<Vec<PeerExportPolicyRestoreReceipt>, RibCommandError> {
-        let mut seen = HashSet::new();
-        if let Some(duplicate) = replacements
-            .iter()
-            .find(|replacement| !seen.insert(replacement.peer))
-        {
-            return Err(RibCommandError::internal(format!(
-                "duplicate peer {} in rollback export-policy batch",
-                duplicate.peer
-            )));
-        }
-        if self.pending_clean_policy_transition.is_some() {
-            return Err(RibCommandError::internal(
-                "internal RIB sequencing error: policy transition already in progress",
-            ));
-        }
+        self.with_replacement_readiness(|manager| {
+            let readiness = manager.replacement_readiness.clone();
+            let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+            checkpoint();
 
-        let execution = replacements.into_iter().rev().collect::<Vec<_>>();
-        let receipts = execution
-            .iter()
-            .map(|replacement| {
-                if self.outbound_peers.contains_key(&replacement.peer) {
-                    PeerExportPolicyRestoreReceipt::Restored {
-                        peer: replacement.peer,
+            let mut seen = HashSet::with_capacity(replacements.len());
+            if let Some(duplicate) = replacements
+                .iter()
+                .inspect(|_| checkpoint())
+                .find(|replacement| !seen.insert(replacement.peer))
+            {
+                let error = RibCommandError::internal(format!(
+                    "duplicate peer {} in rollback export-policy batch",
+                    duplicate.peer
+                ));
+                super::retire_hash_set(&mut seen, &mut || checkpoint());
+                super::retire_vec(&mut replacements, &mut || checkpoint());
+                manager.replacement_checkpoint(true);
+                return Err(error);
+            }
+            super::retire_hash_set(&mut seen, &mut || checkpoint());
+            if manager.pending_clean_policy_transition.is_some() {
+                super::retire_vec(&mut replacements, &mut || checkpoint());
+                manager.replacement_checkpoint(true);
+                return Err(RibCommandError::internal(
+                    "internal RIB sequencing error: policy transition already in progress",
+                ));
+            }
+
+            let execution = replacements
+                .into_iter()
+                .inspect(|_| checkpoint())
+                .rev()
+                .collect::<Vec<_>>();
+            let receipts = execution
+                .iter()
+                .inspect(|_| checkpoint())
+                .map(|replacement| {
+                    if manager.outbound_peers.contains_key(&replacement.peer) {
+                        PeerExportPolicyRestoreReceipt::Restored {
+                            peer: replacement.peer,
+                        }
+                    } else {
+                        PeerExportPolicyRestoreReceipt::NotFound {
+                            peer: replacement.peer,
+                        }
                     }
-                } else {
-                    PeerExportPolicyRestoreReceipt::NotFound {
-                        peer: replacement.peer,
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
-        self.apply_export_policy_replacements_synchronously(execution)?;
-        Ok(receipts)
+                })
+                .collect::<Vec<_>>();
+            manager.apply_export_policy_replacements_synchronously(execution)?;
+            Ok(receipts)
+        })
     }
 
     /// Apply a batch of authoritative export-policy replacements in one
@@ -3234,6 +3768,7 @@ impl RibManager {
         &mut self,
         replacements: Vec<PeerExportPolicyReplacement>,
     ) -> Result<(), RibCommandError> {
+        self.with_replacement_readiness(|manager| {
         let started = std::time::Instant::now();
         let mut r = AuthoritativeTransitionReceipt {
             input_peers: replacements.len(),
@@ -3242,16 +3777,16 @@ impl RibManager {
             failure_stage: "none",
             ..Default::default()
         };
-        r.filtered_state_before = self.policy_filtered_routes.len();
-        r.dirty_before = self.dirty_peers.len();
-        r.pending_before = self.pending_regroup_baseline.len();
-        r.groups_before = self.group_ribs.len();
+        r.filtered_state_before = manager.policy_filtered_routes.len();
+        r.dirty_before = manager.dirty_peers.len();
+        r.pending_before = manager.pending_regroup_baseline.len();
+        r.groups_before = manager.group_ribs.len();
         let previous_deferral =
-            std::mem::replace(&mut self.update_groups.reclamation_deferred, true);
+            std::mem::replace(&mut manager.update_groups.reclamation_deferred, true);
         let result =
-            self.apply_export_policy_replacements_synchronously_inner(replacements, &mut r);
-        self.update_groups.reclamation_deferred = previous_deferral;
-        self.reclaim_unused_update_group_policies();
+            manager.apply_export_policy_replacements_synchronously_inner(replacements, &mut r);
+        manager.update_groups.reclamation_deferred = previous_deferral;
+        manager.reclaim_unused_update_group_policies();
         r.total_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
         let phases = [
             r.precondition_us,
@@ -3269,10 +3804,10 @@ impl RibManager {
             r.duplicate_fallback_us,
         ];
         r.remainder_us = r.total_us.saturating_sub(phases.into_iter().sum());
-        r.filtered_state_after = self.policy_filtered_routes.len();
-        r.dirty_after = self.dirty_peers.len();
-        r.pending_after = self.pending_regroup_baseline.len();
-        r.groups_after = self.group_ribs.len();
+        r.filtered_state_after = manager.policy_filtered_routes.len();
+        r.dirty_after = manager.dirty_peers.len();
+        r.pending_after = manager.pending_regroup_baseline.len();
+        r.groups_after = manager.group_ribs.len();
         info!(target: "authoritative_batch_phase", outcome=r.outcome, classification=r.classification,
             failure_stage=r.failure_stage, total_us=r.total_us, remainder_us=r.remainder_us,
             precondition_us=r.precondition_us, registration_membership_us=r.registration_membership_us,
@@ -3311,8 +3846,10 @@ impl RibManager {
             membership_ungrouped=r.membership_ungrouped,
             "authoritative_batch_phase");
         #[cfg(test)]
-        self.authoritative_transition_receipts.push(r);
+        manager.authoritative_transition_receipts.push(r);
         result
+
+        })
     }
 
     #[expect(
@@ -3322,14 +3859,20 @@ impl RibManager {
     )]
     fn apply_export_policy_replacements_synchronously_inner(
         &mut self,
-        replacements: Vec<PeerExportPolicyReplacement>,
+        mut replacements: Vec<PeerExportPolicyReplacement>,
         receipt: &mut AuthoritativeTransitionReceipt,
     ) -> Result<(), RibCommandError> {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
         let phase = std::time::Instant::now();
         if self.pending_clean_policy_transition.is_some() {
             receipt.precondition_us =
                 u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
             receipt.failure_stage = "precondition";
+            super::retire_vec(&mut replacements, &mut || checkpoint());
+            self.replacement_checkpoint(true);
             return Err(RibCommandError::internal(
                 "internal RIB sequencing error: policy transition already in progress",
             ));
@@ -3342,13 +3885,16 @@ impl RibManager {
         let mut seen: HashSet<IpAddr> = HashSet::new();
         receipt.duplicate_peers = replacements
             .iter()
+            .inspect(|_| checkpoint())
             .filter(|replacement| !seen.insert(replacement.peer))
             .count();
+        super::retire_hash_set(&mut seen, &mut || checkpoint());
         if receipt.duplicate_peers != 0 {
             receipt.precondition_us =
                 u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
             let duplicate_started = std::time::Instant::now();
             for replacement in replacements {
+                checkpoint();
                 match self.replace_peer_export_policy_synchronously(
                     replacement.peer,
                     replacement.export_policy,
@@ -3372,14 +3918,19 @@ impl RibManager {
         receipt.precondition_us = u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX);
         // A still-running destination preparation cannot be trusted
         // mid-walk (same guard as the cohort transition command).
-        if let Some(prestage) = self.pending_destination_prestage.take() {
+        if let Some(mut prestage) = self.pending_destination_prestage.take() {
             let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
+            #[cfg(feature = "bench-internals")]
+            prestage.memo.record_replacement_capacities(self);
+            prestage.retire_with(&mut || checkpoint());
+            self.replacement_checkpoint(true);
         }
 
         let phase = std::time::Instant::now();
         let mut present: Vec<PeerExportPolicyReplacement> = Vec::with_capacity(replacements.len());
         let mut n_skipped_unregistered = 0_usize;
         for replacement in replacements {
+            checkpoint();
             if self.outbound_peers.contains_key(&replacement.peer) {
                 present.push(replacement);
             } else {
@@ -3393,6 +3944,7 @@ impl RibManager {
         // Previous memberships, captured before any mutation.
         let previous: Vec<Option<usize>> = present
             .iter()
+            .inspect(|_| checkpoint())
             .map(|replacement| self.grouped_member_of(replacement.peer))
             .collect();
         receipt.registered_peer_source_membership_scan_us =
@@ -3402,6 +3954,7 @@ impl RibManager {
         // `replace_peer_export_policy_synchronously` for the ADR-0096
         // term-hit rationale), then classify each member's destination.
         for replacement in &present {
+            checkpoint();
             receipt.policy_equality_attempts += 1;
             let equal = self.peer_export_policies.get(&replacement.peer)
                 == Some(&replacement.export_policy);
@@ -3414,7 +3967,13 @@ impl RibManager {
                 self.peer_export_policies.get(&replacement.peer),
                 replacement.export_policy.as_ref(),
             ) {
-                for (old_policy, new_policy) in old.policies.iter().zip(&new.policies) {
+                for (old_policy, new_policy) in old
+                    .policies
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .zip(&new.policies)
+                {
+                    checkpoint();
                     if let (Some(old_rpol), Some(new_rpol)) = (&old_policy.rpol, &new_policy.rpol) {
                         if std::sync::Arc::ptr_eq(old_rpol, new_rpol) {
                             receipt.rpol_shared_backing += 1;
@@ -3423,6 +3982,7 @@ impl RibManager {
                             receipt.detached_prefix_set_entries += new_rpol
                                 .prefix_sets
                                 .iter()
+                                .inspect(|_| checkpoint())
                                 .map(|set| set.entries().len())
                                 .sum::<usize>();
                         }
@@ -3439,6 +3999,7 @@ impl RibManager {
         let phase = std::time::Instant::now();
         let destinations: Vec<Option<usize>> = present
             .iter()
+            .inspect(|_| checkpoint())
             .map(|replacement| {
                 match self.compute_update_group_membership_with_receipt(replacement.peer, receipt) {
                     super::update_groups::GroupMembership::Grouped(gid) => Some(gid),
@@ -3463,7 +4024,8 @@ impl RibManager {
         let mut residual: Vec<IpAddr> = Vec::new();
         {
             let mut by_source: HashMap<usize, Option<(usize, Vec<IpAddr>)>> = HashMap::new();
-            for (index, replacement) in present.iter().enumerate() {
+            for (index, replacement) in present.iter().inspect(|_| checkpoint()).enumerate() {
+                checkpoint();
                 match (previous[index], destinations[index]) {
                     (Some(source), Some(destination)) if source != destination => {
                         match by_source
@@ -3485,6 +4047,7 @@ impl RibManager {
             let mut sources: Vec<usize> = by_source.keys().copied().collect();
             sources.sort_unstable();
             for source in sources {
+                checkpoint();
                 match by_source.remove(&source).flatten() {
                     Some((destination, members)) => {
                         cohorts.push((source, destination, members));
@@ -3493,7 +4056,10 @@ impl RibManager {
                         // Mixed destinations under one source group: every
                         // one of its batched movers takes the per-member
                         // path.
-                        for (index, replacement) in present.iter().enumerate() {
+                        for (index, replacement) in
+                            present.iter().inspect(|_| checkpoint()).enumerate()
+                        {
+                            checkpoint();
                             if previous[index] == Some(source)
                                 && destinations[index]
                                     .is_some_and(|destination| Some(destination) != previous[index])
@@ -3512,6 +4078,7 @@ impl RibManager {
         let mut n_shared_members = 0_usize;
         let mut n_destination_groups = 0_usize;
         for (source, destination, members) in cohorts {
+            checkpoint();
             if self.apply_batched_group_transition(source, destination, &members, receipt) {
                 n_shared_members += members.len();
                 n_destination_groups += 1;
@@ -3526,6 +4093,7 @@ impl RibManager {
         let n_fallback_members = residual.len();
         let phase = std::time::Instant::now();
         for peer in residual {
+            checkpoint();
             let before = self.grouped_member_of(peer);
             self.recompute_update_group(peer);
             let key_stable = before.is_some() && before == self.grouped_member_of(peer);
@@ -3603,6 +4171,10 @@ impl RibManager {
         members: &[IpAddr],
         receipt: &mut AuthoritativeTransitionReceipt,
     ) -> bool {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
         let phase = std::time::Instant::now();
         // The shared delta covers unicast-only, chain-only moves — the
         // same narrow shape as the clean transition, with the
@@ -3630,13 +4202,16 @@ impl RibManager {
         // here without emitting its incumbents' deltas, so retain the
         // authoritative per-member path for this mutable-input boundary.
         if destination_owned
-            && [source, destination].iter().any(|gid| {
-                self.group_ribs.get(gid).is_some_and(|group| {
-                    group.export_chain.as_ref().is_some_and(|chain| {
-                        chain.compiled().referenced_datasets().next().is_some()
+            && [source, destination]
+                .iter()
+                .inspect(|_| checkpoint())
+                .any(|gid| {
+                    self.group_ribs.get(gid).is_some_and(|group| {
+                        group.export_chain.as_ref().is_some_and(|chain| {
+                            chain.compiled().referenced_datasets().next().is_some()
+                        })
                     })
                 })
-            })
         {
             receipt.cohort_precheck_us = receipt
                 .cohort_precheck_us
@@ -3679,7 +4254,7 @@ impl RibManager {
             .destination_build_us
             .saturating_add(u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX));
         let phase = std::time::Instant::now();
-        let inventory = {
+        let mut inventory = {
             let (Some(source_group), Some(destination_group)) = (
                 self.group_ribs.get(&source),
                 self.group_ribs.get(&destination),
@@ -3698,13 +4273,23 @@ impl RibManager {
             // shares normally.
             let mut rs_asns: Vec<u32> = members
                 .iter()
+                .inspect(|_| checkpoint())
                 .filter_map(|member| self.peer_rs_control.get(member).copied())
                 .collect();
             rs_asns.sort_unstable();
             rs_asns.dedup();
-            let Some(inventory) =
-                Self::batched_transition_inventory(source_group, destination_group, &rs_asns)
-            else {
+            let Some(inventory) = Self::batched_transition_inventory(
+                source_group,
+                destination_group,
+                &rs_asns,
+                &mut |force| {
+                    if force {
+                        self.replacement_checkpoint(true);
+                    } else {
+                        self.replacement_checkpoint_at("shared_inventory", false);
+                    }
+                },
+            ) else {
                 receipt.inventory_build_us = receipt
                     .inventory_build_us
                     .saturating_add(u64::try_from(phase.elapsed().as_micros()).unwrap_or(u64::MAX));
@@ -3721,10 +4306,17 @@ impl RibManager {
 
         // Everything below commits: no fallible step touches shared
         // state before this point.
-        let source_tombstones: Vec<(Prefix, u32)> = self
+        let mut source_tombstones: Vec<(Prefix, u32)> = self
             .group_ribs
             .get(&source)
-            .map(|group| group.tombstones.iter().copied().collect())
+            .map(|group| {
+                group
+                    .tombstones
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied()
+                    .collect()
+            })
             .unwrap_or_default();
         receipt.tombstones += source_tombstones.len();
         // A member whose wire lags its table (dirty, or carrying regroup
@@ -3732,8 +4324,9 @@ impl RibManager {
         // heal. It still moves with the cohort, carrying the source
         // group's tombstones as extra (over-)withdraws (the regroup
         // dirty-leaver rule).
-        let lagging: HashSet<IpAddr> = members
+        let mut lagging: HashSet<IpAddr> = members
             .iter()
+            .inspect(|_| checkpoint())
             .copied()
             .filter(|member| {
                 self.dirty_peers.contains(member)
@@ -3744,9 +4337,12 @@ impl RibManager {
         receipt.lagging_members += lagging.len();
         let phase = std::time::Instant::now();
         for &peer in members {
+            checkpoint();
             if lagging.contains(&peer) && !source_tombstones.is_empty() {
                 let extras = self.pending_extra_withdraws.entry(peer).or_default();
-                extras.unicast.extend(source_tombstones.iter().copied());
+                extras
+                    .unicast
+                    .extend(source_tombstones.iter().inspect(|_| checkpoint()).copied());
             }
             self.commit_clean_policy_transition_member(peer, source, destination);
             receipt.membership_moves += 1;
@@ -3763,13 +4359,52 @@ impl RibManager {
         // The prefix scope of the per-member policy-denial restamp: every
         // prefix whose verdict this transition may have moved.
         let phase = std::time::Instant::now();
-        let mut filtered_scope: HashSet<Prefix> =
-            self.loc_rib.iter().map(|route| route.prefix).collect();
+        let capacity = self
+            .loc_rib
+            .len()
+            .saturating_add(
+                self.group_ribs
+                    .get(&destination)
+                    .map_or(0, |group| group.table.len()),
+            )
+            .saturating_add(source_tombstones.len())
+            .saturating_add(inventory.withdraw.len());
+        self.replacement_checkpoint(true);
+        let mut filtered_scope = HashSet::with_capacity(capacity);
+        self.replacement_checkpoint(true);
+        filtered_scope.extend(
+            self.loc_rib
+                .iter()
+                .inspect(|_| checkpoint())
+                .map(|route| route.prefix),
+        );
         if let Some(group) = self.group_ribs.get(&destination) {
-            filtered_scope.extend(group.table.iter().map(|route| route.prefix));
+            filtered_scope.extend(
+                group
+                    .table
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .map(|route| route.prefix),
+            );
         }
-        filtered_scope.extend(source_tombstones.iter().map(|(prefix, _)| *prefix));
-        filtered_scope.extend(inventory.withdraw.iter().map(|(prefix, _)| *prefix));
+        filtered_scope.extend(
+            source_tombstones
+                .iter()
+                .inspect(|_| checkpoint())
+                .map(|(prefix, _)| *prefix),
+        );
+        filtered_scope.extend(
+            inventory
+                .withdraw
+                .iter()
+                .inspect(|_| checkpoint())
+                .map(|(prefix, _)| *prefix),
+        );
+        self.replacement_capacity(
+            "filtered_scope",
+            filtered_scope.len(),
+            filtered_scope.capacity(),
+        );
         receipt.filtered_scope_prefixes += filtered_scope.len();
         receipt.filtered_scope_build_us = receipt
             .filtered_scope_build_us
@@ -3780,6 +4415,7 @@ impl RibManager {
         let mut probe_cache = SharedUnicastProbeCache::default();
         let phase = std::time::Instant::now();
         for &peer in members {
+            checkpoint();
             if lagging.contains(&peer) {
                 continue;
             }
@@ -3802,17 +4438,25 @@ impl RibManager {
             }
             receipt.emits_succeeded += 1;
             self.apply_batched_transition_counters(peer, &inventory);
-            let current: HashSet<PolicyFilteredRouteKey> = self
+            let mut current: HashSet<PolicyFilteredRouteKey> = self
                 .group_ribs
                 .get(&destination)
                 .map(|group| {
                     group
-                        .policy_filtered_for_member(peer, &filtered_scope)
+                        .policy_filtered_for_member_with_checkpoint(
+                            peer,
+                            &filtered_scope,
+                            &mut || checkpoint(),
+                        )
                         .into_iter()
+                        .inspect(|_| checkpoint())
                         .collect()
                 })
                 .unwrap_or_default();
             self.update_policy_filtered_routes_for_prefixes(peer, &filtered_scope, &current);
+            self.replacement_checkpoint(true);
+            super::retire_hash_set(&mut current, &mut || checkpoint());
+            self.replacement_checkpoint(true);
             receipt.filtered_scope_member_visits += filtered_scope.len();
             let advertised = self.grouped_advertised_count(peer).unwrap_or(0);
             self.metrics
@@ -3835,6 +4479,12 @@ impl RibManager {
             supplemented = inventory.supplements.len(),
             "applied batched authoritative export-policy transition"
         );
+        probe_cache.retire_with(&mut || self.replacement_checkpoint_at("retirement", false));
+        inventory.retire_with(&mut |force| self.replacement_checkpoint_at("retirement", force));
+        super::retire_vec(&mut source_tombstones, &mut || checkpoint());
+        super::retire_hash_set(&mut lagging, &mut || checkpoint());
+        super::retire_hash_set(&mut filtered_scope, &mut || checkpoint());
+        self.replacement_checkpoint(true);
         true
     }
 
@@ -3859,6 +4509,10 @@ impl RibManager {
         shared_encode: Option<&Arc<crate::update::SharedGroupEncode>>,
         probe_cache: &mut SharedUnicastProbeCache,
     ) -> Result<(), &'static str> {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
         let Some(sender) = self.outbound_peers.get(&peer).cloned() else {
             return Err("peer no longer registered");
         };
@@ -3874,119 +4528,174 @@ impl RibManager {
         }
         let supplement = inventory.supplements.get(&peer);
         let supplement_announce = supplement.map_or(0, |entry| entry.announce.len());
-        let supplement_withdraw: Vec<(Prefix, u32)> = inventory
+        let mut supplement_withdraw: Vec<(Prefix, u32)> = inventory
             .withdraw
             .iter()
+            .inspect(|_| checkpoint())
             .copied()
             .chain(
                 supplement
                     .into_iter()
-                    .flat_map(|entry| entry.withdraw.iter().copied()),
+                    .inspect(|_| checkpoint())
+                    .flat_map(|entry| entry.withdraw.iter().inspect(|_| checkpoint()).copied()),
             )
             .collect();
-        // Probe the shared payload: the first member's full batch probe
-        // seeds the cohort cache; every compatible member afterwards
-        // proves only the largest encoded message against its own
-        // ceiling (the clean transition's reuse shape).
-        if !inventory.announce.is_empty() {
-            let reused = probe_cache.reuse_grouped_exact_export_maximum(
-                destination,
-                &inventory.announce,
-                &inventory.next_hop_override,
-                snapshot.as_ref(),
-            );
-            match reused {
-                Some(Ok(_)) => {}
-                Some(Err(_)) => return Err("shared payload exceeds the member's message ceiling"),
-                None => {
-                    let candidates: Vec<crate::update::ExactExportCandidate<'_>> = inventory
-                        .announce
-                        .iter()
-                        .zip(inventory.next_hop_override.iter())
-                        .map(
-                            |(route, next_hop)| crate::update::ExactExportCandidate::Unicast {
-                                route,
-                                next_hop_override: next_hop.as_ref(),
-                            },
-                        )
-                        .collect();
-                    let (results, cardinality_correct) =
-                        probe_exact_export_announcements(peer, snapshot.as_ref(), &candidates);
-                    if !cardinality_correct || results.iter().any(Result::is_err) {
-                        return Err("shared payload exact-export probe rejected");
+        self.replacement_capacity(
+            "supplement_withdraw",
+            supplement_withdraw.len(),
+            supplement_withdraw.capacity(),
+        );
+        let result = (|| {
+            // Probe the shared payload: the first member's full batch probe
+            // seeds the cohort cache; every compatible member afterwards
+            // proves only the largest encoded message against its own
+            // ceiling (the clean transition's reuse shape).
+            if !inventory.announce.is_empty() {
+                let reused = probe_cache.reuse_grouped_exact_export_maximum(
+                    destination,
+                    &inventory.announce,
+                    &inventory.next_hop_override,
+                    snapshot.as_ref(),
+                );
+                match reused {
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) => {
+                        return Err("shared payload exceeds the member's message ceiling");
                     }
-                    let encoded_lengths = results
-                        .iter()
-                        .filter_map(|result| result.as_ref().ok().map(|result| result.encoded_len))
-                        .collect();
-                    probe_cache.store(
-                        destination,
-                        Arc::clone(&inventory.announce),
-                        Arc::clone(&inventory.next_hop_override),
-                        Arc::clone(&snapshot),
-                        encoded_lengths,
-                    );
+                    None => {
+                        let mut candidates: Vec<crate::update::ExactExportCandidate<'_>> =
+                            inventory
+                                .announce
+                                .iter()
+                                .inspect(|_| checkpoint())
+                                .zip(inventory.next_hop_override.iter().inspect(|_| checkpoint()))
+                                .map(|(route, next_hop)| {
+                                    crate::update::ExactExportCandidate::Unicast {
+                                        route,
+                                        next_hop_override: next_hop.as_ref(),
+                                    }
+                                })
+                                .collect();
+                        let (mut results, cardinality_correct) = probe_exact_export_announcements(
+                            peer,
+                            snapshot.as_ref(),
+                            &candidates,
+                            &mut || self.replacement_checkpoint(true),
+                        );
+                        self.replacement_capacity(
+                            "exact_candidates",
+                            candidates.len(),
+                            candidates.capacity(),
+                        );
+                        self.replacement_capacity(
+                            "exact_results",
+                            results.len(),
+                            results.capacity(),
+                        );
+                        if !cardinality_correct
+                            || results.iter().inspect(|_| checkpoint()).any(Result::is_err)
+                        {
+                            super::retire_vec(&mut results, &mut || checkpoint());
+                            super::retire_vec(&mut candidates, &mut || checkpoint());
+                            self.replacement_checkpoint(true);
+                            return Err("shared payload exact-export probe rejected");
+                        }
+                        let encoded_lengths = results
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(|result| {
+                                result
+                                    .as_ref()
+                                    .expect("successful probe validated above")
+                                    .encoded_len
+                            })
+                            .collect();
+                        probe_cache.store(
+                            destination,
+                            Arc::clone(&inventory.announce),
+                            Arc::clone(&inventory.next_hop_override),
+                            Arc::clone(&snapshot),
+                            encoded_lengths,
+                            &mut || checkpoint(),
+                        );
+                        self.replacement_checkpoint(true);
+                        super::retire_vec(&mut results, &mut || checkpoint());
+                        super::retire_vec(&mut candidates, &mut || checkpoint());
+                        self.replacement_checkpoint(true);
+                    }
                 }
             }
-        }
-        // Probe the member-scoped lane substitutions.
-        if let Some(entry) = supplement {
-            for (route, next_hop) in &entry.announce {
-                if snapshot
-                    .probe_announcement(crate::update::ExactExportCandidate::Unicast {
-                        route,
-                        next_hop_override: next_hop.as_ref(),
+            // Probe the member-scoped lane substitutions.
+            if let Some(entry) = supplement {
+                for (route, next_hop) in &entry.announce {
+                    checkpoint();
+                    if snapshot
+                        .probe_announcement(crate::update::ExactExportCandidate::Unicast {
+                            route,
+                            next_hop_override: next_hop.as_ref(),
+                        })
+                        .is_err()
+                    {
+                        return Err("lane supplement exact-export probe rejected");
+                    }
+                }
+            }
+            // Reserve every needed permit before sending anything, so a full
+            // channel degrades the member cleanly instead of half-emitting.
+            let shared_permit = if inventory.announce.is_empty() {
+                None
+            } else {
+                match sender.clone().try_reserve_owned() {
+                    Ok(permit) => Some(permit),
+                    Err(_) => return Err("outbound channel full"),
+                }
+            };
+            let supplement_permit = if supplement_announce == 0 && supplement_withdraw.is_empty() {
+                None
+            } else {
+                match sender.clone().try_reserve_owned() {
+                    Ok(permit) => Some(permit),
+                    Err(_) => return Err("outbound channel full"),
+                }
+            };
+            if let Some(permit) = shared_permit {
+                permit.send(OutboundRouteUpdate {
+                    exact_export_snapshot: Some(Arc::clone(&snapshot)),
+                    announce_source_exclusion: Some(peer),
+                    announce: Arc::clone(&inventory.announce),
+                    next_hop_override: Arc::clone(&inventory.next_hop_override),
+                    shared_group_encode: shared_encode.map(Arc::clone),
+                    ..OutboundRouteUpdate::default()
+                });
+            }
+            if let Some(permit) = supplement_permit {
+                let (announce, next_hop_override): (
+                    Vec<crate::route::Route>,
+                    Vec<Option<rustbgpd_policy::NextHopAction>>,
+                ) = supplement
+                    .map(|entry| {
+                        entry
+                            .announce
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .cloned()
+                            .unzip()
                     })
-                    .is_err()
-                {
-                    return Err("lane supplement exact-export probe rejected");
-                }
+                    .unwrap_or_default();
+                permit.send(OutboundRouteUpdate {
+                    exact_export_snapshot: Some(snapshot),
+                    announce: announce.into(),
+                    next_hop_override: next_hop_override.into(),
+                    withdraw: std::mem::take(&mut supplement_withdraw),
+                    ..OutboundRouteUpdate::default()
+                });
             }
-        }
-        // Reserve every needed permit before sending anything, so a full
-        // channel degrades the member cleanly instead of half-emitting.
-        let shared_permit = if inventory.announce.is_empty() {
-            None
-        } else {
-            match sender.clone().try_reserve_owned() {
-                Ok(permit) => Some(permit),
-                Err(_) => return Err("outbound channel full"),
-            }
-        };
-        let supplement_permit = if supplement_announce == 0 && supplement_withdraw.is_empty() {
-            None
-        } else {
-            match sender.clone().try_reserve_owned() {
-                Ok(permit) => Some(permit),
-                Err(_) => return Err("outbound channel full"),
-            }
-        };
-        if let Some(permit) = shared_permit {
-            permit.send(OutboundRouteUpdate {
-                exact_export_snapshot: Some(Arc::clone(&snapshot)),
-                announce_source_exclusion: Some(peer),
-                announce: Arc::clone(&inventory.announce),
-                next_hop_override: Arc::clone(&inventory.next_hop_override),
-                shared_group_encode: shared_encode.map(Arc::clone),
-                ..OutboundRouteUpdate::default()
-            });
-        }
-        if let Some(permit) = supplement_permit {
-            let (announce, next_hop_override): (
-                Vec<crate::route::Route>,
-                Vec<Option<rustbgpd_policy::NextHopAction>>,
-            ) = supplement
-                .map(|entry| entry.announce.iter().cloned().unzip())
-                .unwrap_or_default();
-            permit.send(OutboundRouteUpdate {
-                exact_export_snapshot: Some(snapshot),
-                announce: announce.into(),
-                next_hop_override: next_hop_override.into(),
-                withdraw: supplement_withdraw,
-                ..OutboundRouteUpdate::default()
-            });
-        }
-        Ok(())
+            Ok(())
+        })();
+        self.replacement_checkpoint(true);
+        super::retire_vec(&mut supplement_withdraw, &mut || checkpoint());
+        self.replacement_checkpoint(true);
+        result
     }
 
     /// Begin the unfenced staging of a prospective clean-transition
@@ -4008,39 +4717,51 @@ impl RibManager {
             ));
             return;
         }
-        let Some((_, destination)) = self.clean_policy_transition_destination(peer, export_policy)
-        else {
-            self.reclaim_unused_update_group_policies();
-            let _ = reply.send(Err(
-                "peer/policy pair does not classify as a clean grouped transition".to_string(),
-            ));
-            return;
-        };
-        // A stale completed preparation that was never consumed (its
-        // cohort never arrived) is discarded before a new one begins;
-        // the record must only ever name the latest staged group.
-        if let Some(stale) = self.prepared_destination.take() {
-            let _ = self.discard_uncommitted_policy_transition_group(stale);
-        }
-        // A leftover unowned group under this id may be partially staged
-        // from an aborted attempt; recreate it deterministically. An OWNED
-        // group is maintained by definition — nothing to stage.
-        let _ = self.discard_uncommitted_policy_transition_group(destination);
-        match self.begin_policy_transition_group(destination, peer, export_policy) {
-            super::update_groups::PolicyTransitionGroupStart::Maintained => {
-                let _ = reply.send(Ok(()));
+        let completed = self.with_replacement_readiness(|manager| {
+            let Some((_, destination)) =
+                manager.clean_policy_transition_destination(peer, export_policy)
+            else {
+                manager.reclaim_unused_update_group_policies();
+                return Some((
+                    reply,
+                    Err(
+                        "peer/policy pair does not classify as a clean grouped transition"
+                            .to_string(),
+                    ),
+                ));
+            };
+            // A stale completed preparation that was never consumed (its
+            // cohort never arrived) is discarded before a new one begins;
+            // the record must only ever name the latest staged group.
+            if let Some(stale) = manager.prepared_destination.take() {
+                let _ = manager.discard_uncommitted_policy_transition_group(stale);
             }
-            super::update_groups::PolicyTransitionGroupStart::Created(prefixes) => {
-                self.pending_destination_prestage = Some(DestinationPrestage {
-                    destination,
-                    prefixes,
-                    cursor: 0,
-                    memo: ExportMemo::default(),
-                    reply: Some(reply),
-                });
-            }
+            // A leftover unowned group under this id may be partially staged
+            // from an aborted attempt; recreate it deterministically. An OWNED
+            // group is maintained by definition — nothing to stage.
+            let _ = manager.discard_uncommitted_policy_transition_group(destination);
+            let completed =
+                match manager.begin_policy_transition_group(destination, peer, export_policy) {
+                    super::update_groups::PolicyTransitionGroupStart::Maintained => {
+                        Some((reply, Ok(())))
+                    }
+                    super::update_groups::PolicyTransitionGroupStart::Created(prefixes) => {
+                        manager.pending_destination_prestage = Some(DestinationPrestage {
+                            destination,
+                            prefixes,
+                            cursor: 0,
+                            memo: ExportMemo::default(),
+                            reply: Some(reply),
+                        });
+                        None
+                    }
+                };
+            manager.reclaim_unused_update_group_policies();
+            completed
+        });
+        if let Some((reply, result)) = completed {
+            let _ = reply.send(result);
         }
-        self.reclaim_unused_update_group_policies();
     }
 
     /// Discard a mid-walk destination prestage that a membership event is
@@ -4051,14 +4772,22 @@ impl RibManager {
     /// the prestage costs only the optimization; the held prepare reply
     /// resolves `Err` so the transition stages under its fence instead.
     pub(super) fn discard_destination_prestage_on_membership(&mut self, gid: usize) {
-        let Some(prestage) = self
+        let Some(mut prestage) = self
             .pending_destination_prestage
             .take_if(|prestage| prestage.destination == gid)
         else {
             return;
         };
-        let _ = self.discard_uncommitted_policy_transition_group(gid);
-        if let Some(reply) = prestage.reply {
+        let reply = self.with_replacement_readiness(|manager| {
+            let _ = manager.discard_uncommitted_policy_transition_group(gid);
+            manager.replacement_checkpoint(true);
+            #[cfg(feature = "bench-internals")]
+            prestage.memo.record_replacement_capacities(manager);
+            prestage.retire_with(&mut || manager.replacement_checkpoint(false));
+            manager.replacement_checkpoint(true);
+            prestage.reply.take()
+        });
+        if let Some(reply) = reply {
             let _ = reply.send(Err(
                 "prepared destination group adopted by a membership change; preparation discarded"
                     .to_string(),
@@ -4076,43 +4805,53 @@ impl RibManager {
     /// slices — and that same churn keeps already-staged prefixes current
     /// through the ordinary all-groups staging pass.
     pub(super) fn advance_destination_prestage(&mut self) {
-        let Some(mut prestage) = self.pending_destination_prestage.take() else {
-            return;
-        };
-        let poll_start = std::time::Instant::now();
-        loop {
-            let end = super::policy_transition_slice_end(
-                prestage.cursor,
-                prestage.prefixes.len(),
-                super::POLICY_TRANSITION_ROUTE_SLICE,
-            );
-            if prestage.cursor < end {
-                self.stage_policy_transition_group_chunk(
-                    prestage.destination,
-                    &prestage.prefixes[prestage.cursor..end],
-                    &mut prestage.memo,
+        let reply = self.with_replacement_readiness(|manager| {
+            let readiness = manager.replacement_readiness.clone();
+            let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+            checkpoint();
+
+            let mut prestage = manager.pending_destination_prestage.take()?;
+            let poll_start = std::time::Instant::now();
+            loop {
+                checkpoint();
+                let end = super::policy_transition_slice_end(
+                    prestage.cursor,
+                    prestage.prefixes.len(),
+                    super::POLICY_TRANSITION_ROUTE_SLICE,
                 );
-                prestage.cursor = end;
-            }
-            if prestage.cursor == prestage.prefixes.len() {
-                debug!(
-                    destination = prestage.destination,
-                    prefixes = prestage.prefixes.len(),
-                    "prepared clean-transition destination group without the fence"
-                );
-                // Record the exact staged gid: every later discard (and the
-                // committing cohort's adopt-or-discard decision) keys off
-                // this, never a re-derivation from current attributes.
-                self.prepared_destination = Some(prestage.destination);
-                if let Some(reply) = prestage.reply.take() {
-                    let _ = reply.send(Ok(()));
+                if prestage.cursor < end {
+                    manager.stage_policy_transition_group_chunk(
+                        prestage.destination,
+                        &prestage.prefixes[prestage.cursor..end],
+                        &mut prestage.memo,
+                    );
+                    prestage.cursor = end;
                 }
-                return;
+                if prestage.cursor == prestage.prefixes.len() {
+                    debug!(
+                        destination = prestage.destination,
+                        prefixes = prestage.prefixes.len(),
+                        "prepared clean-transition destination group without the fence"
+                    );
+                    // Record the exact staged gid: every later discard (and the
+                    // committing cohort's adopt-or-discard decision) keys off
+                    // this, never a re-derivation from current attributes.
+                    manager.prepared_destination = Some(prestage.destination);
+                    manager.replacement_checkpoint(true);
+                    #[cfg(feature = "bench-internals")]
+                    prestage.memo.record_replacement_capacities(manager);
+                    prestage.retire_with(&mut || checkpoint());
+                    manager.replacement_checkpoint(true);
+                    return prestage.reply.take();
+                }
+                if poll_start.elapsed() >= manager.flush_poll_budget {
+                    manager.pending_destination_prestage = Some(prestage);
+                    return None;
+                }
             }
-            if poll_start.elapsed() >= self.flush_poll_budget {
-                self.pending_destination_prestage = Some(prestage);
-                return;
-            }
+        });
+        if let Some(reply) = reply {
+            let _ = reply.send(Ok(()));
         }
     }
 
@@ -4124,13 +4863,27 @@ impl RibManager {
     /// leak the staged group. Only a memberless group is removed; an
     /// adopted destination has members and stays.
     pub(super) fn discard_prepared_export_destination(&mut self) {
-        if let Some(prestage) = self.pending_destination_prestage.take() {
-            let _ = self.discard_uncommitted_policy_transition_group(prestage.destination);
-        }
-        if let Some(prepared) = self.prepared_destination.take() {
-            let _ = self.discard_uncommitted_policy_transition_group(prepared);
-        }
-        self.reclaim_unused_update_group_policies();
+        let reply = self.with_replacement_readiness(|manager| {
+            let reply = manager
+                .pending_destination_prestage
+                .take()
+                .and_then(|mut prestage| {
+                    let _ =
+                        manager.discard_uncommitted_policy_transition_group(prestage.destination);
+                    manager.replacement_checkpoint(true);
+                    #[cfg(feature = "bench-internals")]
+                    prestage.memo.record_replacement_capacities(manager);
+                    prestage.retire_with(&mut || manager.replacement_checkpoint(false));
+                    manager.replacement_checkpoint(true);
+                    prestage.reply.take()
+                });
+            if let Some(prepared) = manager.prepared_destination.take() {
+                let _ = manager.discard_uncommitted_policy_transition_group(prepared);
+            }
+            manager.reclaim_unused_update_group_policies();
+            reply
+        });
+        drop(reply);
     }
 
     /// Force re-emission of all currently-advertised routes to a peer
@@ -4797,15 +5550,21 @@ impl RibManager {
         service_ingest_readiness: bool,
         advertised_generation_already_advanced: bool,
     ) {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
+
         self.record_deferred_unicast(best_changed);
         self.record_deferred_unicast(all_affected);
         let best_changed: HashSet<_> = best_changed
             .iter()
+            .inspect(|_| checkpoint())
             .filter(|prefix| !self.selection_deferred(prefix_family(prefix)))
             .copied()
             .collect();
         let all_affected: HashSet<_> = all_affected
             .iter()
+            .inspect(|_| checkpoint())
             .filter(|prefix| !self.selection_deferred(prefix_family(prefix)))
             .copied()
             .collect();
@@ -4838,7 +5597,8 @@ impl RibManager {
         // per-client-best groups stage the widened all-affected union
         // (their winner walk reads the candidate list, not the Loc-RIB
         // best).
-        let group_stage = self.stage_update_groups(&best_changed, &all_affected, &mut export_memo);
+        let mut group_stage =
+            self.stage_update_groups(&best_changed, &all_affected, &mut export_memo);
         let mut shared_unicast_probe_cache = SharedUnicastProbeCache::default();
         let mut shared_group_encodes: HashMap<usize, Arc<crate::update::SharedGroupEncode>> =
             HashMap::new();
@@ -4854,6 +5614,7 @@ impl RibManager {
             &mut self.adj_rib_out_commit_stats,
         );
         for peer in peers {
+            checkpoint();
             // Cold ingest is the path that requires in-pass readiness:
             // service the dedicated, read-only lane at each peer boundary
             // without admitting general queries or mutations. Keep the
@@ -4895,18 +5656,70 @@ impl RibManager {
             #[cfg(feature = "bench-internals")]
             let bench_enumeration_started =
                 bench_per_client_best_resync.then(std::time::Instant::now);
-            let effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
-                let mut all: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
+            let mut effective_prefixes: Cow<'_, HashSet<Prefix>> = if resync {
+                let mut capacity = self.loc_rib.len();
+                if let Some(gid) = member_of {
+                    if let Some(group) = self.group_ribs.get(&gid) {
+                        capacity += group.table.len() + group.tombstones.len();
+                    }
+                    capacity += self
+                        .pending_regroup_baseline
+                        .get(&peer)
+                        .map_or(0, |base| base.unicast.len());
+                } else {
+                    if self.peer_has_any_add_path_send(peer)
+                        || self.peer_per_client_best.contains(&peer)
+                    {
+                        capacity += self
+                            .ribs
+                            .values()
+                            .inspect(|_| checkpoint())
+                            .map(AdjRibIn::len)
+                            .sum::<usize>();
+                    }
+                    capacity += self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::len);
+                }
+                capacity += self
+                    .pending_extra_withdraws
+                    .get(&peer)
+                    .map_or(0, |extra| extra.unicast.len());
+                capacity += self.peer_otc_blocked.get(&peer).map_or(0, HashMap::len);
+                self.replacement_checkpoint(true);
+                let mut all = HashSet::with_capacity(capacity);
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .map(|r| r.prefix),
+                );
                 if let Some(gid) = member_of {
                     // A grouped member's advertised state is the group
                     // table (plus any pending withdraw residue); the
                     // per-peer Adj-RIB-Out holds no unicast for it.
                     if let Some(group) = self.group_ribs.get(&gid) {
-                        all.extend(group.table.iter().map(|r| r.prefix));
-                        all.extend(group.tombstones.iter().map(|(p, _)| *p));
+                        all.extend(
+                            group
+                                .table
+                                .iter()
+                                .inspect(|_| checkpoint())
+                                .map(|r| r.prefix),
+                        );
+                        all.extend(
+                            group
+                                .tombstones
+                                .iter()
+                                .inspect(|_| checkpoint())
+                                .map(|(p, _)| *p),
+                        );
                     }
                     if let Some(base) = self.pending_regroup_baseline.get(&peer) {
-                        all.extend(base.unicast.keys().map(|(p, _)| *p));
+                        all.extend(
+                            base.unicast
+                                .keys()
+                                .inspect(|_| checkpoint())
+                                .map(|(p, _)| *p),
+                        );
                     }
                 } else {
                     // For multi-path (and per-client-best — same
@@ -4916,11 +5729,12 @@ impl RibManager {
                         || self.peer_per_client_best.contains(&peer)
                     {
                         for rib in self.ribs.values() {
-                            all.extend(rib.iter().map(|r| r.prefix));
+                            checkpoint();
+                            all.extend(rib.iter().inspect(|_| checkpoint()).map(|r| r.prefix));
                         }
                     }
                     if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                        all.extend(rib_out.iter().map(|r| r.prefix));
+                        all.extend(rib_out.iter().inspect(|_| checkpoint()).map(|r| r.prefix));
                     }
                 }
                 // Extra (over-)withdraw residue keys can be in NONE of
@@ -4929,12 +5743,21 @@ impl RibManager {
                 // a resync can enumerate empty — or skip the keys
                 // entirely — and the owed withdraws are never emitted.
                 if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
-                    all.extend(extras.unicast.iter().map(|(prefix, _)| *prefix));
+                    all.extend(
+                        extras
+                            .unicast
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(|(prefix, _)| *prefix),
+                    );
                 }
                 if let Some(blocked) = self.peer_otc_blocked.get(&peer) {
-                    all.extend(blocked.keys().copied());
+                    all.extend(blocked.keys().inspect(|_| checkpoint()).copied());
                 }
-                all.retain(|prefix| !self.selection_deferred(prefix_family(prefix)));
+                all.retain(|prefix| {
+                    checkpoint();
+                    !self.selection_deferred(prefix_family(prefix))
+                });
                 Cow::Owned(all)
             } else if let Some(gid) = member_of {
                 // Grouped peers have no ORR / Add-Path extras (both are
@@ -4950,8 +5773,10 @@ impl RibManager {
                     .get(&gid)
                     .is_some_and(|group| group.per_client_best);
                 if group_per_client_best && !all_affected.is_empty() {
-                    let mut prefixes = best_changed.clone();
-                    prefixes.extend(all_affected.iter().copied());
+                    let mut prefixes =
+                        HashSet::with_capacity(best_changed.len() + all_affected.len());
+                    prefixes.extend(best_changed.iter().inspect(|_| checkpoint()).copied());
+                    prefixes.extend(all_affected.iter().inspect(|_| checkpoint()).copied());
                     Cow::Owned(prefixes)
                 } else {
                     Cow::Borrowed(&best_changed)
@@ -4979,6 +5804,7 @@ impl RibManager {
                 } else {
                     let extras: Vec<Prefix> = all_affected
                         .iter()
+                        .inspect(|_| checkpoint())
                         .filter(|prefix| {
                             #[cfg(any(test, feature = "bench-internals"))]
                             {
@@ -5001,58 +5827,103 @@ impl RibManager {
                     if extras.is_empty() {
                         Cow::Borrowed(&best_changed)
                     } else {
-                        let mut prefixes = best_changed.clone();
-                        prefixes.extend(extras);
+                        let mut prefixes =
+                            HashSet::with_capacity(best_changed.len() + all_affected.len());
+                        prefixes.extend(best_changed.iter().inspect(|_| checkpoint()).copied());
+                        let mut extras = extras;
+                        prefixes.extend(extras.drain(..).inspect(|_| checkpoint()));
+                        super::retire_vec(&mut extras, &mut || checkpoint());
                         Cow::Owned(prefixes)
                     }
                 }
             };
-            let effective_flowspec_rules: HashSet<crate::route::FlowSpecKey> = if resync {
-                let mut all: HashSet<crate::route::FlowSpecKey> = self
-                    .loc_rib
-                    .iter_flowspec()
-                    .map(crate::route::FlowSpecRoute::selection_key)
-                    .collect();
+            let mut effective_flowspec_rules: HashSet<crate::route::FlowSpecKey> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<crate::route::FlowSpecKey> = HashSet::with_capacity(
+                    self.loc_rib.flowspec_len()
+                        + self
+                            .adj_ribs_out
+                            .get(&peer)
+                            .map_or(0, AdjRibOut::flowspec_len),
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_flowspec()
+                        .inspect(|_| checkpoint())
+                        .map(crate::route::FlowSpecRoute::selection_key),
+                );
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
                     all.extend(
                         rib_out
                             .iter_flowspec()
+                            .inspect(|_| checkpoint())
                             .map(crate::route::FlowSpecRoute::selection_key),
                     );
                 }
-                all.retain(|key| !self.selection_deferred((key.afi, Safi::FlowSpec)));
+                all.retain(|key| {
+                    checkpoint();
+                    !self.selection_deferred((key.afi, Safi::FlowSpec))
+                });
                 all
             } else {
                 HashSet::new()
             };
 
-            let effective_evpn_keys: HashSet<rustbgpd_wire::EvpnRouteKey> = if resync {
-                let mut all: HashSet<rustbgpd_wire::EvpnRouteKey> = self
-                    .loc_rib
-                    .iter_evpn()
-                    .map(crate::route::EvpnRibRoute::key)
-                    .collect();
+            let mut effective_evpn_keys: HashSet<rustbgpd_wire::EvpnRouteKey> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<rustbgpd_wire::EvpnRouteKey> = HashSet::with_capacity(
+                    self.loc_rib.evpn_len()
+                        + self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::evpn_len),
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_evpn()
+                        .inspect(|_| checkpoint())
+                        .map(crate::route::EvpnRibRoute::key),
+                );
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_evpn().map(crate::route::EvpnRibRoute::key));
+                    all.extend(
+                        rib_out
+                            .iter_evpn()
+                            .inspect(|_| checkpoint())
+                            .map(crate::route::EvpnRibRoute::key),
+                    );
                 }
                 if self.selection_deferred((Afi::L2Vpn, Safi::Evpn)) {
-                    all.clear();
+                    super::retire_hash_set(&mut all, &mut || checkpoint());
                 }
                 all
             } else {
                 HashSet::new()
             };
 
-            let effective_bgpls_keys: HashSet<crate::route::BgpLsRouteKey> = if resync {
-                let mut all: HashSet<crate::route::BgpLsRouteKey> = self
-                    .loc_rib
-                    .iter_bgpls()
-                    .map(crate::route::BgpLsRibRoute::key)
-                    .collect();
+            let mut effective_bgpls_keys: HashSet<crate::route::BgpLsRouteKey> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<crate::route::BgpLsRouteKey> = HashSet::with_capacity(
+                    self.loc_rib.bgpls_len()
+                        + self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::bgpls_len),
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_bgpls()
+                        .inspect(|_| checkpoint())
+                        .map(crate::route::BgpLsRibRoute::key),
+                );
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_bgpls().map(crate::route::BgpLsRibRoute::key));
+                    all.extend(
+                        rib_out
+                            .iter_bgpls()
+                            .inspect(|_| checkpoint())
+                            .map(crate::route::BgpLsRibRoute::key),
+                    );
                 }
-                all.retain(|key| !self.selection_deferred(key.family.to_afi_safi()));
+                all.retain(|key| {
+                    checkpoint();
+                    !self.selection_deferred(key.family.to_afi_safi())
+                });
                 all
             } else {
                 HashSet::new()
@@ -5065,37 +5936,90 @@ impl RibManager {
             // above. (RTC members' Φ is applied by the resync assembly,
             // not the enumeration — over-enumeration is harmless.)
             let vpn_grouped = self.vpn_grouped_member_of(peer);
-            let effective_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = if resync {
-                let mut all: HashSet<rustbgpd_wire::VpnRouteKey> = self
-                    .loc_rib
-                    .iter_vpn()
-                    .map(|route| route.nlri.key())
-                    .collect();
+            let mut effective_l3vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<rustbgpd_wire::VpnRouteKey> = HashSet::with_capacity(
+                    self.loc_rib.vpn_len()
+                        + self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::vpn_len)
+                        + self
+                            .group_ribs
+                            .get(&vpn_grouped.unwrap_or(usize::MAX))
+                            .map_or(0, |group| {
+                                group.table.vpn_len() + group.vpn_tombstones.len()
+                            })
+                        + self
+                            .pending_regroup_baseline
+                            .get(&peer)
+                            .map_or(0, |base| base.vpn.len())
+                        + self
+                            .pending_extra_withdraws
+                            .get(&peer)
+                            .map_or(0, |extra| extra.vpn.len())
+                        + if self.peer_vpn_add_path_send(peer) {
+                            self.ribs
+                                .values()
+                                .inspect(|_| checkpoint())
+                                .map(AdjRibIn::vpn_len)
+                                .sum::<usize>()
+                        } else {
+                            0
+                        },
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_vpn()
+                        .inspect(|_| checkpoint())
+                        .map(|route| route.nlri.key()),
+                );
                 if let Some(gid) = vpn_grouped {
                     if let Some(group) = self.group_ribs.get(&gid) {
-                        all.extend(group.table.iter_vpn().map(|route| route.nlri.key()));
-                        all.extend(group.vpn_tombstones.iter().copied());
+                        all.extend(
+                            group
+                                .table
+                                .iter_vpn()
+                                .inspect(|_| checkpoint())
+                                .map(|route| route.nlri.key()),
+                        );
+                        all.extend(
+                            group
+                                .vpn_tombstones
+                                .iter()
+                                .inspect(|_| checkpoint())
+                                .copied(),
+                        );
                     }
                     if let Some(base) = self.pending_regroup_baseline.get(&peer) {
-                        all.extend(base.vpn.keys().copied());
+                        all.extend(base.vpn.keys().inspect(|_| checkpoint()).copied());
                     }
                 } else {
                     // For a VPN Add-Path-send resync, the staged top-N draws from
                     // every Adj-RIB-In identity, not just the Loc-RIB bests.
                     if self.peer_vpn_add_path_send(peer) {
                         for rib in self.ribs.values() {
-                            all.extend(rib.iter_vpn().map(|route| route.nlri.key()));
+                            checkpoint();
+                            all.extend(
+                                rib.iter_vpn()
+                                    .inspect(|_| checkpoint())
+                                    .map(|route| route.nlri.key()),
+                            );
                         }
                     }
                     if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                        all.extend(rib_out.iter_vpn().map(|route| route.nlri.key()));
+                        all.extend(
+                            rib_out
+                                .iter_vpn()
+                                .inspect(|_| checkpoint())
+                                .map(|route| route.nlri.key()),
+                        );
                     }
                 }
                 // Same residue rule as the unicast enumeration above.
                 if let Some(extras) = self.pending_extra_withdraws.get(&peer) {
-                    all.extend(extras.vpn.iter().copied());
+                    all.extend(extras.vpn.iter().inspect(|_| checkpoint()).copied());
                 }
                 all.retain(|key| {
+                    checkpoint();
                     let family = match key.prefix.family() {
                         rustbgpd_wire::VpnAddressFamily::V4 => (Afi::Ipv4, Safi::MplsVpn),
                         rustbgpd_wire::VpnAddressFamily::V6 => (Afi::Ipv6, Safi::MplsVpn),
@@ -5107,23 +6031,53 @@ impl RibManager {
                 HashSet::new()
             };
 
-            let effective_labeled_keys: HashSet<Prefix> = if resync {
-                let mut all: HashSet<Prefix> = self
-                    .loc_rib
-                    .iter_labeled()
-                    .map(|route| route.nlri.key())
-                    .collect();
+            let mut effective_labeled_keys: HashSet<Prefix> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<Prefix> = HashSet::with_capacity(
+                    self.loc_rib.labeled_len()
+                        + self
+                            .adj_ribs_out
+                            .get(&peer)
+                            .map_or(0, AdjRibOut::labeled_len)
+                        + if self.peer_labeled_add_path_send(peer) {
+                            self.ribs
+                                .values()
+                                .inspect(|_| checkpoint())
+                                .map(AdjRibIn::labeled_len)
+                                .sum::<usize>()
+                        } else {
+                            0
+                        },
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_labeled()
+                        .inspect(|_| checkpoint())
+                        .map(|route| route.nlri.key()),
+                );
                 // For a labeled Add-Path-send resync, the staged top-N draws
                 // from every Adj-RIB-In identity, not just the Loc-RIB bests.
                 if self.peer_labeled_add_path_send(peer) {
                     for rib in self.ribs.values() {
-                        all.extend(rib.iter_labeled().map(|route| route.nlri.key()));
+                        checkpoint();
+                        all.extend(
+                            rib.iter_labeled()
+                                .inspect(|_| checkpoint())
+                                .map(|route| route.nlri.key()),
+                        );
                     }
                 }
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_labeled().map(|route| route.nlri.key()));
+                    all.extend(
+                        rib_out
+                            .iter_labeled()
+                            .inspect(|_| checkpoint())
+                            .map(|route| route.nlri.key()),
+                    );
                 }
                 all.retain(|prefix| {
+                    checkpoint();
                     let afi = match prefix {
                         Prefix::V4(_) => Afi::Ipv4,
                         Prefix::V6(_) => Afi::Ipv6,
@@ -5135,17 +6089,29 @@ impl RibManager {
                 HashSet::new()
             };
 
-            let effective_rtc_keys: HashSet<crate::route::RtcRibRouteKey> = if resync {
-                let mut all: HashSet<crate::route::RtcRibRouteKey> = self
-                    .loc_rib
-                    .iter_rtc()
-                    .map(crate::route::RtcRibRoute::key)
-                    .collect();
+            let mut effective_rtc_keys: HashSet<crate::route::RtcRibRouteKey> = if resync {
+                self.replacement_checkpoint(true);
+                let mut all: HashSet<crate::route::RtcRibRouteKey> = HashSet::with_capacity(
+                    self.loc_rib.rtc_len()
+                        + self.adj_ribs_out.get(&peer).map_or(0, AdjRibOut::rtc_len),
+                );
+                self.replacement_checkpoint(true);
+                all.extend(
+                    self.loc_rib
+                        .iter_rtc()
+                        .inspect(|_| checkpoint())
+                        .map(crate::route::RtcRibRoute::key),
+                );
                 if let Some(rib_out) = self.adj_ribs_out.get(&peer) {
-                    all.extend(rib_out.iter_rtc().map(crate::route::RtcRibRoute::key));
+                    all.extend(
+                        rib_out
+                            .iter_rtc()
+                            .inspect(|_| checkpoint())
+                            .map(crate::route::RtcRibRoute::key),
+                    );
                 }
                 if self.selection_deferred(crate::route::RtcRibRouteKey::afi_safi()) {
-                    all.clear();
+                    super::retire_hash_set(&mut all, &mut || checkpoint());
                 }
                 all
             } else {
@@ -5159,6 +6125,43 @@ impl RibManager {
                 );
             }
 
+            if let Cow::Owned(prefixes) = &effective_prefixes {
+                self.replacement_capacity(
+                    "effective_prefixes",
+                    prefixes.len(),
+                    prefixes.capacity(),
+                );
+            }
+            self.replacement_capacity(
+                "effective_flowspec",
+                effective_flowspec_rules.len(),
+                effective_flowspec_rules.capacity(),
+            );
+            self.replacement_capacity(
+                "effective_evpn",
+                effective_evpn_keys.len(),
+                effective_evpn_keys.capacity(),
+            );
+            self.replacement_capacity(
+                "effective_bgpls",
+                effective_bgpls_keys.len(),
+                effective_bgpls_keys.capacity(),
+            );
+            self.replacement_capacity(
+                "effective_vpn",
+                effective_l3vpn_keys.len(),
+                effective_l3vpn_keys.capacity(),
+            );
+            self.replacement_capacity(
+                "effective_labeled",
+                effective_labeled_keys.len(),
+                effective_labeled_keys.capacity(),
+            );
+            self.replacement_capacity(
+                "effective_rtc",
+                effective_rtc_keys.len(),
+                effective_rtc_keys.capacity(),
+            );
             if effective_prefixes.is_empty()
                 && effective_flowspec_rules.is_empty()
                 && effective_evpn_keys.is_empty()
@@ -5192,12 +6195,28 @@ impl RibManager {
                 if is_force {
                     self.force_outbound_peers.remove(&peer);
                 }
+                super::retire_hash_set(&mut effective_flowspec_rules, &mut || checkpoint());
+                super::retire_hash_set(&mut effective_evpn_keys, &mut || checkpoint());
+                super::retire_hash_set(&mut effective_bgpls_keys, &mut || checkpoint());
+                super::retire_hash_set(&mut effective_l3vpn_keys, &mut || checkpoint());
+                super::retire_hash_set(&mut effective_labeled_keys, &mut || checkpoint());
+                super::retire_hash_set(&mut effective_rtc_keys, &mut || checkpoint());
+                if let Cow::Owned(prefixes) = &mut effective_prefixes {
+                    super::retire_hash_set(prefixes, &mut || checkpoint());
+                }
+                self.replacement_checkpoint(true);
                 continue;
             }
 
             #[cfg(feature = "bench-internals")]
             let bench_staging_started = bench_per_client_best_resync.then(std::time::Instant::now);
             let mut unicast = UnicastDistributionResult::default();
+            if member_of.is_none() || resync {
+                unicast.announce.reserve(effective_prefixes.len());
+                unicast.next_hop_override.reserve(effective_prefixes.len());
+                unicast.withdraw.reserve(effective_prefixes.len());
+            }
+            self.replacement_checkpoint(true);
             // Set for an in-sync grouped member covered by the group's
             // pre-built shared emission: the announce payload is an Arc
             // clone shared across members, not a per-member Vec build.
@@ -5219,7 +6238,7 @@ impl RibManager {
             let mut rtc_withdraw = Vec::new();
             let mut group_otc_blocked = Vec::new();
             let mut current_policy_filtered_routes: HashSet<PolicyFilteredRouteKey> =
-                HashSet::new();
+                HashSet::with_capacity(effective_prefixes.len());
 
             // Grouped member: the unicast portion comes from the group —
             // source-flip matrix over this pass's deltas for a clean
@@ -5290,9 +6309,9 @@ impl RibManager {
                         // — then its announce/withdraw set can diverge
                         // per target and it walks the matrix itself.
                         let rs_diverges = rs_control.is_some_and(|(rs_asn, _)| {
-                            *rs_tagged_pass
-                                .entry((gid, rs_asn))
-                                .or_insert_with(|| stage.has_tagged_route(rs_asn))
+                            *rs_tagged_pass.entry((gid, rs_asn)).or_insert_with(|| {
+                                stage.has_tagged_route_with_checkpoint(rs_asn, &mut || checkpoint())
+                            })
                         });
                         let shared_exact = stage.shared_applies_to(peer);
                         let shared_with_source_exclusion = !shared_exact
@@ -5313,13 +6332,14 @@ impl RibManager {
                                 )));
                             unicast.withdraw.extend_from_slice(&stage.shared_withdraw);
                         } else {
-                            super::update_groups::emit_group_deltas_for_member(
+                            super::update_groups::emit_group_deltas_for_member_with_checkpoint(
                                 &stage.deltas,
                                 peer,
                                 rs_control,
                                 &mut unicast.announce,
                                 &mut unicast.withdraw,
                                 &mut unicast.next_hop_override,
+                                &mut || checkpoint(),
                             );
                             // ADR-0126 Decision 5 lane arm: a
                             // member-scoped emission toward the ONE
@@ -5327,28 +6347,39 @@ impl RibManager {
                             // (`source(w)`); a no-op for everyone
                             // else and for plain groups (no lane
                             // deltas exist).
-                            super::update_groups::emit_lane_deltas_for_member(
+                            super::update_groups::emit_lane_deltas_for_member_with_checkpoint(
                                 &stage.lane_deltas,
                                 peer,
                                 rs_control,
                                 &mut unicast.announce,
                                 &mut unicast.withdraw,
                                 &mut unicast.next_hop_override,
+                                &mut || checkpoint(),
                             );
-                            super::update_groups::emit_rs_tag_transitions(
+                            super::update_groups::emit_rs_tag_transitions_with_checkpoint(
                                 &stage.rs_transitions,
                                 peer,
                                 rs_control,
                                 &mut unicast.announce,
                                 &mut unicast.withdraw,
                                 &mut unicast.next_hop_override,
+                                &mut || checkpoint(),
                             );
                         }
                     }
+                    let mut filtered = group.policy_filtered_for_member_with_checkpoint(
+                        peer,
+                        &effective_prefixes,
+                        &mut || checkpoint(),
+                    );
+                    current_policy_filtered_routes.reserve(filtered.len());
                     current_policy_filtered_routes
-                        .extend(group.policy_filtered_for_member(peer, &effective_prefixes));
+                        .extend(filtered.drain(..).inspect(|_| checkpoint()));
+                    super::retire_vec(&mut filtered, &mut || checkpoint());
                     group_otc_blocked = if resync {
-                        group.otc_blocked_for_member(peer, None)
+                        group.otc_blocked_for_member_with_checkpoint(peer, None, &mut || {
+                            checkpoint();
+                        })
                     } else if group.per_client_best {
                         // The staging pass just refreshed the residue for
                         // exactly its staged prefixes, and the residue
@@ -5356,12 +6387,17 @@ impl RibManager {
                         // `source(w)` — the per-member outcome of the
                         // pre-commit backstop (ADR-0126), which the flat
                         // pass vector below cannot express.
-                        group.otc_blocked_for_member(peer, Some(&effective_prefixes))
+                        group.otc_blocked_for_member_with_checkpoint(
+                            peer,
+                            Some(&effective_prefixes),
+                            &mut || checkpoint(),
+                        )
                     } else {
                         group_stage
                             .get(&gid)
                             .into_iter()
-                            .flat_map(|stage| stage.otc_blocked.iter())
+                            .inspect(|_| checkpoint())
+                            .flat_map(|stage| stage.otc_blocked.iter().inspect(|_| checkpoint()))
                             .filter(|route| route.peer != peer)
                             .cloned()
                             .collect()
@@ -5449,6 +6485,7 @@ impl RibManager {
                 &empty_prefixes
             };
             for prefix in staging_prefixes {
+                checkpoint();
                 let family = prefix_family(prefix);
                 // RFC 5291 §6 gate: suppress this family's advertisement (incl.
                 // ongoing churn) until the peer's first ROUTE-REFRESH lifts it.
@@ -5466,7 +6503,7 @@ impl RibManager {
                 };
                 if prefix_send_max > 0 {
                     // Multi-path: collect all candidates, filter, sort, diff
-                    Self::distribute_multipath_prefix(
+                    Self::distribute_multipath_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         rib_out,
@@ -5493,9 +6530,10 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         is_force,
+                        &mut || checkpoint(),
                     );
                     current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
+                        .extend(unicast.policy_filtered.drain(..).inspect(|_| checkpoint()));
                 } else if per_client_best {
                     // RFC 7947 §2.3.2 per-client best-path: the first
                     // export-policy-permitted candidate from the
@@ -5507,7 +6545,7 @@ impl RibManager {
                     // while per_client_best requires an eBGP
                     // route-server client (validation-enforced).
                     debug_assert!(orr_ctx.is_none(), "ORR vantage on a per-client-best peer");
-                    Self::distribute_multipath_prefix(
+                    Self::distribute_multipath_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         rib_out,
@@ -5534,12 +6572,13 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         is_force,
+                        &mut || checkpoint(),
                     );
                     current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
+                        .extend(unicast.policy_filtered.drain(..).inspect(|_| checkpoint()));
                 } else if let Some((orr_topology, orr_spf)) = orr_ctx {
                     // ORR peer with a resolved vantage: per-vantage best.
-                    Self::distribute_orr_best_prefix(
+                    Self::distribute_orr_best_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         rib_out,
@@ -5564,9 +6603,10 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         is_force,
+                        &mut || checkpoint(),
                     );
                     current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
+                        .extend(unicast.policy_filtered.drain(..).inspect(|_| checkpoint()));
                 } else {
                     let mut target = ExportTarget::Peer {
                         peer,
@@ -5576,7 +6616,7 @@ impl RibManager {
                         policy_stats: &mut *policy_stats,
                         peer_label: &target_peer_label,
                     };
-                    Self::distribute_single_best_prefix(
+                    Self::distribute_single_best_prefix_with_checkpoint(
                         loc_rib,
                         rib_out,
                         &self.peer_is_rr_client,
@@ -5594,14 +6634,15 @@ impl RibManager {
                         &mut export_memo,
                         &mut unicast,
                         is_force,
+                        &mut || checkpoint(),
                     );
                     current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
+                        .extend(unicast.policy_filtered.drain(..).inspect(|_| checkpoint()));
                 }
             }
 
             if resync && !effective_flowspec_rules.is_empty() {
-                Self::stage_flowspec_rules(
+                Self::stage_flowspec_rules_with_checkpoint(
                     loc_rib,
                     rib_out,
                     &self.peer_is_rr_client,
@@ -5621,11 +6662,12 @@ impl RibManager {
                     &target_peer_label,
                     &mut fs_announce,
                     &mut fs_withdraw,
+                    &mut || checkpoint(),
                 );
             }
 
             if resync && !effective_evpn_keys.is_empty() {
-                Self::stage_evpn_routes(
+                Self::stage_evpn_routes_with_checkpoint(
                     loc_rib,
                     rib_out,
                     &self.peer_is_rr_client,
@@ -5648,11 +6690,12 @@ impl RibManager {
                     &mut evpn_announce,
                     &mut evpn_withdraw,
                     is_force,
+                    &mut || checkpoint(),
                 );
             }
 
             if resync && !effective_bgpls_keys.is_empty() {
-                Self::stage_bgpls_routes(
+                Self::stage_bgpls_routes_with_checkpoint(
                     loc_rib,
                     rib_out,
                     &self.peer_is_rr_client,
@@ -5673,6 +6716,7 @@ impl RibManager {
                     &mut bgpls_announce,
                     &mut bgpls_withdraw,
                     is_force,
+                    &mut || checkpoint(),
                 );
             }
 
@@ -5707,13 +6751,14 @@ impl RibManager {
                     policy_stats: &mut *policy_stats,
                     peer_label: &target_peer_label,
                 };
-                Self::stage_vpn_routes(
+                Self::stage_vpn_routes_with_checkpoint(
                     &vpn_labeled_context,
                     &effective_l3vpn_keys,
                     &mut target,
                     rtc_filter.as_ref(),
                     &mut vpn_announce,
                     &mut vpn_withdraw,
+                    &mut || checkpoint(),
                 );
             }
 
@@ -5726,17 +6771,18 @@ impl RibManager {
                     policy_stats: &mut *policy_stats,
                     peer_label: &target_peer_label,
                 };
-                Self::stage_labeled_routes(
+                Self::stage_labeled_routes_with_checkpoint(
                     &vpn_labeled_context,
                     &effective_labeled_keys,
                     &mut target,
                     &mut labeled_announce,
                     &mut labeled_withdraw,
+                    &mut || checkpoint(),
                 );
             }
 
             if resync && !effective_rtc_keys.is_empty() {
-                Self::stage_rtc_routes(
+                Self::stage_rtc_routes_with_checkpoint(
                     loc_rib,
                     rib_out,
                     &self.peer_is_rr_client,
@@ -5757,6 +6803,7 @@ impl RibManager {
                     &mut rtc_announce,
                     &mut rtc_withdraw,
                     is_force,
+                    &mut || checkpoint(),
                 );
             }
 
@@ -5777,27 +6824,45 @@ impl RibManager {
                 && member_of.is_none()
                 && let Some(extras) = self.pending_extra_withdraws.get(&peer)
             {
-                let announced: HashSet<(Prefix, u32)> = unicast
+                let mut announced: HashSet<(Prefix, u32)> = unicast
                     .announce
                     .iter()
+                    .inspect(|_| checkpoint())
                     .map(|r| (r.prefix, r.path_id))
                     .collect();
-                let staged: HashSet<(Prefix, u32)> = unicast.withdraw.iter().copied().collect();
-                unicast
+                let mut staged: HashSet<(Prefix, u32)> = unicast
                     .withdraw
-                    .extend(extras.unicast.iter().copied().filter(|key| {
-                        !announced.contains(key)
-                            && !staged.contains(key)
-                            && rib_out.get(&key.0, key.1).is_none()
-                    }));
-                let vpn_announced: HashSet<rustbgpd_wire::VpnRouteKey> =
-                    vpn_announce.iter().map(|r| r.nlri.key()).collect();
-                let vpn_staged: HashSet<rustbgpd_wire::VpnRouteKey> =
-                    vpn_withdraw.iter().map(|key| key.nlri_key).collect();
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .copied()
+                    .collect();
+                unicast.withdraw.extend(
+                    extras
+                        .unicast
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .copied()
+                        .filter(|key| {
+                            !announced.contains(key)
+                                && !staged.contains(key)
+                                && rib_out.get(&key.0, key.1).is_none()
+                        }),
+                );
+                let mut vpn_announced: HashSet<rustbgpd_wire::VpnRouteKey> = vpn_announce
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .map(|r| r.nlri.key())
+                    .collect();
+                let mut vpn_staged: HashSet<rustbgpd_wire::VpnRouteKey> = vpn_withdraw
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .map(|key| key.nlri_key)
+                    .collect();
                 vpn_withdraw.extend(
                     extras
                         .vpn
                         .iter()
+                        .inspect(|_| checkpoint())
                         .copied()
                         .filter(|key| {
                             !vpn_announced.contains(key)
@@ -5814,6 +6879,10 @@ impl RibManager {
                             path_id: 0,
                         }),
                 );
+                super::retire_hash_set(&mut announced, &mut || checkpoint());
+                super::retire_hash_set(&mut staged, &mut || checkpoint());
+                super::retire_hash_set(&mut vpn_announced, &mut || checkpoint());
+                super::retire_hash_set(&mut vpn_staged, &mut || checkpoint());
             }
 
             #[cfg(feature = "bench-internals")]
@@ -5832,12 +6901,25 @@ impl RibManager {
                     || (unicast.announce.is_empty() && unicast.next_hop_override.is_empty()),
                 "shared group payload must not coexist with per-peer staged unicast"
             );
+            super::retire_vec(&mut unicast.policy_filtered, &mut || checkpoint());
+            self.replacement_capacity(
+                "private_announce",
+                unicast.announce.len(),
+                unicast.announce.capacity(),
+            );
+            self.replacement_capacity(
+                "private_withdraw",
+                unicast.withdraw.len(),
+                unicast.withdraw.capacity(),
+            );
+            self.replacement_checkpoint(true);
             let shared_unicast_cache_group = shared_unicast.as_ref().and(member_of);
             let (announce, nh_override_flags): super::update_groups::SharedUnicastPayload =
                 match shared_unicast {
                     Some(shared) => shared,
                     None => (unicast.announce.into(), unicast.next_hop_override.into()),
                 };
+            self.replacement_checkpoint(true);
             if !announce.is_empty()
                 || !unicast.withdraw.is_empty()
                 || !fs_announce.is_empty()
@@ -5869,6 +6951,7 @@ impl RibManager {
                         .map(|families| {
                             families
                                 .iter()
+                                .inspect(|_| checkpoint())
                                 .copied()
                                 .filter(|family| !self.selection_convergence_held(*family))
                                 .collect()
@@ -5924,7 +7007,7 @@ impl RibManager {
                         // as possibly replacing an advertised key so an exact
                         // rejection over-withdraws instead of leaking stale
                         // attributes on the peer.
-                        prior.extend(announce.iter().map(|route| {
+                        prior.extend(announce.iter().inspect(|_| checkpoint()).map(|route| {
                             crate::update::ExactExportKey::Unicast(route.prefix, route.path_id)
                         }));
                     } else if is_force {
@@ -5935,30 +7018,36 @@ impl RibManager {
                             // Decision 4): a lane-substituted slot IS
                             // on the wire (same staged key), an
                             // own-sourced slot without one is not.
-                            prior.extend(group.table.iter().filter_map(|route| {
-                                let key = crate::update::ExactExportKey::Unicast(
-                                    route.prefix,
-                                    route.path_id,
-                                );
-                                (group
-                                    .adv_entry(peer, &route.prefix, route.path_id)
-                                    .is_some()
-                                    && !rejected.is_some_and(|keys| keys.contains(&key)))
-                                .then_some(key)
-                            }));
+                            prior.extend(group.table.iter().inspect(|_| checkpoint()).filter_map(
+                                |route| {
+                                    let key = crate::update::ExactExportKey::Unicast(
+                                        route.prefix,
+                                        route.path_id,
+                                    );
+                                    (group
+                                        .adv_entry(peer, &route.prefix, route.path_id)
+                                        .is_some()
+                                        && !rejected.is_some_and(|keys| keys.contains(&key)))
+                                    .then_some(key)
+                                },
+                            ));
                         }
                     } else if !defer_clean_group_prior && let Some(stage) = group_stage.get(&gid) {
                         let rejected = self.peer_unexportable.get(&peer);
-                        prior.extend(stage.deltas.iter().filter_map(|delta| {
-                            let key =
-                                crate::update::ExactExportKey::Unicast(delta.prefix, delta.path_id);
-                            (delta.old_source.is_some_and(|source| source != peer)
-                                && !rejected.is_some_and(|keys| keys.contains(&key)))
-                            .then_some(crate::update::ExactExportKey::Unicast(
-                                delta.prefix,
-                                delta.path_id,
-                            ))
-                        }));
+                        prior.extend(stage.deltas.iter().inspect(|_| checkpoint()).filter_map(
+                            |delta| {
+                                let key = crate::update::ExactExportKey::Unicast(
+                                    delta.prefix,
+                                    delta.path_id,
+                                );
+                                (delta.old_source.is_some_and(|source| source != peer)
+                                    && !rejected.is_some_and(|keys| keys.contains(&key)))
+                                .then_some(crate::update::ExactExportKey::Unicast(
+                                    delta.prefix,
+                                    delta.path_id,
+                                ))
+                            },
+                        ));
                     }
                     if is_dirty || is_force {
                         // Both full-resync shapes replace the member's
@@ -5968,6 +7057,7 @@ impl RibManager {
                         prior.extend(
                             vpn_announce
                                 .iter()
+                                .inspect(|_| checkpoint())
                                 .map(|route| crate::update::ExactExportKey::Vpn(route.key())),
                         );
                     }
@@ -6065,7 +7155,8 @@ impl RibManager {
                         && let Some(stage) = group_stage.get(&gid)
                     {
                         if let Some(group) = self.group_ribs.get_mut(&gid) {
-                            let withdrawn: Vec<(Prefix, u32)> = stage.withdrawn_keys().collect();
+                            let withdrawn: Vec<(Prefix, u32)> =
+                                stage.withdrawn_keys(&checkpoint).collect();
                             group.tombstones.extend(withdrawn);
                         }
                         // A source-flip member-scoped withdraw (this
@@ -6073,7 +7164,7 @@ impl RibManager {
                         // key IN the table — invisible to tombstones.
                         // Ride the member's extra-withdraw residue.
                         let lost: Vec<(Prefix, u32)> =
-                            stage.member_scoped_withdraws(peer).collect();
+                            stage.member_scoped_withdraws(peer, &checkpoint).collect();
                         if !lost.is_empty() {
                             self.pending_extra_withdraws
                                 .entry(peer)
@@ -6085,6 +7176,22 @@ impl RibManager {
                     }
                 }
             } else {
+                super::retire_vec(&mut unicast.withdraw, &mut || checkpoint());
+                super::retire_vec(&mut fs_announce, &mut || checkpoint());
+                super::retire_vec(&mut fs_withdraw, &mut || checkpoint());
+                super::retire_vec(&mut evpn_announce, &mut || checkpoint());
+                super::retire_vec(&mut evpn_withdraw, &mut || checkpoint());
+                super::retire_vec(&mut bgpls_announce, &mut || checkpoint());
+                super::retire_vec(&mut bgpls_withdraw, &mut || checkpoint());
+                super::retire_vec(&mut vpn_announce, &mut || checkpoint());
+                super::retire_vec(&mut vpn_withdraw, &mut || checkpoint());
+                super::retire_vec(&mut labeled_announce, &mut || checkpoint());
+                super::retire_vec(&mut labeled_withdraw, &mut || checkpoint());
+                super::retire_vec(&mut rtc_announce, &mut || checkpoint());
+                super::retire_vec(&mut rtc_withdraw, &mut || checkpoint());
+                self.replacement_checkpoint(true);
+                drop((announce, nh_override_flags));
+                self.replacement_checkpoint(true);
                 self.update_policy_filtered_routes_for_prefixes(
                     peer,
                     &effective_prefixes,
@@ -6106,6 +7213,34 @@ impl RibManager {
                     }
                 }
             }
+            self.replacement_capacity(
+                "current_policy_filtered",
+                current_policy_filtered_routes.len(),
+                current_policy_filtered_routes.capacity(),
+            );
+            super::retire_hash_set(&mut current_policy_filtered_routes, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_flowspec_rules, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_evpn_keys, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_bgpls_keys, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_l3vpn_keys, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_labeled_keys, &mut || checkpoint());
+            super::retire_hash_set(&mut effective_rtc_keys, &mut || checkpoint());
+            if let Cow::Owned(prefixes) = &mut effective_prefixes {
+                super::retire_hash_set(prefixes, &mut || checkpoint());
+            }
+            self.replacement_checkpoint(true);
         }
+        shared_unicast_probe_cache
+            .retire_with(&mut || self.replacement_checkpoint_at("retirement", false));
+        for (_, mut stage) in group_stage.drain() {
+            stage.retire_with(&mut |force| self.replacement_checkpoint_at("retirement", force));
+        }
+        crate::adj_rib_out::release_hash_map(&mut group_stage, &mut || checkpoint());
+        #[cfg(feature = "bench-internals")]
+        export_memo.record_replacement_capacities(self);
+        export_memo.retire_with(&mut || self.replacement_checkpoint_at("retirement", false));
+        crate::adj_rib_out::release_hash_map(&mut shared_group_encodes, &mut || checkpoint());
+        crate::adj_rib_out::release_hash_map(&mut rs_tagged_pass, &mut || checkpoint());
+        self.replacement_checkpoint(true);
     }
 }

--- a/crates/rib/src/manager/distribution/rtc.rs
+++ b/crates/rib/src/manager/distribution/rtc.rs
@@ -36,7 +36,6 @@ impl RibManager {
     #[expect(
         clippy::fn_params_excessive_bools,
         clippy::too_many_arguments,
-        clippy::too_many_lines,
         reason = "RTC staging mirrors VPN/BGP-LS distribution context for RR/export parity"
     )]
     pub(in crate::manager) fn stage_rtc_routes(
@@ -61,10 +60,65 @@ impl RibManager {
         rtc_withdraw: &mut Vec<crate::route::RtcRibRouteKey>,
         force: bool,
     ) {
+        Self::stage_rtc_routes_with_checkpoint(
+            loc_rib,
+            rib_out,
+            peer_is_rr_client,
+            keys,
+            target_peer,
+            target_peer_asn,
+            target_peer_group,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            metrics,
+            policy_stats,
+            target_peer_label,
+            rtc_announce,
+            rtc_withdraw,
+            force,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::fn_params_excessive_bools,
+        clippy::too_many_arguments,
+        clippy::too_many_lines,
+        reason = "RTC staging mirrors VPN/BGP-LS distribution context for RR/export parity"
+    )]
+    pub(in crate::manager) fn stage_rtc_routes_with_checkpoint(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        keys: &HashSet<crate::route::RtcRibRouteKey>,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        rtc_announce: &mut Vec<crate::route::RtcRibRoute>,
+        rtc_withdraw: &mut Vec<crate::route::RtcRibRouteKey>,
+        force: bool,
+        checkpoint: &mut impl FnMut(),
+    ) {
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let family = crate::route::RtcRibRouteKey::afi_safi();
         let family_sendable = sendable.is_some_and(|f| f.contains(&family));
         for key in keys {
+            checkpoint();
             if !family_sendable {
                 if rib_out.get_rtc(key).is_some() {
                     rtc_withdraw.push(key.clone());
@@ -183,8 +237,10 @@ impl RibManager {
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
+            checkpoint();
             let (result, evaluation) =
                 rustbgpd_policy::evaluate_chain_with_attribution(export_pol, &ctx);
+            checkpoint();
             record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
             if result.action != rustbgpd_policy::PolicyAction::Permit {
                 if rib_out.get_rtc(key).is_some() {
@@ -195,10 +251,12 @@ impl RibManager {
 
             let mut modified = best.clone();
             if !result.modifications.is_empty() {
+                checkpoint();
                 let nh = rustbgpd_policy::apply_modifications(
                     std::sync::Arc::make_mut(&mut modified.attributes),
                     &result.modifications,
                 );
+                checkpoint();
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
@@ -221,7 +279,9 @@ impl RibManager {
             {
                 continue;
             }
+            checkpoint();
             rtc_announce.push(modified);
+            checkpoint();
         }
     }
 

--- a/crates/rib/src/manager/distribution/unicast.rs
+++ b/crates/rib/src/manager/distribution/unicast.rs
@@ -39,6 +39,223 @@ fn export_deny_attribution(
     }
 }
 
+impl RibManager {
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::fn_params_excessive_bools,
+        reason = "multipath export keeps peer, policy, and Adj-RIB-Out diff state together; the bools are independent per-target mode/state flags threaded from the caller's ladder"
+    )]
+    pub(in crate::manager) fn distribute_multipath_prefix(
+        ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        prefix: &Prefix,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        send_max: u32,
+        stage_path_id_zero: bool,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        rs_control_asn: Option<u32>,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        orf_filter: Option<&crate::orf::OrfFilterSet>,
+        orr: Option<(&crate::orr::OrrTopology, &crate::orr::SpfResult)>,
+        memo: &mut super::ExportMemo,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        out: &mut UnicastDistributionResult,
+        force: bool,
+    ) {
+        Self::distribute_multipath_prefix_with_checkpoint(
+            ribs,
+            prefix_peers,
+            rib_out,
+            peer_is_rr_client,
+            prefix,
+            target_peer,
+            target_peer_asn,
+            target_peer_group,
+            send_max,
+            stage_path_id_zero,
+            target_is_ebgp,
+            interpret_rfc1997,
+            rs_control_asn,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            orf_filter,
+            orr,
+            memo,
+            metrics,
+            policy_stats,
+            target_peer_label,
+            out,
+            force,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "group per-client-best export keeps group, policy, and table diff state together"
+    )]
+    pub(in crate::manager) fn distribute_group_per_client_best_prefix(
+        ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        prefix: &Prefix,
+        group_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        group_is_rr_client: bool,
+        group_local_role: Option<rustbgpd_wire::BgpRole>,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        memo: &mut super::ExportMemo,
+        evals: &mut GroupEvalAccumulator,
+        out: &mut UnicastDistributionResult<(PolicyFilteredRouteKey, Option<PolicyLabel>)>,
+        otc_blocked: &mut Vec<crate::route::Route>,
+    ) -> PerClientBestPrefixStage {
+        Self::distribute_group_per_client_best_prefix_with_checkpoint(
+            ribs,
+            prefix_peers,
+            rib_out,
+            peer_is_rr_client,
+            prefix,
+            group_is_ebgp,
+            interpret_rfc1997,
+            group_is_rr_client,
+            group_local_role,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            memo,
+            evals,
+            out,
+            otc_blocked,
+            &mut || {},
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::fn_params_excessive_bools,
+        reason = "single-best export keeps target, policy, and Adj-RIB-Out diff state together"
+    )]
+    pub(in crate::manager) fn distribute_single_best_prefix(
+        loc_rib: &LocRib,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        prefix: &Prefix,
+        target: &mut super::ExportTarget<'_>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        rs_control_asn: Option<u32>,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        orf_filter: Option<&crate::orf::OrfFilterSet>,
+        memo: &mut super::ExportMemo,
+        result: &mut UnicastDistributionResult,
+        force: bool,
+    ) {
+        Self::distribute_single_best_prefix_with_checkpoint(
+            loc_rib,
+            rib_out,
+            peer_is_rr_client,
+            prefix,
+            target,
+            target_is_ebgp,
+            interpret_rfc1997,
+            rs_control_asn,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            orf_filter,
+            memo,
+            result,
+            force,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        clippy::fn_params_excessive_bools,
+        reason = "ORR export keeps peer, policy, and Adj-RIB-Out diff state together"
+    )]
+    pub(in crate::manager) fn distribute_orr_best_prefix(
+        ribs: &HashMap<IpAddr, AdjRibIn>,
+        prefix_peers: &UnicastPrefixPeers,
+        rib_out: &AdjRibOut,
+        peer_is_rr_client: &HashMap<IpAddr, bool>,
+        orr_topology: &crate::orr::OrrTopology,
+        orr_spf: &crate::orr::SpfResult,
+        prefix: &Prefix,
+        target_peer: IpAddr,
+        target_peer_asn: Option<u32>,
+        target_peer_group: Option<&str>,
+        target_is_ebgp: bool,
+        interpret_rfc1997: bool,
+        target_is_rr_client: bool,
+        cluster_id: Option<Ipv4Addr>,
+        sendable: Option<&Vec<(Afi, Safi)>>,
+        llgr: Option<&Vec<(Afi, Safi)>>,
+        export_pol: Option<&PolicyChain>,
+        orf_filter: Option<&crate::orf::OrfFilterSet>,
+        memo: &mut super::ExportMemo,
+        metrics: &BgpMetrics,
+        policy_stats: &mut NeighborPolicyStats,
+        target_peer_label: &str,
+        result: &mut UnicastDistributionResult,
+        force: bool,
+    ) {
+        Self::distribute_orr_best_prefix_with_checkpoint(
+            ribs,
+            prefix_peers,
+            rib_out,
+            peer_is_rr_client,
+            orr_topology,
+            orr_spf,
+            prefix,
+            target_peer,
+            target_peer_asn,
+            target_peer_group,
+            target_is_ebgp,
+            interpret_rfc1997,
+            target_is_rr_client,
+            cluster_id,
+            sendable,
+            llgr,
+            export_pol,
+            orf_filter,
+            memo,
+            metrics,
+            policy_stats,
+            target_peer_label,
+            result,
+            force,
+            &mut || {},
+        );
+    }
+}
+
 /// Candidate paths for `prefix` visible to `target_peer` under RFC 9107
 /// ORR: every eligible Adj-RIB-In entry that survives split horizon and the
 /// iBGP / RFC 4456 reflection rules. Shared by the ORR distribution and
@@ -156,6 +373,107 @@ fn multipath_candidates<'a>(
             llgr,
         )
     })
+}
+
+/// Checkpointed live counterpart to [`orr_candidates`]. Explain keeps the
+/// iterator form above; distribution collects the same candidates while
+/// polling every raw Adj-RIB-In visit, including rejected routes.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "candidate collection mirrors the per-target reflection filter inputs"
+)]
+fn orr_candidates_with_checkpoint<'a>(
+    ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    prefix_peers: &'a UnicastPrefixPeers,
+    peer_is_rr_client: &'a HashMap<IpAddr, bool>,
+    prefix: &'a Prefix,
+    target_peer: Option<IpAddr>,
+    target_is_ebgp: bool,
+    target_is_rr_client: bool,
+    cluster_id: Option<Ipv4Addr>,
+    checkpoint: &mut impl FnMut(),
+) -> Vec<&'a crate::route::Route> {
+    let mut candidates = Vec::new();
+    for route in RibManager::unicast_candidates(ribs, prefix_peers, prefix) {
+        checkpoint();
+        if Some(route.peer) == target_peer
+            || should_suppress_ibgp_inner(
+                route,
+                target_is_ebgp,
+                target_is_rr_client,
+                cluster_id,
+                peer_is_rr_client,
+            )
+        {
+            continue;
+        }
+        candidates.push(route);
+        checkpoint();
+    }
+    candidates
+}
+
+/// Checkpointed live counterpart to [`multipath_candidates`].
+#[expect(
+    clippy::too_many_arguments,
+    reason = "candidate collection mirrors the per-target reflection filter inputs"
+)]
+fn multipath_candidates_with_checkpoint<'a>(
+    ribs: &'a HashMap<IpAddr, AdjRibIn>,
+    prefix_peers: &'a UnicastPrefixPeers,
+    peer_is_rr_client: &'a HashMap<IpAddr, bool>,
+    prefix: &'a Prefix,
+    target_peer: Option<IpAddr>,
+    target_is_ebgp: bool,
+    interpret_rfc1997: bool,
+    rs_control: Option<(u32, u32)>,
+    target_is_rr_client: bool,
+    cluster_id: Option<Ipv4Addr>,
+    family: (Afi, Safi),
+    llgr: Option<&'a Vec<(Afi, Safi)>>,
+    checkpoint: &mut impl FnMut(),
+) -> Vec<&'a crate::route::Route> {
+    let mut candidates = Vec::new();
+    for route in orr_candidates_with_checkpoint(
+        ribs,
+        prefix_peers,
+        peer_is_rr_client,
+        prefix,
+        target_peer,
+        target_is_ebgp,
+        target_is_rr_client,
+        cluster_id,
+        checkpoint,
+    ) {
+        checkpoint();
+        if super::no_advertise_export_suppressed(route.communities())
+            || super::no_export_export_suppressed(
+                route.communities(),
+                target_is_ebgp,
+                interpret_rfc1997,
+            )
+            || rs_control.is_some_and(|(rs_asn, peer_asn)| {
+                super::rs_control::rs_control_export_suppressed(
+                    route.communities(),
+                    route.large_communities(),
+                    rs_asn,
+                    peer_asn,
+                )
+            })
+            || super::llgr_stale_export_suppressed(
+                route.is_llgr_stale,
+                route.communities(),
+                family,
+                target_is_ebgp,
+                llgr,
+            )
+        {
+            continue;
+        }
+        candidates.push(route);
+        checkpoint();
+    }
+    candidates
 }
 
 impl RibManager {
@@ -1447,7 +1765,7 @@ impl RibManager {
         clippy::fn_params_excessive_bools,
         reason = "multipath export keeps peer, policy, and Adj-RIB-Out diff state together; the bools are independent per-target mode/state flags threaded from the caller's ladder"
     )]
-    pub(in crate::manager) fn distribute_multipath_prefix(
+    pub(in crate::manager) fn distribute_multipath_prefix_with_checkpoint(
         ribs: &HashMap<IpAddr, AdjRibIn>,
         prefix_peers: &UnicastPrefixPeers,
         rib_out: &AdjRibOut,
@@ -1474,6 +1792,7 @@ impl RibManager {
         target_peer_label: &str,
         out: &mut UnicastDistributionResult,
         force: bool,
+        checkpoint: &mut impl FnMut(),
     ) {
         use crate::best_path::{best_path_cmp, best_path_cmp_orr};
 
@@ -1485,6 +1804,7 @@ impl RibManager {
         if !sendable.is_some_and(|f| f.contains(&family)) {
             // Withdraw all previously advertised paths for this prefix
             for path_id in rib_out.path_ids_for_prefix(prefix) {
+                checkpoint();
                 out.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1494,6 +1814,7 @@ impl RibManager {
         // path-ids — gate the whole prefix once, before collecting candidates.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
             for path_id in rib_out.path_ids_for_prefix(prefix) {
+                checkpoint();
                 out.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1503,7 +1824,8 @@ impl RibManager {
         // (reverse-index probe, not an all-peers scan) — the collector is
         // shared with the per-client-best explain arm so explain walks
         // exactly this set.
-        let mut candidates: Vec<&crate::route::Route> = multipath_candidates(
+        checkpoint();
+        let mut candidates = multipath_candidates_with_checkpoint(
             ribs,
             prefix_peers,
             peer_is_rr_client,
@@ -1516,8 +1838,9 @@ impl RibManager {
             cluster_id,
             family,
             llgr,
-        )
-        .collect();
+            checkpoint,
+        );
+        checkpoint();
         #[cfg(feature = "bench-internals")]
         if stage_path_id_zero {
             super::super::bench_support::bench_record_per_client_best_candidates(
@@ -1531,6 +1854,7 @@ impl RibManager {
         // each NEXT_HOP first (RFC 9107 §3.1) — comparator swap only.
         match orr {
             Some((topology, spf)) => candidates.sort_by(|a, b| {
+                checkpoint();
                 best_path_cmp_orr(
                     a,
                     b,
@@ -1538,7 +1862,10 @@ impl RibManager {
                     spf.cost_to(topology, b.next_hop),
                 )
             }),
-            None => candidates.sort_by(|a, b| best_path_cmp(a, b)),
+            None => candidates.sort_by(|a, b| {
+                checkpoint();
+                best_path_cmp(a, b)
+            }),
         }
 
         // Walk candidates, evaluate export policy, assign path_ids 1..N
@@ -1550,6 +1877,7 @@ impl RibManager {
             send_max as usize
         };
         for candidate in &candidates {
+            checkpoint();
             if (next_rank as usize) > limit {
                 break;
             }
@@ -1581,7 +1909,9 @@ impl RibManager {
                 local_pref: candidate.local_pref_attr(),
                 med: candidate.med_attr(),
             };
+            checkpoint();
             let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+            checkpoint();
             record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
             if result.action != PolicyAction::Permit {
                 out.policy_filtered.push(PolicyFilteredRouteKey {
@@ -1596,7 +1926,9 @@ impl RibManager {
             // Apply export modifications — the pass-scoped memo shares one
             // post-modification attribute Arc across every (route, peer)
             // with the same source attrs and equal modifications.
+            checkpoint();
             let (mut modified, nh_action) = memo.apply(candidate, &result.modifications);
+            checkpoint();
             if super::no_advertise_export_suppressed(modified.communities()) {
                 // Export policy added NO_ADVERTISE: the route is suppressed
                 // by policy, so surface it through the same policy-filtered
@@ -1631,6 +1963,7 @@ impl RibManager {
                     .get(prefix, modified.path_id)
                     .is_none_or(|existing| !routes_equal(existing, &modified));
             if changed {
+                checkpoint();
                 out.next_hop_override.push(nh_action);
                 out.announce.push(modified);
             }
@@ -1646,6 +1979,7 @@ impl RibManager {
             // withdraw+announce pair when the filtered best flips).
             let staged_winner = next_rank > 1;
             for path_id in rib_out.path_ids_for_prefix(prefix) {
+                checkpoint();
                 if path_id != 0 || !staged_winner {
                     out.withdraw.push((*prefix, path_id));
                 }
@@ -1653,6 +1987,7 @@ impl RibManager {
         } else {
             // Withdraw any previously advertised path_ids beyond the new set
             for path_id in rib_out.path_ids_for_prefix(prefix) {
+                checkpoint();
                 if path_id >= next_rank {
                     out.withdraw.push((*prefix, path_id));
                 }
@@ -1706,7 +2041,7 @@ impl RibManager {
         clippy::too_many_lines,
         reason = "group per-client-best export keeps group, policy, and table diff state together"
     )]
-    pub(in crate::manager) fn distribute_group_per_client_best_prefix(
+    pub(in crate::manager) fn distribute_group_per_client_best_prefix_with_checkpoint(
         ribs: &HashMap<IpAddr, AdjRibIn>,
         prefix_peers: &UnicastPrefixPeers,
         rib_out: &AdjRibOut,
@@ -1724,6 +2059,7 @@ impl RibManager {
         evals: &mut GroupEvalAccumulator,
         out: &mut UnicastDistributionResult<(PolicyFilteredRouteKey, Option<PolicyLabel>)>,
         otc_blocked: &mut Vec<crate::route::Route>,
+        checkpoint: &mut impl FnMut(),
     ) -> PerClientBestPrefixStage {
         use crate::best_path::best_path_cmp;
 
@@ -1734,12 +2070,14 @@ impl RibManager {
         };
         if !sendable.is_some_and(|f| f.contains(&family)) {
             for path_id in rib_out.path_ids_for_prefix(prefix) {
+                checkpoint();
                 out.withdraw.push((*prefix, path_id));
             }
             return stage;
         }
 
-        let mut candidates: Vec<&crate::route::Route> = multipath_candidates(
+        checkpoint();
+        let mut candidates = multipath_candidates_with_checkpoint(
             ribs,
             prefix_peers,
             peer_is_rr_client,
@@ -1753,13 +2091,18 @@ impl RibManager {
             cluster_id,
             family,
             llgr,
-        )
-        .collect();
-        candidates.sort_by(|a, b| best_path_cmp(a, b));
+            checkpoint,
+        );
+        checkpoint();
+        candidates.sort_by(|a, b| {
+            checkpoint();
+            best_path_cmp(a, b)
+        });
 
         let needs_as_path_string = export_pol.is_some_and(PolicyChain::requires_as_path_string);
         let mut winner_source: Option<IpAddr> = None;
         for candidate in &candidates {
+            checkpoint();
             if winner_source == Some(candidate.peer) {
                 continue;
             }
@@ -1792,7 +2135,9 @@ impl RibManager {
                 local_pref: candidate.local_pref_attr(),
                 med: candidate.med_attr(),
             };
+            checkpoint();
             let (result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+            checkpoint();
             evals.record(&evaluation, candidate.peer);
             let label = evaluation.matched_policy.clone();
             let filtered_key = PolicyFilteredRouteKey {
@@ -1806,7 +2151,9 @@ impl RibManager {
                 out.policy_filtered.push((filtered_key, label));
                 continue;
             }
+            checkpoint();
             let (mut modified, nh_action) = memo.apply(candidate, &result.modifications);
+            checkpoint();
             if super::no_advertise_export_suppressed(modified.communities()) {
                 // Policy-added NO_ADVERTISE is a policy suppression —
                 // same accounting as the deny arm, matching the
@@ -1840,12 +2187,14 @@ impl RibManager {
             // equality-suppressed: the caller's `record_otc_blocked`
             // refreshes this prefix's residue every pass.
             if super::otc_egress_blocked(&modified, group_local_role) {
+                checkpoint();
                 otc_blocked.push(modified.clone());
             }
             let changed = rib_out
                 .get(prefix, 0)
                 .is_none_or(|existing| !routes_equal(existing, &modified));
             if changed {
+                checkpoint();
                 out.next_hop_override.push(nh_action);
                 out.announce.push(modified);
             }
@@ -1857,6 +2206,7 @@ impl RibManager {
         // implicit replace otherwise.
         let staged_winner = winner_source.is_some();
         for path_id in rib_out.path_ids_for_prefix(prefix) {
+            checkpoint();
             if path_id != 0 || !staged_winner {
                 out.withdraw.push((*prefix, path_id));
             }
@@ -1876,7 +2226,7 @@ impl RibManager {
         clippy::fn_params_excessive_bools,
         reason = "single-best export keeps target, policy, and Adj-RIB-Out diff state together"
     )]
-    pub(in crate::manager) fn distribute_single_best_prefix(
+    pub(in crate::manager) fn distribute_single_best_prefix_with_checkpoint(
         loc_rib: &LocRib,
         rib_out: &AdjRibOut,
         peer_is_rr_client: &HashMap<IpAddr, bool>,
@@ -1894,16 +2244,19 @@ impl RibManager {
         memo: &mut super::ExportMemo,
         result: &mut UnicastDistributionResult,
         force: bool,
+        checkpoint: &mut impl FnMut(),
     ) {
         use crate::update::ExportGateVerdict::{NotApplicable, Pass, Stop};
 
         let existing_path_ids = rib_out.path_ids_for_prefix(prefix);
 
+        checkpoint();
         let Some(best) = loc_rib.get(prefix) else {
             target.gate("best_route", "no_best_route", Stop, || {
                 "no best route exists for this prefix".to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1932,6 +2285,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1959,6 +2313,7 @@ impl RibManager {
                 trace.push("rr_reflection", code, Stop, detail.to_string());
             }
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1974,6 +2329,7 @@ impl RibManager {
                 format!("peer cannot receive {} routes", family_label(family))
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -1997,6 +2353,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2025,6 +2382,7 @@ impl RibManager {
                         .to_string()
                 });
                 for &path_id in &existing_path_ids {
+                    checkpoint();
                     result.withdraw.push((*prefix, path_id));
                 }
                 return;
@@ -2048,6 +2406,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2064,6 +2423,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2090,6 +2450,7 @@ impl RibManager {
                     .to_string()
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2125,7 +2486,9 @@ impl RibManager {
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
+        checkpoint();
         let (policy_result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+        checkpoint();
         target.record_eval(&evaluation, best.peer);
         if let Some(trace) = target.trace() {
             // Keep Permit on the chain-default label. For Deny, enrich the
@@ -2160,6 +2523,7 @@ impl RibManager {
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2191,7 +2555,9 @@ impl RibManager {
         // (route, peer) with the same source attribute set and equal
         // modifications; no-modification exports keep sharing the
         // source Arc as before.
+        checkpoint();
         let (mut modified, nh_action) = memo.apply(best, &policy_result.modifications);
+        checkpoint();
         modified.path_id = 0;
 
         // Export policy may add NO_ADVERTISE to an otherwise eligible
@@ -2218,6 +2584,7 @@ impl RibManager {
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2251,6 +2618,7 @@ impl RibManager {
             });
             target.record_otc_blocked(modified);
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2315,6 +2683,7 @@ impl RibManager {
             }
         }
         if changed {
+            checkpoint();
             result.next_hop_override.push(nh_action);
             result.announce.push(modified);
         }
@@ -2322,6 +2691,7 @@ impl RibManager {
         // Clean up any stale multi-path entries if this prefix was previously
         // advertised via Add-Path and is now single-best.
         for &path_id in &existing_path_ids {
+            checkpoint();
             if path_id != 0 {
                 result.withdraw.push((*prefix, path_id));
             }
@@ -2352,7 +2722,7 @@ impl RibManager {
         clippy::fn_params_excessive_bools,
         reason = "ORR export keeps peer, policy, and Adj-RIB-Out diff state together"
     )]
-    pub(in crate::manager) fn distribute_orr_best_prefix(
+    pub(in crate::manager) fn distribute_orr_best_prefix_with_checkpoint(
         ribs: &HashMap<IpAddr, AdjRibIn>,
         prefix_peers: &UnicastPrefixPeers,
         rib_out: &AdjRibOut,
@@ -2377,6 +2747,7 @@ impl RibManager {
         target_peer_label: &str,
         result: &mut UnicastDistributionResult,
         force: bool,
+        checkpoint: &mut impl FnMut(),
     ) {
         use crate::best_path::best_path_cmp_orr;
 
@@ -2386,6 +2757,7 @@ impl RibManager {
         let family = prefix_family(prefix);
         if !sendable.is_some_and(|f| f.contains(&family)) {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2395,6 +2767,7 @@ impl RibManager {
         // policy denial — see `distribute_single_best_prefix`.
         if orf_filter.is_some_and(|f| !f.permits(prefix)) {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2404,7 +2777,8 @@ impl RibManager {
         // verbatim the multipath collector's per-target filter set.
         // Shared with the ORR explain path (`explain_single_best_prefix`)
         // so explain ranks exactly what distribution ranks.
-        let candidates = orr_candidates(
+        checkpoint();
+        let candidates = orr_candidates_with_checkpoint(
             ribs,
             prefix_peers,
             peer_is_rr_client,
@@ -2413,11 +2787,13 @@ impl RibManager {
             target_is_ebgp,
             target_is_rr_client,
             cluster_id,
+            checkpoint,
         );
 
         // Per-vantage best (RFC 9107): the vantage's interior cost to
         // each NEXT_HOP breaks ties between step 5 and step 5.5.
-        let Some(best) = candidates.min_by(|a, b| {
+        let Some(best) = candidates.into_iter().min_by(|a, b| {
+            checkpoint();
             best_path_cmp_orr(
                 a,
                 b,
@@ -2426,6 +2802,7 @@ impl RibManager {
             )
         }) else {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2443,6 +2820,7 @@ impl RibManager {
             llgr,
         ) {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2453,6 +2831,7 @@ impl RibManager {
         // runner-up merely because the selected best is NO_ADVERTISE.
         if super::no_advertise_export_suppressed(best.communities()) {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2462,6 +2841,7 @@ impl RibManager {
         if super::no_export_export_suppressed(best.communities(), target_is_ebgp, interpret_rfc1997)
         {
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2494,7 +2874,9 @@ impl RibManager {
             local_pref: best.local_pref_attr(),
             med: best.med_attr(),
         };
+        checkpoint();
         let (policy_result, evaluation) = evaluate_chain_with_attribution(export_pol, &ctx);
+        checkpoint();
         record_export_policy_eval(metrics, policy_stats, target_peer_label, &evaluation);
         if policy_result.action != PolicyAction::Permit {
             result.policy_filtered.push(PolicyFilteredRouteKey {
@@ -2504,6 +2886,7 @@ impl RibManager {
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2516,7 +2899,9 @@ impl RibManager {
         // winner memo the doc comment above rejects — the key here is
         // (source attribute identity, modifications value), which is
         // independent of which candidate won.
+        checkpoint();
         let (mut modified, nh_action) = memo.apply(best, &policy_result.modifications);
+        checkpoint();
         modified.path_id = 0;
 
         if super::no_advertise_export_suppressed(modified.communities()) {
@@ -2530,6 +2915,7 @@ impl RibManager {
                 path_id: best.path_id,
             });
             for &path_id in &existing_path_ids {
+                checkpoint();
                 result.withdraw.push((*prefix, path_id));
             }
             return;
@@ -2541,6 +2927,7 @@ impl RibManager {
                 .get(prefix, 0)
                 .is_none_or(|existing| !routes_equal(existing, &modified));
         if changed {
+            checkpoint();
             result.next_hop_override.push(nh_action);
             result.announce.push(modified);
         }
@@ -2548,6 +2935,7 @@ impl RibManager {
         // Clean up any stale multi-path entries if this prefix was
         // previously advertised via Add-Path and is now single-best.
         for &path_id in &existing_path_ids {
+            checkpoint();
             if path_id != 0 {
                 result.withdraw.push((*prefix, path_id));
             }

--- a/crates/rib/src/manager/distribution/vpn.rs
+++ b/crates/rib/src/manager/distribution/vpn.rs
@@ -75,10 +75,6 @@ impl RibManager {
     /// candidates per key are ranked — with the ORR vantage comparator when
     /// a vantage is resolved — and staged with outbound path IDs `1..=N`.
     /// Otherwise the single best is staged with `path_id = 0`.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "VPN staging mirrors unicast multipath/single-best distribution context for RR/export parity"
-    )]
     pub(in crate::manager) fn stage_vpn_routes(
         context: &crate::manager::VpnLabeledStagingContext<'_>,
         keys: &HashSet<VpnRouteKey>,
@@ -87,6 +83,31 @@ impl RibManager {
         vpn_announce: &mut Vec<VpnRibRoute>,
         vpn_withdraw: &mut Vec<VpnRibRouteKey>,
     ) {
+        Self::stage_vpn_routes_with_checkpoint(
+            context,
+            keys,
+            target,
+            rtc_filter,
+            vpn_announce,
+            vpn_withdraw,
+            &mut || {},
+        );
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "VPN staging mirrors unicast multipath/single-best distribution context for RR/export parity"
+    )]
+    pub(in crate::manager) fn stage_vpn_routes_with_checkpoint(
+        context: &crate::manager::VpnLabeledStagingContext<'_>,
+        keys: &HashSet<VpnRouteKey>,
+        target: &mut super::ExportTarget<'_>,
+        rtc_filter: Option<&crate::manager::RtcMembership>,
+        vpn_announce: &mut Vec<VpnRibRoute>,
+        vpn_withdraw: &mut Vec<VpnRibRouteKey>,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        let checkpoint = std::cell::RefCell::new(checkpoint);
         let &crate::manager::VpnLabeledStagingContext {
             loc_rib,
             ribs,
@@ -110,12 +131,14 @@ impl RibManager {
         // at emit time by the VPN source-flip matrix.
         let split_horizon_peer = target.split_horizon_peer();
         for key in keys {
+            checkpoint.borrow_mut()();
             let family = vpn_afi_safi(key);
             // Path IDs currently advertised for this identity — the diff
             // baseline for every withdraw decision below.
             let existing_path_ids = rib_out.vpn_path_ids_for_key(key);
             let withdraw_existing = |vpn_withdraw: &mut Vec<VpnRibRouteKey>, existing: &[u32]| {
                 for &path_id in existing {
+                    checkpoint.borrow_mut()();
                     vpn_withdraw.push(VpnRibRouteKey {
                         nlri_key: *key,
                         path_id,
@@ -170,9 +193,16 @@ impl RibManager {
                 // rank it, and stage the top N with path IDs 1..=N.
                 let mut candidates: Vec<&VpnRibRoute> = ribs
                     .values()
-                    .flat_map(|rib| rib.iter_vpn_for_nlri(key))
-                    .filter(|route| crate::srv6::vpn_eligible(route))
+                    .flat_map(|rib| {
+                        checkpoint.borrow_mut()();
+                        rib.iter_vpn_for_nlri(key)
+                    })
+                    .filter(|route| {
+                        checkpoint.borrow_mut()();
+                        crate::srv6::vpn_eligible(route)
+                    })
                     .filter(|candidate| {
+                        checkpoint.borrow_mut()();
                         split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &vpn_suppression_probe(candidate),
@@ -188,6 +218,7 @@ impl RibManager {
                 // each candidate's next-hop (comparator swap only).
                 match orr_ctx {
                     Some((orr_topology, orr_spf)) => candidates.sort_by(|a, b| {
+                        checkpoint.borrow_mut()();
                         vpn_tiebreak_orr(
                             a,
                             b,
@@ -195,7 +226,10 @@ impl RibManager {
                             orr_spf.cost_to(orr_topology, b.next_hop),
                         )
                     }),
-                    None => candidates.sort_by(|a, b| crate::loc_rib::vpn_tiebreak(a, b)),
+                    None => candidates.sort_by(|a, b| {
+                        checkpoint.borrow_mut()();
+                        crate::loc_rib::vpn_tiebreak(a, b)
+                    }),
                 }
 
                 let mut next_rank: u32 = 1;
@@ -205,6 +239,7 @@ impl RibManager {
                     key_send_max as usize
                 };
                 for candidate in &candidates {
+                    checkpoint.borrow_mut()();
                     if (next_rank as usize) > limit {
                         break;
                     }
@@ -278,7 +313,9 @@ impl RibManager {
                         local_pref: candidate.local_pref_attr(),
                         med: candidate.med_attr(),
                     };
+                    checkpoint.borrow_mut()();
                     let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+                    checkpoint.borrow_mut()();
                     target.record_eval(&evaluation, candidate.peer);
                     if result.action != rustbgpd_policy::PolicyAction::Permit {
                         continue;
@@ -286,6 +323,7 @@ impl RibManager {
 
                     let mut modified = (*candidate).clone();
                     if !result.modifications.is_empty() {
+                        checkpoint.borrow_mut()();
                         let nh = rustbgpd_policy::apply_modifications(
                             std::sync::Arc::make_mut(&mut modified.attributes),
                             &result.modifications,
@@ -293,6 +331,7 @@ impl RibManager {
                         if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                             modified.next_hop = addr;
                         }
+                        checkpoint.borrow_mut()();
                     }
                     if super::no_advertise_export_suppressed(modified.communities()) {
                         continue;
@@ -308,6 +347,7 @@ impl RibManager {
                             .get_vpn(&out_key)
                             .is_none_or(|existing| !vpn_routes_equal(existing, &modified))
                     {
+                        checkpoint.borrow_mut()();
                         vpn_announce.push(modified);
                     }
                     next_rank += 1;
@@ -316,6 +356,7 @@ impl RibManager {
                 // Withdraw previously advertised path IDs outside the new
                 // 1..next_rank set (including a stale single-best 0 entry).
                 for &path_id in existing_path_ids {
+                    checkpoint.borrow_mut()();
                     if path_id == 0 || path_id >= next_rank {
                         vpn_withdraw.push(VpnRibRouteKey {
                             nlri_key: *key,
@@ -336,9 +377,16 @@ impl RibManager {
             let best = if let Some((orr_topology, orr_spf)) = orr_ctx {
                 let winner = ribs
                     .values()
-                    .flat_map(|rib| rib.iter_vpn_for_nlri(key))
-                    .filter(|route| crate::srv6::vpn_eligible(route))
+                    .flat_map(|rib| {
+                        checkpoint.borrow_mut()();
+                        rib.iter_vpn_for_nlri(key)
+                    })
+                    .filter(|route| {
+                        checkpoint.borrow_mut()();
+                        crate::srv6::vpn_eligible(route)
+                    })
                     .filter(|candidate| {
+                        checkpoint.borrow_mut()();
                         split_horizon_peer != Some(candidate.peer)
                             && !should_suppress_ibgp_inner(
                                 &vpn_suppression_probe(candidate),
@@ -349,6 +397,7 @@ impl RibManager {
                             )
                     })
                     .min_by(|a, b| {
+                        checkpoint.borrow_mut()();
                         vpn_tiebreak_orr(
                             a,
                             b,
@@ -606,7 +655,9 @@ impl RibManager {
                 local_pref: best.local_pref_attr(),
                 med: best.med_attr(),
             };
+            checkpoint.borrow_mut()();
             let (result, evaluation) = target.evaluate_export_chain(export_pol, &ctx);
+            checkpoint.borrow_mut()();
             target.record_eval(&evaluation, best.peer);
             if let Some(trace) = target.trace() {
                 trace.policy_label = export_pol.map(|chain| {
@@ -653,6 +704,7 @@ impl RibManager {
 
             let mut modified = best.clone();
             if !result.modifications.is_empty() {
+                checkpoint.borrow_mut()();
                 let nh = rustbgpd_policy::apply_modifications(
                     std::sync::Arc::make_mut(&mut modified.attributes),
                     &result.modifications,
@@ -660,6 +712,7 @@ impl RibManager {
                 if let Some(rustbgpd_policy::NextHopAction::Specific(addr)) = nh {
                     modified.next_hop = addr;
                 }
+                checkpoint.borrow_mut()();
             }
             if super::no_advertise_export_suppressed(modified.communities()) {
                 target.gate(
@@ -701,6 +754,7 @@ impl RibManager {
                         },
                     );
                 }
+                checkpoint.borrow_mut()();
                 vpn_announce.push(modified);
             } else if let Some(trace) = target.trace() {
                 trace.staged_next_hop = Some(modified.next_hop);
@@ -719,6 +773,7 @@ impl RibManager {
             // Clean up stale multi-path entries if this identity was
             // previously advertised via Add-Path and is now single-best.
             for &path_id in existing_path_ids {
+                checkpoint.borrow_mut()();
                 if path_id != 0 {
                     vpn_withdraw.push(VpnRibRouteKey {
                         nlri_key: *key,
@@ -746,6 +801,7 @@ impl RibManager {
         &mut self,
         affected: &HashSet<VpnRibRouteKey>,
     ) {
+        let readiness = self.replacement_readiness.clone();
         self.record_deferred_vpn(affected);
         let affected_nlri: HashSet<VpnRouteKey> = affected
             .iter()
@@ -850,13 +906,15 @@ impl RibManager {
                 let member_filter = self.member_rt_filter(peer);
                 let mut vpn_announce = Vec::new();
                 let mut vpn_withdraw = Vec::new();
-                let count_delta = crate::manager::update_groups::emit_vpn_group_deltas_for_member(
-                    &stage.deltas,
-                    peer,
-                    member_filter.as_ref(),
-                    &mut vpn_announce,
-                    &mut vpn_withdraw,
-                );
+                let count_delta =
+                    crate::manager::update_groups::emit_vpn_group_deltas_for_member_with_checkpoint(
+                        &stage.deltas,
+                        peer,
+                        member_filter.as_ref(),
+                        &mut vpn_announce,
+                        &mut vpn_withdraw,
+                        &mut || super::super::replacement_readiness_checkpoint(&readiness, false),
+                    );
                 if vpn_announce.is_empty() && vpn_withdraw.is_empty() {
                     continue;
                 }
@@ -916,7 +974,9 @@ impl RibManager {
                     // IN the table — invisible to tombstones. Ride the
                     // member's extra-withdraw residue instead.
                     let lost: Vec<VpnRouteKey> = stage
-                        .member_scoped_withdraws(peer, member_filter.as_ref())
+                        .member_scoped_withdraws(peer, member_filter.as_ref(), || {
+                            super::super::replacement_readiness_checkpoint(&readiness, false);
+                        })
                         .collect();
                     if !lost.is_empty() {
                         self.pending_extra_withdraws
@@ -1011,13 +1071,14 @@ impl RibManager {
                 policy_stats: &mut *policy_stats,
                 peer_label: &target_peer_label,
             };
-            Self::stage_vpn_routes(
+            Self::stage_vpn_routes_with_checkpoint(
                 &context,
                 staged_keys,
                 &mut target,
                 rtc_filter.as_ref(),
                 &mut vpn_announce,
                 &mut vpn_withdraw,
+                &mut || super::super::replacement_readiness_checkpoint(&readiness, false),
             );
 
             if (!vpn_announce.is_empty() || !vpn_withdraw.is_empty())

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -28,7 +28,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::hash::{BuildHasher, Hasher};
 use std::net::{IpAddr, Ipv4Addr};
 use std::num::NonZeroU32;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use rustbgpd_policy::PolicyChain;
 use rustbgpd_rpki::VrpTable;
@@ -41,6 +41,30 @@ use rustbgpd_telemetry::metrics::StaleSessionMessageKind::{
 use rustbgpd_wire::{Afi, BgpRole, Prefix, Safi};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, info, warn};
+
+/// Release owned temporary elements while the actor still owns readiness.
+fn retire_vec<T>(values: &mut Vec<T>, checkpoint: &mut impl FnMut()) {
+    checkpoint();
+    while let Some(value) = values.pop() {
+        drop(value);
+        checkpoint();
+    }
+    drop(std::mem::take(values));
+    checkpoint();
+}
+
+fn retire_hash_set<T, S: BuildHasher + Default>(
+    values: &mut HashSet<T, S>,
+    checkpoint: &mut impl FnMut(),
+) {
+    checkpoint();
+    for value in values.drain() {
+        drop(value);
+        checkpoint();
+    }
+    drop(std::mem::take(values));
+    checkpoint();
+}
 
 use crate::adj_rib_in::AdjRibIn;
 use crate::adj_rib_out::AdjRibOut;
@@ -785,6 +809,13 @@ pub struct RibManager {
     query_rx: mpsc::Receiver<RibUpdate>,
     /// Dedicated type-narrow lane used only by core readiness.
     readiness_rx: Option<mpsc::Receiver<RibReadinessQuery>>,
+    /// Only the readiness receiver and invariant count are shared across
+    /// synchronous replacement helpers. Canonical RIB state remains actor-owned.
+    replacement_readiness: Option<Arc<Mutex<ReplacementReadiness>>>,
+    #[cfg(test)]
+    replacement_readiness_test_hook: Option<Arc<dyn Fn(&'static str) + Send + Sync>>,
+    #[cfg(test)]
+    replacement_readiness_receipts: Vec<ReplacementReadinessReceipt>,
     /// Large route batches that are being processed in chunks.
     pending_route_batches: VecDeque<PendingRoutesReceived>,
     /// One explicit shared policy transition advanced by the actor itself.
@@ -908,6 +939,107 @@ const SLOW_POLICY_TRANSITION: std::time::Duration = std::time::Duration::from_se
 /// once ownership is far beyond any legitimate transition receipt.
 pub(in crate::manager) const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration =
     std::time::Duration::from_secs(30);
+
+struct ReplacementReadiness {
+    #[cfg(feature = "bench-internals")]
+    capacities: HashMap<&'static str, (usize, usize, usize)>,
+    #[cfg(test)]
+    observer: Option<Arc<dyn Fn(&'static str) + Send + Sync>>,
+    rx: Option<mpsc::Receiver<RibReadinessQuery>>,
+    count: usize,
+    started: tokio::time::Instant,
+    last_service: std::time::Instant,
+    budget: std::time::Duration,
+    #[cfg(any(test, feature = "bench-internals"))]
+    max_gap: std::time::Duration,
+    #[cfg(any(test, feature = "bench-internals"))]
+    serviced: usize,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct ReplacementReadinessReceipt {
+    count: usize,
+    elapsed: std::time::Duration,
+    max_gap: std::time::Duration,
+    serviced: usize,
+}
+
+#[expect(
+    clippy::ref_option,
+    reason = "callbacks borrow the actor's optional shared fence handle without creating another owner"
+)]
+fn replacement_readiness_checkpoint_at(
+    readiness: &Option<Arc<Mutex<ReplacementReadiness>>>,
+    stage: &'static str,
+    force: bool,
+) {
+    #[cfg(test)]
+    if let Some(context) = readiness {
+        let observer = context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .observer
+            .clone();
+        if let Some(observer) = observer {
+            observer(stage);
+        }
+    }
+    #[cfg(not(test))]
+    let _ = stage;
+    replacement_readiness_checkpoint(readiness, force);
+}
+
+/// Call only on the actor while its synchronous replacement fence is held.
+/// The short mutex guard never spans a helper, callback, or canonical mutation.
+#[expect(
+    clippy::ref_option,
+    reason = "callbacks borrow the actor's optional shared fence handle without creating another owner"
+)]
+fn replacement_readiness_checkpoint(
+    readiness: &Option<Arc<Mutex<ReplacementReadiness>>>,
+    force: bool,
+) {
+    let Some(readiness) = readiness else {
+        return;
+    };
+    let mut readiness = readiness
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let gap = readiness.last_service.elapsed();
+    if !force && gap < readiness.budget {
+        return;
+    }
+    #[cfg(any(test, feature = "bench-internals"))]
+    {
+        readiness.max_gap = readiness.max_gap.max(gap);
+    }
+    readiness.last_service = std::time::Instant::now();
+    for _ in 0..QUERY_BUDGET_PER_CHUNK {
+        let query = match readiness.rx.as_mut() {
+            Some(rx) => match rx.try_recv() {
+                Ok(query) => query,
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    readiness.rx = None;
+                    break;
+                }
+            },
+            None => break,
+        };
+        let RibReadinessQuery::LocRibCount { reply } = query;
+        let result = if readiness.started.elapsed() >= MAX_HEALTHY_POLICY_TRANSITION_AGE {
+            Err(RibReadinessError::PolicyTransitionStalled)
+        } else {
+            Ok(readiness.count)
+        };
+        let _ = reply.send(result);
+        #[cfg(any(test, feature = "bench-internals"))]
+        {
+            readiness.serviced += 1;
+        }
+    }
+}
 
 fn collect_evpn_dataplane_routes<'a>(
     rows: impl Iterator<Item = &'a crate::route::EvpnRibRoute>,
@@ -1520,6 +1652,11 @@ impl RibManager {
             rx,
             query_rx,
             readiness_rx: None,
+            replacement_readiness: None,
+            #[cfg(test)]
+            replacement_readiness_test_hook: None,
+            #[cfg(test)]
+            replacement_readiness_receipts: Vec::new(),
             pending_route_batches: VecDeque::new(),
             pending_clean_policy_transition: None,
             pending_destination_prestage: None,
@@ -1573,6 +1710,144 @@ impl RibManager {
     ) -> Self {
         self.readiness_rx = Some(readiness_rx);
         self
+    }
+
+    /// Export replacement does not change Loc-RIB cardinality. Keep that exact
+    /// actor-owned invariant while only readiness acknowledgements interleave.
+    fn with_replacement_readiness<T>(&mut self, work: impl FnOnce(&mut Self) -> T) -> T {
+        let age = self.pending_clean_policy_transition.as_ref().map_or(
+            std::time::Duration::ZERO,
+            distribution::PendingCleanPolicyTransition::elapsed,
+        );
+        self.with_replacement_readiness_age(age, work)
+    }
+
+    fn with_replacement_readiness_age<T>(
+        &mut self,
+        age: std::time::Duration,
+        work: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        if self.replacement_readiness.is_some() {
+            return work(self);
+        }
+        let started = tokio::time::Instant::now() - age;
+        self.replacement_readiness = Some(Arc::new(Mutex::new(ReplacementReadiness {
+            #[cfg(feature = "bench-internals")]
+            capacities: HashMap::new(),
+            #[cfg(test)]
+            observer: self.replacement_readiness_test_hook.clone(),
+            rx: self.readiness_rx.take(),
+            count: self.loc_rib.len(),
+            started,
+            last_service: std::time::Instant::now(),
+            budget: self.flush_poll_budget.min(FLUSH_POLL_BUDGET),
+            #[cfg(any(test, feature = "bench-internals"))]
+            max_gap: std::time::Duration::ZERO,
+            #[cfg(any(test, feature = "bench-internals"))]
+            serviced: 0,
+        })));
+        self.replacement_checkpoint(true);
+        self.record_replacement_capacities();
+        let result = work(self);
+        self.record_replacement_capacities();
+        self.replacement_checkpoint_at("terminal_cleanup", true);
+        let context = self
+            .replacement_readiness
+            .take()
+            .expect("replacement scope retains its readiness context");
+        debug_assert_eq!(
+            Arc::strong_count(&context),
+            1,
+            "readiness callback escaped its command frame"
+        );
+        let mut readiness = context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert_eq!(readiness.count, self.loc_rib.len());
+        self.readiness_rx = readiness.rx.take();
+        #[cfg(all(feature = "bench-internals", not(test)))]
+        info!(target: "replacement_readiness", count = readiness.count,
+            elapsed_us = readiness.started.elapsed().as_micros(),
+            max_gap_us = readiness.max_gap.as_micros(), serviced = readiness.serviced,
+            "replacement readiness scope finished");
+        #[cfg(all(feature = "bench-internals", not(test)))]
+        for (name, (len, capacity, slots)) in &readiness.capacities {
+            info!(target: "replacement_capacity", name, max_len = len, max_capacity = capacity,
+                max_raw_slots = slots, "replacement capacity maximum");
+        }
+        #[cfg(test)]
+        {
+            self.replacement_readiness_receipts
+                .push(ReplacementReadinessReceipt {
+                    count: readiness.count,
+                    elapsed: readiness.started.elapsed(),
+                    max_gap: readiness.max_gap,
+                    serviced: readiness.serviced,
+                });
+        }
+        result
+    }
+
+    fn replacement_checkpoint_at(&self, stage: &'static str, force: bool) {
+        replacement_readiness_checkpoint_at(&self.replacement_readiness, stage, force);
+    }
+
+    fn replacement_checkpoint(&self, force: bool) {
+        replacement_readiness_checkpoint(&self.replacement_readiness, force);
+    }
+
+    /// Aggregate capacity evidence within the owning command, never per route.
+    fn replacement_capacity(&self, name: &'static str, len: usize, capacity: usize) {
+        self.replacement_storage_shape(name, len, capacity, 0);
+    }
+
+    fn replacement_storage_shape(
+        &self,
+        name: &'static str,
+        len: usize,
+        capacity: usize,
+        slots: usize,
+    ) {
+        #[cfg(feature = "bench-internals")]
+        if let Some(context) = &self.replacement_readiness {
+            let mut context = context
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let maximum = context.capacities.entry(name).or_default();
+            maximum.0 = maximum.0.max(len);
+            maximum.1 = maximum.1.max(capacity);
+            maximum.2 = maximum.2.max(slots);
+        }
+        #[cfg(not(feature = "bench-internals"))]
+        let _ = (self, name, len, capacity, slots);
+    }
+
+    fn record_replacement_capacities(&self) {
+        #[cfg(not(feature = "bench-internals"))]
+        let _ = self;
+        #[cfg(feature = "bench-internals")]
+        if self.replacement_readiness.is_some() {
+            for group in self.group_ribs.values() {
+                let (len, slots, capacity) = group.table.bench_unicast_storage_shape();
+                self.replacement_storage_shape("group_unicast", len, capacity, slots);
+                let (len, capacity) = group.bench_otc_storage_shape();
+                self.replacement_capacity("group_otc", len, capacity);
+            }
+            for table in self.adj_ribs_out.values() {
+                let (len, slots, capacity) = table.bench_unicast_storage_shape();
+                self.replacement_storage_shape("private_unicast", len, capacity, slots);
+            }
+            for baseline in self.pending_regroup_baseline.values() {
+                self.replacement_capacity(
+                    "pending_baseline",
+                    baseline.unicast.len(),
+                    baseline.unicast.capacity(),
+                );
+            }
+            for pending in self.pending_otc_blocked.values() {
+                self.replacement_capacity("pending_otc", pending.len(), pending.capacity());
+            }
+        }
     }
 
     /// Test-only ADR-0078 fault injection: sleep before handling a
@@ -3155,31 +3430,38 @@ impl RibManager {
         prefixes: &HashSet<Prefix>,
         current: &HashSet<PolicyFilteredRouteKey>,
     ) {
+        let readiness = &self.replacement_readiness;
+        let checkpoint = || replacement_readiness_checkpoint(readiness, false);
         let peer_routes = self.policy_filtered_routes.entry(target_peer).or_default();
-        let previous = peer_routes
-            .iter()
-            .copied()
-            .filter(|key| prefixes.contains(&key.prefix))
-            .collect::<Vec<_>>();
-
-        for key in previous {
-            if !current.contains(&key) {
-                peer_routes.remove(&key);
+        peer_routes.retain(|key| {
+            checkpoint();
+            !prefixes.contains(&key.prefix) || current.contains(key)
+        });
+        let required = peer_routes.len().saturating_add(current.len());
+        if required > peer_routes.capacity() {
+            checkpoint();
+            let mut replacement = HashSet::with_capacity(required);
+            for key in peer_routes.drain() {
+                replacement.insert(key);
+                checkpoint();
             }
+            drop(std::mem::replace(peer_routes, replacement));
+            checkpoint();
         }
-
-        let mut newly_filtered = Vec::new();
+        let mut newly_filtered = Vec::with_capacity(current.len());
+        checkpoint();
         for key in current.iter().copied() {
+            checkpoint();
             if peer_routes.insert(key) {
                 newly_filtered.push(key);
             }
         }
-
         if peer_routes.is_empty() {
             self.policy_filtered_routes.remove(&target_peer);
         }
-
-        for key in newly_filtered {
+        let mut newly_filtered = newly_filtered.into_iter();
+        for key in newly_filtered.by_ref() {
+            self.replacement_checkpoint(false);
             self.publish_route_event(RouteEvent {
                 event_id: 0,
                 event_type: RouteEventType::PolicyFiltered,
@@ -3192,10 +3474,15 @@ impl RibManager {
                 reason: "policy_denied".to_string(),
             });
         }
+        self.replacement_checkpoint(true);
+        drop(newly_filtered);
+        self.replacement_checkpoint(true);
     }
 
     pub(super) fn clear_policy_filtered_routes_for_peer(&mut self, target_peer: IpAddr) {
-        self.policy_filtered_routes.remove(&target_peer);
+        if let Some(mut routes) = self.policy_filtered_routes.remove(&target_peer) {
+            retire_hash_set(&mut routes, &mut || self.replacement_checkpoint(false));
+        }
     }
 
     fn publish_evpn_route_event(&mut self, event: crate::event::EvpnRouteEvent) {
@@ -3763,31 +4050,38 @@ impl RibManager {
                 self.drain_readiness_queries(Some(pending.elapsed()));
                 let kind = pending.poll_kind();
                 let started = std::time::Instant::now();
-                let policy_transition_elapsed = match self.advance_clean_policy_transition(pending)
+                let mut terminal_reply = None;
+                let policy_transition_elapsed = self.with_replacement_readiness_age(pending.elapsed(), |manager| { match manager.advance_clean_policy_transition(pending)
                 {
                     distribution::CleanPolicyTransitionAdvance::Continue(mut next) => {
-                        self.record_policy_transition_poll(kind, started.elapsed());
+                        manager.record_policy_transition_poll(kind, started.elapsed());
                         let member_count = next.member_count();
                         Self::warn_if_policy_transition_slow(&mut next, member_count);
                         let elapsed = next.elapsed();
-                        self.pending_clean_policy_transition = Some(next);
+                        manager.pending_clean_policy_transition = Some(next);
                         Some(elapsed)
                     }
                     distribution::CleanPolicyTransitionAdvance::Committed(mut done) => {
-                        self.record_policy_transition_poll(kind, started.elapsed());
+                        manager.record_policy_transition_poll(kind, started.elapsed());
                         let member_count = done.member_count();
                         Self::warn_if_policy_transition_slow(&mut done, member_count);
-                        self.finish_policy_transition_observability(
+                        manager.finish_policy_transition_observability(
                             RibPolicyTransitionOutcome::Committed,
                             done.member_count(),
                             done.elapsed(),
                         );
+                        done.retire_inputs(manager);
+                        let reply = done.take_reply();
                         drop(done);
+                        manager.replacement_checkpoint(true);
+                        if let Some(reply) = reply {
+                            terminal_reply = Some((reply, Ok(crate::update::ExportPolicyCohortOutcome::Committed)));
+                        }
                         None
                     }
                     distribution::CleanPolicyTransitionAdvance::Fallback(mut failed) => {
-                        let cleanup = failed.discard_uncommitted_transition(&mut self);
-                        self.record_policy_transition_poll(kind, started.elapsed());
+                        let cleanup = failed.discard_uncommitted_transition(manager);
+                        manager.record_policy_transition_poll(kind, started.elapsed());
                         let member_count = failed.member_count();
                         Self::warn_if_policy_transition_slow(&mut failed, member_count);
                         let outcome = if cleanup.is_ok() {
@@ -3795,20 +4089,26 @@ impl RibManager {
                         } else {
                             RibPolicyTransitionOutcome::FallbackCleanupError
                         };
-                        self.finish_policy_transition_observability(
+                        manager.finish_policy_transition_observability(
                             outcome,
                             member_count,
                             failed.elapsed(),
                         );
-                        if let Some(reply) = failed.take_reply() {
+                        let reply = failed.take_reply();
+                        drop(failed);
+                        manager.replacement_checkpoint(true);
+                        if let Some(reply) = reply {
                             let result = cleanup.map(|()| {
                                 crate::update::ExportPolicyCohortOutcome::RequiresAuthoritativePerPeerApply
                             });
-                            let _ = reply.send(result);
+                            terminal_reply = Some((reply, result));
                         }
                         None
                     }
-                };
+                } });
+                if let Some((reply, result)) = terminal_reply {
+                    let _ = reply.send(result);
+                }
                 self.drain_readiness_queries(policy_transition_elapsed);
                 tokio::task::yield_now().await;
                 continue;

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -45,9 +45,11 @@ use tracing::{debug, info, warn};
 /// Release owned temporary elements while the actor still owns readiness.
 fn retire_vec<T>(values: &mut Vec<T>, checkpoint: &mut impl FnMut()) {
     checkpoint();
-    while let Some(value) = values.pop() {
-        drop(value);
-        checkpoint();
+    if std::mem::needs_drop::<T>() {
+        while let Some(value) = values.pop() {
+            drop(value);
+            checkpoint();
+        }
     }
     drop(std::mem::take(values));
     checkpoint();
@@ -58,9 +60,11 @@ fn retire_hash_set<T, S: BuildHasher + Default>(
     checkpoint: &mut impl FnMut(),
 ) {
     checkpoint();
-    for value in values.drain() {
-        drop(value);
-        checkpoint();
+    if std::mem::needs_drop::<T>() {
+        for value in values.drain() {
+            drop(value);
+            checkpoint();
+        }
     }
     drop(std::mem::take(values));
     checkpoint();

--- a/crates/rib/src/manager/outbound_prefix_limits.rs
+++ b/crates/rib/src/manager/outbound_prefix_limits.rs
@@ -150,6 +150,44 @@ impl OutboundPrefixLimits {
         }
     }
 
+    fn reserve_grouped_with_checkpoint(
+        &mut self,
+        afi: Afi,
+        additional: usize,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        let capacity = self.grouped_len(afi).saturating_add(additional);
+        checkpoint();
+        let replacement = match afi {
+            Afi::Ipv4 if self.grouped_admitted_ipv4.capacity() < capacity => {
+                Some(TypedGroupedAdmitted::collect_with_capacity(
+                    afi,
+                    self.grouped_admitted_ipv4
+                        .drain()
+                        .inspect(|_| checkpoint())
+                        .map(Prefix::V4),
+                    capacity,
+                ))
+            }
+            Afi::Ipv6 if self.grouped_admitted_ipv6.capacity() < capacity => {
+                Some(TypedGroupedAdmitted::collect_with_capacity(
+                    afi,
+                    self.grouped_admitted_ipv6
+                        .drain()
+                        .inspect(|_| checkpoint())
+                        .map(Prefix::V6),
+                    capacity,
+                ))
+            }
+            _ => None,
+        };
+        checkpoint();
+        if let Some(replacement) = replacement {
+            self.replace_grouped_with_checkpoint(replacement, checkpoint);
+        }
+        checkpoint();
+    }
+
     /// Release retained grouped ownership for one family.
     pub(in crate::manager) fn grouped_clear(&mut self, afi: Afi) {
         match afi {
@@ -161,10 +199,24 @@ impl OutboundPrefixLimits {
 
     /// Install a directly collected family-typed materialization.
     fn replace_grouped(&mut self, admitted: TypedGroupedAdmitted) {
-        match admitted {
-            TypedGroupedAdmitted::Ipv4(prefixes) => self.grouped_admitted_ipv4 = prefixes,
-            TypedGroupedAdmitted::Ipv6(prefixes) => self.grouped_admitted_ipv6 = prefixes,
-        }
+        self.replace_grouped_with_checkpoint(admitted, &mut || {});
+    }
+
+    fn replace_grouped_with_checkpoint(
+        &mut self,
+        admitted: TypedGroupedAdmitted,
+        checkpoint: &mut impl FnMut(),
+    ) {
+        let mut retired =
+            match admitted {
+                TypedGroupedAdmitted::Ipv4(prefixes) => TypedGroupedAdmitted::Ipv4(
+                    std::mem::replace(&mut self.grouped_admitted_ipv4, prefixes),
+                ),
+                TypedGroupedAdmitted::Ipv6(prefixes) => TypedGroupedAdmitted::Ipv6(
+                    std::mem::replace(&mut self.grouped_admitted_ipv6, prefixes),
+                ),
+            };
+        retired.retire_with(checkpoint);
     }
 }
 
@@ -177,26 +229,39 @@ enum TypedGroupedAdmitted {
 
 impl TypedGroupedAdmitted {
     fn collect(afi: Afi, prefixes: impl IntoIterator<Item = Prefix>) -> Self {
+        Self::collect_with_capacity(afi, prefixes, 0)
+    }
+
+    fn collect_with_capacity(
+        afi: Afi,
+        prefixes: impl IntoIterator<Item = Prefix>,
+        capacity: usize,
+    ) -> Self {
         match afi {
-            Afi::Ipv4 => Self::Ipv4(
-                prefixes
-                    .into_iter()
-                    .filter_map(|prefix| match prefix {
-                        Prefix::V4(prefix) => Some(prefix),
-                        Prefix::V6(_) => None,
-                    })
-                    .collect(),
-            ),
-            Afi::Ipv6 => Self::Ipv6(
-                prefixes
-                    .into_iter()
-                    .filter_map(|prefix| match prefix {
-                        Prefix::V6(prefix) => Some(prefix),
-                        Prefix::V4(_) => None,
-                    })
-                    .collect(),
-            ),
+            Afi::Ipv4 => {
+                let mut admitted = HashSet::with_capacity(capacity);
+                admitted.extend(prefixes.into_iter().filter_map(|prefix| match prefix {
+                    Prefix::V4(prefix) => Some(prefix),
+                    Prefix::V6(_) => None,
+                }));
+                Self::Ipv4(admitted)
+            }
+            Afi::Ipv6 => {
+                let mut admitted = HashSet::with_capacity(capacity);
+                admitted.extend(prefixes.into_iter().filter_map(|prefix| match prefix {
+                    Prefix::V6(prefix) => Some(prefix),
+                    Prefix::V4(_) => None,
+                }));
+                Self::Ipv6(admitted)
+            }
             _ => unreachable!("only limited unicast families are materialized"),
+        }
+    }
+
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        match self {
+            Self::Ipv4(prefixes) => super::retire_hash_set(prefixes, checkpoint),
+            Self::Ipv6(prefixes) => super::retire_hash_set(prefixes, checkpoint),
         }
     }
 
@@ -294,6 +359,7 @@ pub(in crate::manager) struct BatchAdmission {
 /// cap. An announcement for a prefix still admitted after the withdrawals
 /// always passes — an attribute change or an additional path identity for an
 /// admitted prefix is an update, not a new prefix.
+#[cfg(test)]
 pub(in crate::manager) fn admit_batch<'a>(
     limit: NonZeroU32,
     usage: usize,
@@ -301,9 +367,26 @@ pub(in crate::manager) fn admit_batch<'a>(
     announced: impl IntoIterator<Item = &'a Prefix>,
     is_admitted: impl Fn(&Prefix) -> bool,
 ) -> BatchAdmission {
+    admit_batch_into(
+        limit,
+        usage,
+        freed,
+        announced,
+        is_admitted,
+        BatchAdmission::default(),
+    )
+}
+
+fn admit_batch_into<'a>(
+    limit: NonZeroU32,
+    usage: usize,
+    freed: &HashSet<Prefix>,
+    announced: impl IntoIterator<Item = &'a Prefix>,
+    is_admitted: impl Fn(&Prefix) -> bool,
+    mut verdict: BatchAdmission,
+) -> BatchAdmission {
     let limit = usize::try_from(limit.get()).unwrap_or(usize::MAX);
     let mut usage = usage.saturating_sub(freed.len());
-    let mut verdict = BatchAdmission::default();
     for prefix in announced {
         if verdict.admitted.contains(prefix) || verdict.blocked.contains(prefix) {
             continue;
@@ -333,6 +416,14 @@ struct FamilyVerdict {
     verdict: BatchAdmission,
 }
 
+impl FamilyVerdict {
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        super::retire_hash_set(&mut self.freed, checkpoint);
+        super::retire_hash_set(&mut self.verdict.admitted, checkpoint);
+        super::retire_hash_set(&mut self.verdict.blocked, checkpoint);
+    }
+}
+
 impl RibManager {
     /// Resolve one batch against every limited family of `peer`, reading the
     /// advertised state that decides admission but mutating nothing.
@@ -342,6 +433,10 @@ impl RibManager {
     /// path per prefix. An ungrouped peer reads its private Adj-RIB-Out,
     /// which does refcount path identities — there a prefix frees its slot
     /// only when its LAST advertised path leaves.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "family admission sizes its withdrawal and verdict inventories before checkpointed fill and cleanup"
+    )]
     fn outbound_limit_verdicts(
         &self,
         peer: IpAddr,
@@ -353,59 +448,113 @@ impl RibManager {
         let Some(limits) = self.outbound_prefix_limits.get(&peer) else {
             return Vec::new();
         };
+        self.replacement_checkpoint(true);
         let rib_out = self.adj_ribs_out.get(&peer);
         let mut verdicts = Vec::new();
         for afi in LIMITED_FAMILIES {
             let Some(limit) = limits.family(afi).and_then(|family| family.limit) else {
                 continue;
             };
-            let advertised_paths = |prefix: &Prefix| {
-                rib_out
-                    .map(|rib| rib.path_ids_for_prefix(prefix))
-                    .unwrap_or_default()
-            };
             let is_admitted = |prefix: &Prefix| {
                 if grouped {
                     limits.grouped_contains(prefix)
                 } else {
-                    !advertised_paths(prefix).is_empty()
+                    rib_out.is_some_and(|rib| rib.iter_prefix(prefix).next().is_some())
                 }
             };
-            let mut withdrawn: HashMap<Prefix, HashSet<u32>> = HashMap::new();
-            for (prefix, path_id) in withdraw {
+            self.replacement_checkpoint(true);
+            let mut withdrawn: HashMap<Prefix, (usize, HashSet<u32>)> =
+                HashMap::with_capacity(withdraw.len());
+            self.replacement_checkpoint(true);
+            for (prefix, _) in withdraw {
+                self.replacement_checkpoint(false);
                 if prefix_family(prefix).0 == afi {
-                    withdrawn.entry(*prefix).or_default().insert(*path_id);
+                    withdrawn.entry(*prefix).or_default().0 += 1;
                 }
             }
-            let freed: HashSet<Prefix> = withdrawn
-                .into_iter()
-                .filter(|(prefix, path_ids)| {
-                    if grouped {
-                        is_admitted(prefix)
-                    } else {
-                        let advertised = advertised_paths(prefix);
-                        !advertised.is_empty() && advertised.iter().all(|id| path_ids.contains(id))
-                    }
-                })
-                .map(|(prefix, _)| prefix)
-                .collect();
+            for (count, path_ids) in withdrawn.values_mut() {
+                self.replacement_checkpoint(true);
+                *path_ids = HashSet::with_capacity(*count);
+                self.replacement_checkpoint(true);
+            }
+            for (prefix, path_id) in withdraw {
+                self.replacement_checkpoint(false);
+                if let Some((_, path_ids)) = withdrawn.get_mut(prefix) {
+                    path_ids.insert(*path_id);
+                }
+            }
+            self.replacement_checkpoint(true);
+            let mut freed = HashSet::with_capacity(withdrawn.len());
+            self.replacement_checkpoint(true);
+            for (prefix, (_, mut path_ids)) in withdrawn.drain() {
+                self.replacement_checkpoint(false);
+                let frees_prefix = if grouped {
+                    is_admitted(&prefix)
+                } else {
+                    rib_out.is_some_and(|rib| {
+                        // Borrow each path so a large Add-Path inventory stays checkpointed.
+                        let mut advertised = rib.iter_prefix(&prefix).peekable();
+                        advertised.peek().is_some()
+                            && advertised.all(|route| {
+                                self.replacement_checkpoint(false);
+                                path_ids.contains(&route.path_id)
+                            })
+                    })
+                };
+                if frees_prefix {
+                    freed.insert(prefix);
+                }
+                self.replacement_checkpoint(true);
+                super::retire_hash_set(&mut path_ids, &mut || self.replacement_checkpoint(false));
+                self.replacement_checkpoint(true);
+            }
+            self.replacement_checkpoint(true);
+            drop(withdrawn);
+            self.replacement_checkpoint(true);
             let usage = if grouped {
                 limits.grouped_len(afi)
             } else {
                 rib_out.map_or(0, |rib| rib.unicast_prefix_count(afi))
             };
-            let verdict = admit_batch(
+            let headroom = usize::try_from(limit.get())
+                .unwrap_or(usize::MAX)
+                .saturating_sub(usage.saturating_sub(freed.len()));
+            self.replacement_checkpoint(true);
+            let admitted = HashSet::with_capacity(announce.len().min(headroom));
+            self.replacement_checkpoint(true);
+            let blocked = HashSet::with_capacity(announce.len().saturating_sub(headroom));
+            self.replacement_checkpoint(true);
+            let mut verdict = admit_batch_into(
                 limit,
                 usage,
                 &freed,
                 announce
                     .iter()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint_at(
+                            &self.replacement_readiness,
+                            "outbound_limits",
+                            false,
+                        );
+                    })
                     .filter(|route| announce_source_exclusion != Some(route.peer))
                     .map(|route| &route.prefix)
                     .filter(|prefix| prefix_family(prefix).0 == afi),
                 is_admitted,
+                BatchAdmission { blocked, admitted },
             );
             if freed.is_empty() && verdict.admitted.is_empty() && verdict.blocked.is_empty() {
+                self.replacement_checkpoint(true);
+                super::retire_hash_set(&mut freed, &mut || self.replacement_checkpoint(false));
+                self.replacement_checkpoint(true);
+                super::retire_hash_set(&mut verdict.admitted, &mut || {
+                    self.replacement_checkpoint(false);
+                });
+                self.replacement_checkpoint(true);
+                super::retire_hash_set(&mut verdict.blocked, &mut || {
+                    self.replacement_checkpoint(false);
+                });
+                self.replacement_checkpoint(true);
                 continue;
             }
             verdicts.push(FamilyVerdict {
@@ -416,6 +565,7 @@ impl RibManager {
                 freed,
             });
         }
+        self.replacement_checkpoint(true);
         verdicts
     }
 
@@ -435,6 +585,10 @@ impl RibManager {
     /// NOTIFICATION is sent.
     ///
     /// Returns immediately for a peer with no configured limit.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "prefix-limit commit keeps aligned filtering, admission ownership, and checkpointed cleanup together"
+    )]
     pub(super) fn enforce_outbound_prefix_limits(
         &mut self,
         peer: IpAddr,
@@ -444,7 +598,9 @@ impl RibManager {
         next_hop_override: &mut Arc<[Option<rustbgpd_policy::NextHopAction>]>,
         withdraw: &[(Prefix, u32)],
     ) -> bool {
-        let verdicts = self.outbound_limit_verdicts(
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        let mut verdicts = self.outbound_limit_verdicts(
             peer,
             grouped,
             announce_source_exclusion,
@@ -455,35 +611,92 @@ impl RibManager {
             return false;
         }
 
-        let blocked: HashSet<Prefix> = verdicts
-            .iter()
-            .flat_map(|family| family.verdict.blocked.iter().copied())
-            .collect();
+        self.replacement_checkpoint(true);
+        let mut blocked = HashSet::with_capacity(
+            verdicts
+                .iter()
+                .map(|family| family.verdict.blocked.len())
+                .sum(),
+        );
+        self.replacement_checkpoint(true);
+        blocked.extend(verdicts.iter().flat_map(|family| {
+            family
+                .verdict
+                .blocked
+                .iter()
+                .inspect(|_| checkpoint())
+                .copied()
+        }));
         if !blocked.is_empty() {
-            let (kept_routes, kept_next_hops): (Vec<_>, Vec<_>) = announce
+            let keep = |route: &crate::route::Route| {
+                announce_source_exclusion == Some(route.peer) || !blocked.contains(&route.prefix)
+            };
+            let kept = announce
                 .iter()
                 .zip(next_hop_override.iter())
-                .filter(|(route, _)| {
-                    announce_source_exclusion == Some(route.peer)
-                        || !blocked.contains(&route.prefix)
-                })
-                .map(|(route, next_hop)| (route.clone(), next_hop.clone()))
-                .unzip();
-            *announce = kept_routes.into();
-            *next_hop_override = kept_next_hops.into();
+                .inspect(|_| checkpoint())
+                .filter(|(route, _)| keep(route))
+                .count();
+            self.replacement_checkpoint(true);
+            let mut kept_routes = Vec::with_capacity(kept);
+            self.replacement_checkpoint(true);
+            let mut kept_next_hops = Vec::with_capacity(kept);
+            self.replacement_checkpoint(true);
+            for (route, next_hop) in announce.iter().zip(next_hop_override.iter()) {
+                checkpoint();
+                if keep(route) {
+                    kept_routes.push(route.clone());
+                    kept_next_hops.push(next_hop.clone());
+                }
+            }
+            self.replacement_checkpoint(true);
+            let retired = std::mem::replace(announce, kept_routes.into());
+            self.replacement_checkpoint(true);
+            drop(retired);
+            self.replacement_checkpoint(true);
+            let retired = std::mem::replace(next_hop_override, kept_next_hops.into());
+            self.replacement_checkpoint(true);
+            drop(retired);
+            self.replacement_checkpoint(true);
         }
 
         // One record per family: (afi, prefixes blocked, episode transition).
         let mut episodes: Vec<(Afi, usize, Option<bool>)> = Vec::new();
         let Some(limits) = self.outbound_prefix_limits.get_mut(&peer) else {
+            for verdict in &mut verdicts {
+                self.replacement_checkpoint(true);
+                verdict.retire_with(&mut checkpoint);
+                self.replacement_checkpoint(true);
+            }
+            super::retire_vec(&mut verdicts, &mut checkpoint);
+            self.replacement_checkpoint(true);
+            super::retire_hash_set(&mut blocked, &mut checkpoint);
+            self.replacement_checkpoint(true);
             return false;
         };
-        for family_verdict in verdicts {
+        for family_verdict in &mut verdicts {
+            checkpoint();
             if grouped {
                 for prefix in &family_verdict.freed {
+                    checkpoint();
                     limits.grouped_remove(prefix);
                 }
-                limits.grouped_extend(family_verdict.afi, family_verdict.verdict.admitted);
+                super::replacement_readiness_checkpoint(&readiness, true);
+                limits.reserve_grouped_with_checkpoint(
+                    family_verdict.afi,
+                    family_verdict.verdict.admitted.len(),
+                    &mut checkpoint,
+                );
+                super::replacement_readiness_checkpoint(&readiness, true);
+                limits.grouped_extend(
+                    family_verdict.afi,
+                    family_verdict
+                        .verdict
+                        .admitted
+                        .iter()
+                        .inspect(|_| checkpoint())
+                        .copied(),
+                );
             }
             let Some(family) = limits.family_mut(family_verdict.afi) else {
                 continue;
@@ -504,6 +717,13 @@ impl RibManager {
             episodes.push((family_verdict.afi, blocked, transition));
         }
 
+        for verdict in &mut verdicts {
+            self.replacement_checkpoint(true);
+            verdict.retire_with(&mut checkpoint);
+            self.replacement_checkpoint(true);
+        }
+        super::retire_vec(&mut verdicts, &mut checkpoint);
+        self.replacement_checkpoint(true);
         let peer_label = peer.to_string();
         for (afi, blocked, transition) in episodes {
             let family = family_label(afi);
@@ -538,7 +758,11 @@ impl RibManager {
         // Adj-RIB-Out commit, so an ungrouped peer's usage would still read
         // the pre-batch count. The commit path refreshes them from the same
         // admitted truth the API reports, once that truth exists.
-        !blocked.is_empty()
+        let filtered = !blocked.is_empty();
+        self.replacement_checkpoint(true);
+        super::retire_hash_set(&mut blocked, &mut checkpoint);
+        self.replacement_checkpoint(true);
+        filtered
     }
 
     /// Distinct admitted prefixes for one limited family.
@@ -630,8 +854,10 @@ impl RibManager {
     /// API reports. A family that became unlimited drops its limit and
     /// headroom series instead of keeping a stale finite value.
     pub(in crate::manager) fn refresh_outbound_limit_gauges(&mut self, peer: IpAddr) {
+        self.replacement_checkpoint(true);
         let peer_label = peer.to_string();
         for row in self.outbound_prefix_limit_rows(peer) {
+            self.replacement_checkpoint(false);
             self.metrics.set_outbound_prefix_capacity(
                 &peer_label,
                 &row.family,
@@ -640,6 +866,7 @@ impl RibManager {
                 row.blocking,
             );
         }
+        self.replacement_checkpoint(true);
     }
 
     /// Install this registration's effective limits before its initial feed
@@ -1081,32 +1308,58 @@ impl RibManager {
         if !self.outbound_prefix_limits.contains_key(&peer) {
             return;
         }
-        let seeded: Vec<TypedGroupedAdmitted> = LIMITED_FAMILIES
+        self.replacement_checkpoint(true);
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        let mut seeded: Vec<TypedGroupedAdmitted> = LIMITED_FAMILIES
             .into_iter()
             .map(|afi| {
-                if entering_group {
+                super::replacement_readiness_checkpoint(&readiness, true);
+                let admitted = if entering_group {
                     self.adj_ribs_out.get(&peer).map_or_else(
                         || TypedGroupedAdmitted::collect(afi, std::iter::empty()),
                         |rib| {
-                            TypedGroupedAdmitted::collect(afi, rib.iter().map(|route| route.prefix))
+                            TypedGroupedAdmitted::collect_with_capacity(
+                                afi,
+                                rib.iter()
+                                    .inspect(|_| checkpoint())
+                                    .map(|route| route.prefix),
+                                rib.unicast_prefix_count(afi),
+                            )
                         },
                     )
                 } else {
                     TypedGroupedAdmitted::collect(afi, std::iter::empty())
-                }
+                };
+                super::replacement_readiness_checkpoint(&readiness, true);
+                admitted
             })
             .collect();
+        self.replacement_checkpoint(true);
         let Some(entry) = self.outbound_prefix_limits.get_mut(&peer) else {
+            for admitted in &mut seeded {
+                admitted.retire_with(&mut checkpoint);
+            }
+            super::retire_vec(&mut seeded, &mut checkpoint);
+            self.replacement_checkpoint(true);
             return;
         };
-        for admitted in seeded {
+        for mut admitted in seeded.drain(..) {
+            checkpoint();
             let afi = admitted.afi();
             let limited = entry
                 .family(afi)
                 .is_some_and(|family| family.limit.is_some());
+            super::replacement_readiness_checkpoint(&readiness, true);
             if limited {
-                entry.replace_grouped(admitted);
+                entry.replace_grouped_with_checkpoint(admitted, &mut checkpoint);
+            } else {
+                admitted.retire_with(&mut checkpoint);
             }
+            super::replacement_readiness_checkpoint(&readiness, true);
         }
+        self.replacement_checkpoint(true);
+        drop(seeded);
+        self.replacement_checkpoint(true);
     }
 }

--- a/crates/rib/src/manager/route_refresh.rs
+++ b/crates/rib/src/manager/route_refresh.rs
@@ -706,6 +706,7 @@ impl RibManager {
         safi: Safi,
         replay_kind: FamilyReplayKind,
     ) -> FamilyReplayOutcome {
+        self.replacement_checkpoint(true);
         let family = (afi, safi);
         let (suppress_eor, deferred_eor) = match replay_kind {
             FamilyReplayKind::PeerRefresh { suppress_eor } => {
@@ -805,12 +806,23 @@ impl RibManager {
         let mut all_prefixes: HashSet<Prefix> = self
             .loc_rib
             .iter()
+            .inspect(|_| {
+                super::replacement_readiness_checkpoint_at(
+                    &self.replacement_readiness,
+                    "refresh",
+                    false,
+                );
+            })
             .map(|r| r.prefix)
             .filter(|p| prefix_family(p) == family)
             .collect();
         for rib in self.ribs.values() {
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
             all_prefixes.extend(
                 rib.iter()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
                     .map(|r| r.prefix)
                     .filter(|p| prefix_family(p) == family),
             );
@@ -819,6 +831,9 @@ impl RibManager {
             all_prefixes.extend(
                 blocked
                     .keys()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
                     .filter(|prefix| prefix_family(prefix) == family)
                     .copied(),
             );
@@ -832,14 +847,17 @@ impl RibManager {
         let mut grouped_otc_blocked = Vec::new();
 
         if safi == Safi::FlowSpec {
-            let flow_rules: HashSet<FlowSpecKey> = self
+            let mut flow_rules: HashSet<FlowSpecKey> = self
                 .loc_rib
                 .iter_flowspec()
+                .inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                })
                 .filter(|route| route.afi == afi)
                 .map(FlowSpecRoute::selection_key)
                 .collect();
             if !flow_rules.is_empty() {
-                Self::stage_flowspec_rules(
+                Self::stage_flowspec_rules_with_checkpoint(
                     loc_rib,
                     &refresh_view,
                     &self.peer_is_rr_client,
@@ -859,16 +877,27 @@ impl RibManager {
                     &target_peer_label,
                     &mut fs_announce,
                     &mut fs_withdraw,
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
                 );
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut flow_rules, &mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         } else if (afi, safi) == (Afi::L2Vpn, Safi::Evpn) {
-            let evpn_keys: HashSet<EvpnRouteKey> = self
+            let mut evpn_keys: HashSet<EvpnRouteKey> = self
                 .loc_rib
                 .iter_evpn()
+                .inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                })
                 .map(crate::route::EvpnRibRoute::key)
                 .collect();
             if !evpn_keys.is_empty() {
-                Self::stage_evpn_routes(
+                Self::stage_evpn_routes_with_checkpoint(
                     loc_rib,
                     &refresh_view,
                     &self.peer_is_rr_client,
@@ -891,17 +920,28 @@ impl RibManager {
                     &mut evpn_announce,
                     &mut evpn_withdraw,
                     false, // route refresh re-emits via empty refresh_view
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
                 );
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut evpn_keys, &mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         } else if let Some(bgpls_family) = BgpLsFamily::from_afi_safi(afi, safi) {
-            let bgpls_keys: HashSet<crate::route::BgpLsRouteKey> = self
+            let mut bgpls_keys: HashSet<crate::route::BgpLsRouteKey> = self
                 .loc_rib
                 .iter_bgpls()
+                .inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                })
                 .filter(|route| route.family == bgpls_family)
                 .map(crate::route::BgpLsRibRoute::key)
                 .collect();
             if !bgpls_keys.is_empty() {
-                Self::stage_bgpls_routes(
+                Self::stage_bgpls_routes_with_checkpoint(
                     loc_rib,
                     &refresh_view,
                     &self.peer_is_rr_client,
@@ -922,8 +962,16 @@ impl RibManager {
                     &mut bgpls_announce,
                     &mut bgpls_withdraw,
                     false, // route refresh re-emits via empty refresh_view
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
                 );
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut bgpls_keys, &mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         } else if safi == Safi::MplsVpn {
             // A member of a VPN-staging group replays the refreshed
             // family from the group table — own-sourced excluded,
@@ -934,7 +982,9 @@ impl RibManager {
             // below).
             if let Some(gid) = vpn_member_of {
                 if let Some(group) = self.group_ribs.get(&gid) {
-                    for route in group.table.iter_vpn() {
+                    for route in group.table.iter_vpn().inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    }) {
                         if route.peer == peer
                             || route.afi_safi() != family
                             || !super::update_groups::rt_passes(rtc_filter.as_ref(), route)
@@ -952,6 +1002,9 @@ impl RibManager {
                 let mut vpn_keys: HashSet<rustbgpd_wire::VpnRouteKey> = self
                     .loc_rib
                     .iter_vpn()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
                     .filter(|route| route.afi_safi() == family)
                     .map(|route| route.nlri.key())
                     .collect();
@@ -960,11 +1013,24 @@ impl RibManager {
                 if peer_add_path_send_max > 0
                     && peer_add_path_send_families
                         .iter()
+                        .inspect(|_| {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        })
                         .any(|(_, safi)| *safi == Safi::MplsVpn)
                 {
                     for rib in self.ribs.values() {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
                         vpn_keys.extend(
                             rib.iter_vpn()
+                                .inspect(|_| {
+                                    super::replacement_readiness_checkpoint(
+                                        &self.replacement_readiness,
+                                        false,
+                                    );
+                                })
                                 .filter(|route| route.afi_safi() == family)
                                 .map(|route| route.nlri.key()),
                         );
@@ -997,20 +1063,34 @@ impl RibManager {
                         policy_stats: &mut *policy_stats,
                         peer_label: &target_peer_label,
                     };
-                    Self::stage_vpn_routes(
+                    Self::stage_vpn_routes_with_checkpoint(
                         &context,
                         &vpn_keys,
                         &mut target,
                         rtc_filter.as_ref(),
                         &mut vpn_announce,
                         &mut vpn_withdraw,
+                        &mut || {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        },
                     );
                 }
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+                super::retire_hash_set(&mut vpn_keys, &mut || {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                });
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
             }
         } else if safi == Safi::LabeledUnicast {
             let mut labeled_keys: HashSet<Prefix> = self
                 .loc_rib
                 .iter_labeled()
+                .inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                })
                 .filter(|route| route.afi_safi() == family)
                 .map(|route| route.nlri.key())
                 .collect();
@@ -1019,11 +1099,21 @@ impl RibManager {
             if peer_add_path_send_max > 0
                 && peer_add_path_send_families
                     .iter()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
                     .any(|(_, safi)| *safi == Safi::LabeledUnicast)
             {
                 for rib in self.ribs.values() {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
                     labeled_keys.extend(
                         rib.iter_labeled()
+                            .inspect(|_| {
+                                super::replacement_readiness_checkpoint(
+                                    &self.replacement_readiness,
+                                    false,
+                                );
+                            })
                             .filter(|route| route.afi_safi() == family)
                             .map(|route| route.nlri.key()),
                     );
@@ -1056,22 +1146,33 @@ impl RibManager {
                     policy_stats: &mut *policy_stats,
                     peer_label: &target_peer_label,
                 };
-                Self::stage_labeled_routes(
+                Self::stage_labeled_routes_with_checkpoint(
                     &context,
                     &labeled_keys,
                     &mut target,
                     &mut labeled_announce,
                     &mut labeled_withdraw,
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
                 );
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut labeled_keys, &mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         } else if safi == Safi::RtConstrain {
-            let rtc_keys: HashSet<crate::route::RtcRibRouteKey> = self
+            let mut rtc_keys: HashSet<crate::route::RtcRibRouteKey> = self
                 .loc_rib
                 .iter_rtc()
+                .inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                })
                 .map(crate::route::RtcRibRoute::key)
                 .collect();
             if !rtc_keys.is_empty() {
-                Self::stage_rtc_routes(
+                Self::stage_rtc_routes_with_checkpoint(
                     loc_rib,
                     &refresh_view,
                     &self.peer_is_rr_client,
@@ -1092,8 +1193,16 @@ impl RibManager {
                     &mut rtc_announce,
                     &mut rtc_withdraw,
                     false, // route refresh re-emits via empty refresh_view
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
                 );
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut rtc_keys, &mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         } else if let Some(gid) = member_of {
             // A grouped member's refresh replay comes from the group
             // table — family-filtered, the member's derived view — with
@@ -1109,7 +1218,9 @@ impl RibManager {
                 // tagged entries rewritten per target (prepend from the
                 // captured source, scrub post-policy).
                 let rs_control = rs_control_asn.zip(target_peer_asn);
-                for staged in group.table.iter() {
+                for staged in group.table.iter().inspect(|_| {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                }) {
                     if prefix_family(&staged.prefix) != family {
                         continue;
                     }
@@ -1140,9 +1251,25 @@ impl RibManager {
                     );
                     unicast.announce.push(route);
                 }
-                current_policy_filtered_routes
-                    .extend(group.policy_filtered_for_member(peer, &all_prefixes));
-                grouped_otc_blocked = group.otc_blocked_for_member(peer, Some(&all_prefixes));
+                let mut filtered = group
+                    .policy_filtered_for_member_with_checkpoint(peer, &all_prefixes, &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
+                    .into_iter();
+                for key in filtered.by_ref() {
+                    super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    current_policy_filtered_routes.insert(key);
+                }
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+                drop(filtered);
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+                grouped_otc_blocked = group.otc_blocked_for_member_with_checkpoint(
+                    peer,
+                    Some(&all_prefixes),
+                    &mut || {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    },
+                );
             }
             // Export counters for the replayed family, from the group's
             // staged residue (per-peer refresh re-eval parity).
@@ -1153,6 +1280,7 @@ impl RibManager {
             // post-modification attributes and AS_PATH match string.
             let mut export_memo = super::distribution::ExportMemo::default();
             for prefix in &all_prefixes {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
                 let prefix_family = prefix_family(prefix);
                 let prefix_send_max = if peer_add_path_send_families.contains(&prefix_family) {
                     peer_add_path_send_limits
@@ -1163,7 +1291,7 @@ impl RibManager {
                     0
                 };
                 if prefix_send_max > 0 {
-                    Self::distribute_multipath_prefix(
+                    Self::distribute_multipath_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         &refresh_view,
@@ -1190,9 +1318,13 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         false, // route refresh re-emits all anyway via empty refresh_view
+                        &mut || {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        },
                     );
-                    current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if per_client_best {
                     // RFC 7947 §2.3.2 per-client best-path: the refresh
                     // replay re-derives the same filtered best the live
@@ -1200,7 +1332,7 @@ impl RibManager {
                     // `send_initial_table` arm for the mode-precedence
                     // notes (Add-Path outranks; ORR cannot coexist).
                     debug_assert!(orr_ctx.is_none(), "ORR vantage on a per-client-best peer");
-                    Self::distribute_multipath_prefix(
+                    Self::distribute_multipath_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         &refresh_view,
@@ -1227,12 +1359,16 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         false, // route refresh re-emits all anyway via empty refresh_view
+                        &mut || {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        },
                     );
-                    current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else if let Some((orr_topology, orr_spf)) = orr_ctx {
                     // ORR peer with a resolved vantage: per-vantage best.
-                    Self::distribute_orr_best_prefix(
+                    Self::distribute_orr_best_prefix_with_checkpoint(
                         &self.ribs,
                         &self.unicast_prefix_peers,
                         &refresh_view,
@@ -1257,9 +1393,13 @@ impl RibManager {
                         &target_peer_label,
                         &mut unicast,
                         false,
+                        &mut || {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        },
                     );
-                    current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 } else {
                     let mut target = super::distribution::ExportTarget::Peer {
                         peer,
@@ -1269,7 +1409,7 @@ impl RibManager {
                         policy_stats: &mut *policy_stats,
                         peer_label: &target_peer_label,
                     };
-                    Self::distribute_single_best_prefix(
+                    Self::distribute_single_best_prefix_with_checkpoint(
                         loc_rib,
                         &refresh_view,
                         &self.peer_is_rr_client,
@@ -1287,10 +1427,17 @@ impl RibManager {
                         &mut export_memo,
                         &mut unicast,
                         false,
+                        &mut || {
+                            super::replacement_readiness_checkpoint(
+                                &self.replacement_readiness,
+                                false,
+                            );
+                        },
                     );
-                    current_policy_filtered_routes
-                        .extend(std::mem::take(&mut unicast.policy_filtered));
                 }
+                current_policy_filtered_routes.extend(unicast.policy_filtered.drain(..).inspect(
+                    |_| super::replacement_readiness_checkpoint(&self.replacement_readiness, false),
+                ));
             }
             // The refresh view is intentionally empty so permitted routes are
             // re-advertised for ROUTE-REFRESH. That empty view cannot discover
@@ -1302,42 +1449,115 @@ impl RibManager {
             {
                 for route in rib_out
                     .iter()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
                     .filter(|r| prefix_family(&r.prefix) == family && !filter.permits(&r.prefix))
                 {
                     unicast.withdraw.push((route.prefix, route.path_id));
                 }
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            #[cfg(feature = "bench-internals")]
+            export_memo.record_replacement_capacities(self);
+            export_memo.retire_with(&mut || {
+                super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         }
 
+        self.replacement_checkpoint(true);
         if member_of.is_some() {
             self.reconcile_peer_otc_blocked(peer, &all_prefixes, grouped_otc_blocked);
         }
 
         if !self.outbound_peers.contains_key(&peer) {
+            self.replacement_checkpoint(true);
+            unicast.retire_with(&mut || self.replacement_checkpoint(false));
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut fs_announce, &mut || self.replacement_checkpoint(false));
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut fs_withdraw, &mut || self.replacement_checkpoint(false));
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut evpn_announce, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut evpn_withdraw, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut bgpls_announce, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut bgpls_withdraw, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut vpn_announce, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut vpn_withdraw, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut labeled_announce, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut labeled_withdraw, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut rtc_announce, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_vec(&mut rtc_withdraw, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut all_prefixes, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut current_policy_filtered_routes, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            self.replacement_checkpoint(true);
             return FamilyReplayOutcome::Failed;
         }
         let mut group_prior = HashSet::new();
         if member_of.is_some()
             && let Some(routes) = self.grouped_advertised_routes(peer)
         {
-            group_prior.extend(
-                routes.into_iter().map(|route| {
-                    crate::update::ExactExportKey::Unicast(route.prefix, route.path_id)
-                }),
-            );
+            group_prior.extend(routes.into_iter().map(|route| {
+                self.replacement_checkpoint(false);
+                crate::update::ExactExportKey::Unicast(route.prefix, route.path_id)
+            }));
         }
         if let Some(gid) = vpn_member_of
             && let Some(group) = self.group_ribs.get(&gid)
         {
             let filter = self.member_rt_filter(peer);
             let rejected = self.peer_unexportable.get(&peer);
-            group_prior.extend(group.table.iter_vpn().filter_map(|route| {
-                let key = crate::update::ExactExportKey::Vpn(route.key());
-                (route.peer != peer
-                    && crate::manager::update_groups::rt_passes(filter.as_ref(), route)
-                    && !rejected.is_some_and(|keys| keys.contains(&key)))
-                .then_some(key)
-            }));
+            group_prior.extend(
+                group
+                    .table
+                    .iter_vpn()
+                    .inspect(|_| {
+                        super::replacement_readiness_checkpoint(&self.replacement_readiness, false);
+                    })
+                    .filter_map(|route| {
+                        let key = crate::update::ExactExportKey::Vpn(route.key());
+                        (route.peer != peer
+                            && crate::manager::update_groups::rt_passes(filter.as_ref(), route)
+                            && !rejected.is_some_and(|keys| keys.contains(&key)))
+                        .then_some(key)
+                    }),
+            );
         }
         let prior_blocking =
             matches!(replay_kind, FamilyReplayKind::PrefixLimitRecovery).then(|| {
@@ -1361,6 +1581,15 @@ impl RibManager {
                 (vec![], vec![])
             }
         };
+        self.replacement_checkpoint(true);
+        let announce = unicast.announce.into();
+        self.replacement_checkpoint(true);
+        let next_hop_override = unicast.next_hop_override.into();
+        self.replacement_checkpoint(true);
+        super::retire_vec(&mut unicast.policy_filtered, &mut || {
+            self.replacement_checkpoint(false);
+        });
+        super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
         if !self.try_send_and_commit_outbound_update_with_group_prior_and_otc_scope(
             peer,
             OutboundCommitBatch {
@@ -1379,10 +1608,7 @@ impl RibManager {
                 labeled_withdraw,
                 rtc_announce,
                 rtc_withdraw,
-                ..OutboundCommitBatch::with_unicast(
-                    unicast.announce.into(),
-                    unicast.next_hop_override.into(),
-                )
+                ..OutboundCommitBatch::with_unicast(announce, next_hop_override)
             },
             group_prior,
             None,
@@ -1405,6 +1631,15 @@ impl RibManager {
                     warn!(%peer, ?family, "outbound channel full during explicit outbound replay");
                 }
             }
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut all_prefixes, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+            super::retire_hash_set(&mut current_policy_filtered_routes, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            self.replacement_checkpoint(true);
             return FamilyReplayOutcome::Failed;
         }
         self.update_policy_filtered_routes_for_prefixes(
@@ -1436,6 +1671,15 @@ impl RibManager {
                 }
             }
         }
+        super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+        super::retire_hash_set(&mut all_prefixes, &mut || {
+            self.replacement_checkpoint(false);
+        });
+        super::replacement_readiness_checkpoint(&self.replacement_readiness, true);
+        super::retire_hash_set(&mut current_policy_filtered_routes, &mut || {
+            self.replacement_checkpoint(false);
+        });
+        self.replacement_checkpoint(true);
         FamilyReplayOutcome::Committed
     }
 
@@ -1472,11 +1716,14 @@ impl RibManager {
 
     /// Retry any deferred enhanced route refresh responses for a peer.
     pub(super) fn retry_pending_refresh(&mut self, peer: IpAddr) {
+        self.replacement_checkpoint(true);
         let Some(families) = self.pending_refresh.remove(&peer) else {
             return;
         };
         for (afi, safi) in families {
+            self.replacement_checkpoint(false);
             self.send_route_refresh_response(peer, afi, safi);
+            self.replacement_checkpoint(true);
         }
     }
 

--- a/crates/rib/src/manager/tests/exportability.rs
+++ b/crates/rib/src/manager/tests/exportability.rs
@@ -88,10 +88,19 @@ impl ExactExportSnapshot for MockExactExportSnapshot {
         &self,
         candidates: &[ExactExportCandidate<'_>],
     ) -> Vec<Result<ExactExportResult, ExactExportError>> {
+        self.probe_announcements_with_checkpoint(candidates, &mut || {})
+    }
+
+    fn probe_announcements_with_checkpoint(
+        &self,
+        candidates: &[ExactExportCandidate<'_>],
+        checkpoint: &mut dyn FnMut(),
+    ) -> Vec<Result<ExactExportResult, ExactExportError>> {
         self.probe_batches.fetch_add(1, Ordering::Relaxed);
         candidates
             .iter()
             .copied()
+            .inspect(|_| checkpoint())
             .map(|candidate| self.probe_announcement(candidate))
             .collect()
     }

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -4855,7 +4855,15 @@ fn step_parked_transition(manager: &mut RibManager) -> (&'static str, &'static s
             manager.pending_clean_policy_transition = Some(next);
             (kind, "continue")
         }
-        CleanPolicyTransitionAdvance::Committed(_) => (kind, "committed"),
+        CleanPolicyTransitionAdvance::Committed(mut done) => {
+            manager.with_replacement_readiness_age(done.elapsed(), |manager| {
+                done.retire_inputs(manager);
+            });
+            if let Some(reply) = done.take_reply() {
+                let _ = reply.send(Ok(crate::update::ExportPolicyCohortOutcome::Committed));
+            }
+            (kind, "committed")
+        }
         CleanPolicyTransitionAdvance::Fallback(mut failed) => {
             failed
                 .discard_uncommitted_transition(manager)
@@ -6722,6 +6730,724 @@ fn batched_pcb_fleet_n(export_policy: Option<&PolicyChain>, member_count: u16) -
 
 fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
     batched_pcb_fleet_n(export_policy, 4)
+}
+
+/// Four routes across both unicast families keep readiness counts distinct
+/// from either family's count without depending on scheduler timing.
+fn replacement_readiness_fleet(export_policy: &PolicyChain) -> BatchedPcbFleet {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut manager = RibManager::new(rx, dummy_query_rx(), None, None, BgpMetrics::new());
+    manager.flush_poll_budget = Duration::ZERO;
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let members: Vec<IpAddr> = (1..=4)
+        .map(|index| IpAddr::V4(Ipv4Addr::new(10, 54, 0, index)))
+        .collect();
+    let mut receivers = Vec::new();
+    for (index, &peer) in members.iter().enumerate() {
+        manager.handle_update(RibUpdate::SetPeerExportEncoder {
+            peer,
+            session_id: 0,
+            encoder: Arc::new(CohortExactEncoder {
+                owner: u64::try_from(index + 1).unwrap(),
+                profile: 54,
+                max_len: 4_096,
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&probes),
+                reuses: Arc::clone(&reuses),
+            }),
+        });
+        receivers.push(register_direct_peer_with_families(
+            &mut manager,
+            peer,
+            vec![(Afi::Ipv4, Safi::Unicast), (Afi::Ipv6, Safi::Unicast)],
+        ));
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 54);
+    let shared_prefix = Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24);
+    let mut announced = vec![
+        make_route(shared_prefix, source),
+        make_route(Ipv4Prefix::new(Ipv4Addr::new(198, 51, 100, 0), 24), source),
+    ];
+    for address in ["2001:db8:54::", "2001:db8:55::"] {
+        let mut route = make_v6_route(
+            Ipv6Prefix::new(address.parse().unwrap(), 48),
+            "2001:db8::54".parse().unwrap(),
+        );
+        route.peer = IpAddr::V4(source);
+        announced.push(route);
+    }
+    manager.handle_update(RibUpdate::RoutesReceived {
+        peer: IpAddr::V4(source),
+        session_id: 0,
+        announced,
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    });
+    while manager.process_next_route_chunk() {}
+    manager
+        .apply_export_policy_replacements_synchronously(batch_replacements(&members, export_policy))
+        .unwrap();
+    for receiver in &mut receivers {
+        while receiver.try_recv().is_ok() {}
+    }
+    assert_eq!(manager.loc_rib.len(), 4);
+    manager.replacement_readiness_receipts.clear();
+    BatchedPcbFleet {
+        manager,
+        members,
+        receivers,
+        shared_prefix,
+        probes,
+        reuses,
+    }
+}
+
+fn queue_replacement_readiness(
+    tx: &mpsc::Sender<crate::update::RibReadinessQuery>,
+) -> oneshot::Receiver<Result<usize, crate::update::RibReadinessError>> {
+    let (reply, response) = oneshot::channel();
+    tx.try_send(crate::update::RibReadinessQuery::LocRibCount { reply })
+        .unwrap();
+    response
+}
+
+#[test]
+fn replacement_readiness_nested_rollback_keeps_original_age_and_restores_receiver() {
+    let old = community_chain(0xFDE8_0001);
+    let next = community_chain(0xFDE8_0002);
+    let mut fleet = replacement_readiness_fleet(&old);
+    let (tx, rx) = mpsc::channel(8);
+    fleet.manager.readiness_rx = Some(rx);
+    fleet.manager.with_replacement_readiness_age(
+        super::super::MAX_HEALTHY_POLICY_TRANSITION_AGE,
+        |manager| {
+            let original = manager.replacement_readiness.clone().unwrap();
+            let mut response = queue_replacement_readiness(&tx);
+            manager.with_replacement_readiness_age(Duration::ZERO, |manager| {
+                assert!(Arc::ptr_eq(
+                    &original,
+                    manager.replacement_readiness.as_ref().unwrap()
+                ));
+                manager.replacement_checkpoint(true);
+                assert_eq!(
+                    response.try_recv().unwrap(),
+                    Err(crate::update::RibReadinessError::PolicyTransitionStalled)
+                );
+                manager
+                    .restore_export_policy_replacements_synchronously(batch_replacements(
+                        &fleet.members,
+                        &next,
+                    ))
+                    .unwrap();
+                assert!(manager.replacement_readiness_receipts.is_empty());
+                assert!(manager.readiness_rx.is_none());
+            });
+        },
+    );
+    assert!(fleet.manager.replacement_readiness.is_none());
+    assert!(fleet.manager.readiness_rx.is_some());
+    assert_eq!(fleet.manager.replacement_readiness_receipts.len(), 1);
+    let receipt = &fleet.manager.replacement_readiness_receipts[0];
+    assert_eq!((receipt.count, receipt.serviced), (4, 1));
+    assert!(receipt.elapsed >= super::super::MAX_HEALTHY_POLICY_TRANSITION_AGE);
+    assert!(receipt.max_gap <= receipt.elapsed);
+    let mut response = queue_replacement_readiness(&tx);
+    fleet
+        .manager
+        .with_replacement_readiness_age(Duration::ZERO, |_| {});
+    assert_eq!(response.try_recv().unwrap(), Ok(4));
+    assert_eq!(fleet.manager.replacement_readiness_receipts.len(), 2);
+    let mut response = queue_replacement_readiness(&tx);
+    fleet.manager.replacement_checkpoint(true);
+    assert!(matches!(
+        response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    fleet.manager.drain_readiness_queries(None);
+    assert_eq!(response.try_recv().unwrap(), Ok(4));
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the regression checks interior readiness, ordinary-channel isolation, and terminal acknowledgement in each production branch"
+)]
+fn replacement_readiness_services_production_interiors_before_ack_and_queued_mutation() {
+    for (stage, deny_all) in [
+        ("shared_inventory", false),
+        ("shared_inventory", true),
+        ("fallback_baseline", false),
+        ("family_commit", false),
+        ("outbound_limits", false),
+        ("retirement", false),
+        ("refresh", false),
+    ] {
+        let old = if stage == "outbound_limits" {
+            PolicyChain::new(vec![Policy {
+                entries: vec![],
+                default_action: PolicyAction::Deny,
+            }])
+        } else {
+            community_chain(0xFDE8_0001)
+        };
+        let next = if deny_all {
+            PolicyChain::new(vec![Policy {
+                entries: vec![],
+                default_action: PolicyAction::Deny,
+            }])
+        } else if matches!(
+            stage,
+            "fallback_baseline" | "family_commit" | "outbound_limits"
+        ) {
+            peer_context_chain()
+        } else {
+            community_chain(0xFDE8_0002)
+        };
+        let mut fleet = replacement_readiness_fleet(&old);
+        if stage == "outbound_limits" {
+            for &peer in &fleet.members {
+                let limits = fleet
+                    .manager
+                    .outbound_prefix_limits
+                    .entry(peer)
+                    .or_default();
+                for afi in [Afi::Ipv4, Afi::Ipv6] {
+                    limits.family_mut(afi).unwrap().limit = std::num::NonZeroU32::new(1);
+                }
+            }
+        }
+        let (readiness_tx, readiness_rx) = mpsc::channel(8);
+        fleet.manager.readiness_rx = Some(readiness_rx);
+        let (query_tx, query_rx) = mpsc::channel(1);
+        fleet.manager.query_rx = query_rx;
+        let (general_reply, general_response) = oneshot::channel();
+        query_tx
+            .try_send(RibUpdate::QueryLocRibCount {
+                reply: general_reply,
+            })
+            .unwrap();
+        let general_response = Arc::new(Mutex::new(general_response));
+        let (mutation_tx, mutation_rx) = mpsc::channel(1);
+        fleet.manager.rx = mutation_rx;
+        let source = Ipv4Addr::new(192, 0, 2, 54);
+        mutation_tx
+            .try_send(RibUpdate::RoutesReceived {
+                peer: IpAddr::V4(source),
+                session_id: 0,
+                announced: vec![make_route(
+                    Ipv4Prefix::new(Ipv4Addr::new(198, 18, 54, 0), 24),
+                    source,
+                )],
+                withdrawn: vec![],
+                flowspec_announced: vec![],
+                flowspec_withdrawn: vec![],
+                evpn_announced: vec![],
+                evpn_withdrawn: vec![],
+            })
+            .unwrap();
+        let (reply, response) = oneshot::channel();
+        let response = Arc::new(Mutex::new(response));
+        let visits = Arc::new(AtomicUsize::new(0));
+        let terminals = Arc::new(AtomicUsize::new(0));
+        let pending = Mutex::new(None);
+        fleet.manager.replacement_readiness_test_hook = Some(Arc::new({
+            let readiness_tx = readiness_tx.clone();
+            let general_response = Arc::clone(&general_response);
+            let response = Arc::clone(&response);
+            let visits = Arc::clone(&visits);
+            let terminals = Arc::clone(&terminals);
+            move |observed| {
+                if observed != stage && observed != "terminal_cleanup" {
+                    return;
+                }
+                assert!(
+                    matches!(
+                        response.lock().unwrap().try_recv(),
+                        Err(oneshot::error::TryRecvError::Empty)
+                    ),
+                    "{stage}: acknowledgement preceded cleanup"
+                );
+                assert!(
+                    matches!(
+                        general_response.lock().unwrap().try_recv(),
+                        Err(oneshot::error::TryRecvError::Empty)
+                    ),
+                    "{stage}: ordinary query crossed the replacement fence"
+                );
+                assert_eq!(mutation_tx.capacity(), 0, "{stage}: mutation was consumed");
+                if observed == "terminal_cleanup" {
+                    terminals.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+                match visits.fetch_add(1, Ordering::Relaxed) {
+                    0 => {
+                        *pending.lock().unwrap() = Some(queue_replacement_readiness(&readiness_tx));
+                    }
+                    1 => assert_eq!(
+                        pending
+                            .lock()
+                            .unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .try_recv()
+                            .unwrap(),
+                        Ok(4),
+                        "{stage}: readiness must be serviced before the next interior observation"
+                    ),
+                    _ => {}
+                }
+            }
+        }));
+        if stage == "refresh" {
+            fleet
+                .manager
+                .with_replacement_readiness_age(Duration::ZERO, |manager| {
+                    manager.send_route_refresh_response(fleet.members[0], Afi::Ipv4, Safi::Unicast);
+                });
+            reply.send(Ok(())).unwrap();
+        } else {
+            // A pre-existing dirty member outside the replacement batch must
+            // also finish the forced repair before its command acknowledges.
+            let members = if stage == "family_commit" {
+                fleet.manager.mark_outbound_dirty(fleet.members[3]);
+                &fleet.members[..3]
+            } else {
+                &fleet.members
+            };
+            fleet
+                .manager
+                .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+                    replacements: batch_replacements(members, &next),
+                    reply,
+                });
+        }
+        assert!(
+            visits.load(Ordering::Relaxed) >= 2,
+            "{stage}: interior hook was not exercised"
+        );
+        assert_eq!(
+            terminals.load(Ordering::Relaxed),
+            1,
+            "{stage}: nested scope finalized early"
+        );
+        assert_eq!(response.lock().unwrap().try_recv().unwrap(), Ok(()));
+        assert!(fleet.manager.replacement_readiness.is_none());
+        assert!(fleet.manager.pending_regroup_baseline.is_empty());
+        assert!(fleet.manager.dirty_peers.is_empty());
+        assert_eq!(fleet.manager.replacement_readiness_receipts.len(), 1);
+        assert_eq!(fleet.manager.replacement_readiness_receipts[0].serviced, 1);
+        assert_eq!(fleet.manager.loc_rib.len(), 4);
+        if stage == "outbound_limits" {
+            for peer in &fleet.members {
+                let rib_out = &fleet.manager.adj_ribs_out[peer];
+                assert_eq!(rib_out.len(), 2);
+                for afi in [Afi::Ipv4, Afi::Ipv6] {
+                    assert_eq!(
+                        rib_out
+                            .iter()
+                            .filter(|route| prefix_family(&route.prefix).0 == afi)
+                            .count(),
+                        1
+                    );
+                    let family = fleet.manager.outbound_prefix_limits[peer]
+                        .family(afi)
+                        .unwrap();
+                    assert_eq!(family.limit.unwrap().get(), 1);
+                    assert!(family.blocking);
+                }
+            }
+        }
+        fleet.manager.replacement_readiness_test_hook = None;
+        for receiver in &mut fleet.receivers {
+            while receiver.try_recv().is_ok() {}
+        }
+        let mutation = fleet.manager.rx.try_recv().unwrap();
+        fleet.manager.handle_update(mutation);
+        while fleet.manager.process_next_route_chunk() {}
+        assert_eq!(fleet.manager.loc_rib.len(), 5);
+        let mut readiness = queue_replacement_readiness(&readiness_tx);
+        fleet.manager.drain_readiness_queries(None);
+        assert_eq!(readiness.try_recv().unwrap(), Ok(5));
+        let query = fleet.manager.query_rx.try_recv().unwrap();
+        fleet.manager.handle_update(query);
+        assert_eq!(general_response.lock().unwrap().try_recv().unwrap(), 5);
+    }
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the terminal matrix keeps branch setup, last-cleanup observation, and receiver restoration together"
+)]
+fn replacement_readiness_terminal_paths_restore_service_before_ack() {
+    for case in [
+        "empty",
+        "missing",
+        "duplicate",
+        "rollback_duplicate",
+        "precondition",
+        "closed_outbound",
+        "exact_reject",
+    ] {
+        let old = community_chain(0xFDE8_0001);
+        let next = community_chain(0xFDE8_0002);
+        let mut fleet = replacement_readiness_fleet(&old);
+        let (readiness_tx, readiness_rx) = mpsc::channel(8);
+        fleet.manager.readiness_rx = Some(readiness_rx);
+        let mut replacements = batch_replacements(&fleet.members, &next);
+        match case {
+            "empty" => replacements.clear(),
+            "missing" => replacements[0].peer = "192.0.2.254".parse().unwrap(),
+            "duplicate" | "rollback_duplicate" => replacements.push(replacements[0].clone()),
+            "precondition" => {
+                fleet.manager.pending_clean_policy_transition = Some(
+                    super::distribution::PendingCleanPolicyTransition::new(Vec::new(), None),
+                );
+            }
+            "closed_outbound" => fleet.receivers[0].close(),
+            "exact_reject" => {
+                fleet.manager.peer_export_encoders.insert(
+                    fleet.members[0],
+                    Arc::new(CohortExactEncoder {
+                        owner: 1,
+                        profile: 54,
+                        max_len: 0,
+                        generation: AtomicUsize::new(0),
+                        advance_generation: false,
+                        probes: Arc::clone(&fleet.probes),
+                        reuses: Arc::clone(&fleet.reuses),
+                    }),
+                );
+            }
+            _ => unreachable!(),
+        }
+        let (reply, response) = oneshot::channel();
+        let response = Arc::new(Mutex::new(response));
+        let terminal_readiness = Arc::new(Mutex::new(None));
+        fleet.manager.replacement_readiness_test_hook = Some(Arc::new({
+            let response = Arc::clone(&response);
+            let terminal_readiness = Arc::clone(&terminal_readiness);
+            let readiness_tx = readiness_tx.clone();
+            move |stage| {
+                if stage == "terminal_cleanup" {
+                    assert!(
+                        matches!(
+                            response.lock().unwrap().try_recv(),
+                            Err(oneshot::error::TryRecvError::Empty)
+                        ),
+                        "{case}: acknowledgement preceded terminal cleanup"
+                    );
+                    let mut pending = terminal_readiness.lock().unwrap();
+                    assert!(pending.is_none(), "{case}: nested context finalized twice");
+                    *pending = Some(queue_replacement_readiness(&readiness_tx));
+                }
+            }
+        }));
+        if case == "rollback_duplicate" {
+            let result = fleet
+                .manager
+                .restore_export_policy_replacements_synchronously(replacements)
+                .map(|_| ());
+            reply.send(result).unwrap();
+        } else {
+            fleet
+                .manager
+                .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+                    replacements,
+                    reply,
+                });
+        }
+        assert_eq!(
+            response.lock().unwrap().try_recv().unwrap().is_err(),
+            matches!(case, "rollback_duplicate" | "precondition"),
+            "{case}"
+        );
+        assert_eq!(
+            terminal_readiness
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .try_recv()
+                .unwrap(),
+            Ok(4),
+            "{case}: terminal request was left behind the restored receiver"
+        );
+        assert!(fleet.manager.replacement_readiness.is_none(), "{case}");
+        assert!(fleet.manager.readiness_rx.is_some(), "{case}");
+        assert_eq!(
+            fleet.manager.replacement_readiness_receipts.len(),
+            1,
+            "{case}"
+        );
+        if case == "closed_outbound" {
+            assert_eq!(
+                fleet.manager.peer_export_policies[&fleet.members[0]].as_ref(),
+                Some(&next),
+                "closed outbound emission must not undo the accepted policy replacement"
+            );
+        }
+        if case == "exact_reject" {
+            assert!(!fleet.manager.peer_unexportable[&fleet.members[0]].is_empty());
+        }
+        fleet.manager.replacement_readiness_test_hook = None;
+        fleet.manager.pending_clean_policy_transition = None;
+        let mut readiness = queue_replacement_readiness(&readiness_tx);
+        fleet.manager.drain_readiness_queries(None);
+        assert_eq!(readiness.try_recv().unwrap(), Ok(4), "{case}");
+    }
+}
+
+#[test]
+fn replacement_readiness_closed_forward_and_rollback_replies_keep_their_semantics() {
+    for case in [
+        "forward_closed_before",
+        "forward_closed_inside",
+        "rollback_closed_before",
+    ] {
+        let old = community_chain(0xFDE8_0001);
+        let next = community_chain(0xFDE8_0002);
+        let mut fleet = replacement_readiness_fleet(&old);
+        let (readiness_tx, readiness_rx) = mpsc::channel(8);
+        fleet.manager.readiness_rx = Some(readiness_rx);
+        let (reply, response) = oneshot::channel();
+        let response = Arc::new(Mutex::new(Some(response)));
+        if case == "forward_closed_before" {
+            drop(response.lock().unwrap().take());
+        }
+        let terminal_readiness = Arc::new(Mutex::new(None));
+        let closed_inside = Arc::new(AtomicBool::new(false));
+        fleet.manager.replacement_readiness_test_hook = Some(Arc::new({
+            let response = Arc::clone(&response);
+            let terminal_readiness = Arc::clone(&terminal_readiness);
+            let closed_inside = Arc::clone(&closed_inside);
+            move |stage| {
+                if case == "forward_closed_inside" && stage == "shared_inventory" {
+                    drop(response.lock().unwrap().take());
+                    closed_inside.store(true, Ordering::Relaxed);
+                }
+                if stage == "terminal_cleanup" {
+                    let mut pending = terminal_readiness.lock().unwrap();
+                    assert!(pending.is_none());
+                    *pending = Some(queue_replacement_readiness(&readiness_tx));
+                }
+            }
+        }));
+        let replacements = batch_replacements(&fleet.members, &next);
+        if case == "rollback_closed_before" {
+            let (rollback_reply, rollback_response) = oneshot::channel();
+            drop(rollback_response);
+            fleet
+                .manager
+                .handle_update(RibUpdate::RestorePeerExportPoliciesAuthoritatively {
+                    replacements,
+                    reply: rollback_reply,
+                });
+        } else {
+            fleet
+                .manager
+                .handle_update(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+                    replacements,
+                    reply,
+                });
+        }
+        assert_eq!(
+            terminal_readiness
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .try_recv()
+                .unwrap(),
+            Ok(4),
+            "{case}"
+        );
+        let expected = if case == "forward_closed_before" {
+            &old
+        } else {
+            &next
+        };
+        for peer in &fleet.members {
+            assert_eq!(
+                fleet.manager.peer_export_policies[peer].as_ref(),
+                Some(expected),
+                "{case}"
+            );
+        }
+        if case == "forward_closed_inside" {
+            assert!(closed_inside.load(Ordering::Relaxed));
+        }
+        if case == "forward_closed_before" {
+            assert!(
+                fleet
+                    .receivers
+                    .iter_mut()
+                    .all(|receiver| receiver.try_recv().is_err())
+            );
+        }
+        assert!(fleet.manager.replacement_readiness.is_none());
+        assert!(fleet.manager.readiness_rx.is_some());
+        assert_eq!(fleet.manager.replacement_readiness_receipts.len(), 1);
+    }
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the regression supplies two identities per non-unicast family and checks both atomic announce and withdrawal commits"
+)]
+fn replacement_readiness_services_each_family_commit_without_changing_loc_rib_count() {
+    let mut fleet = replacement_readiness_fleet(&community_chain(0xFDE8_0001));
+    let peer = "10.54.0.9".parse().unwrap();
+    fleet
+        .manager
+        .handle_update(RibUpdate::SetPeerExportEncoder {
+            peer,
+            session_id: 0,
+            encoder: Arc::new(CohortExactEncoder {
+                owner: 9,
+                profile: 54,
+                max_len: 4_096,
+                generation: AtomicUsize::new(0),
+                advance_generation: false,
+                probes: Arc::clone(&fleet.probes),
+                reuses: Arc::clone(&fleet.reuses),
+            }),
+        });
+    let mut outbound = register_direct_peer_with_families(
+        &mut fleet.manager,
+        peer,
+        vec![
+            (Afi::Ipv4, Safi::Unicast),
+            (Afi::Ipv6, Safi::Unicast),
+            (Afi::Ipv4, Safi::FlowSpec),
+            (Afi::L2Vpn, Safi::Evpn),
+            (Afi::BgpLs, Safi::BgpLs),
+            (Afi::Ipv4, Safi::MplsVpn),
+            (Afi::Ipv4, Safi::LabeledUnicast),
+            (Afi::Ipv4, Safi::RtConstrain),
+        ],
+    );
+    fleet
+        .manager
+        .replace_peer_export_policy_synchronously(peer, Some(peer_context_chain()))
+        .unwrap();
+    while outbound.try_recv().is_ok() {}
+    assert!(fleet.manager.grouped_member_of(peer).is_none());
+    assert!(fleet.manager.vpn_grouped_member_of(peer).is_none());
+    // Registration may already advertise the locally originated default RTC
+    // route. Neither announcing nor withdrawing these identities may alter it.
+    let rib = &fleet.manager.adj_ribs_out[&peer];
+    let retained = [
+        rib.flowspec_len(),
+        rib.evpn_len(),
+        rib.bgpls_len(),
+        rib.vpn_len(),
+        rib.labeled_len(),
+        rib.rtc_len(),
+    ];
+    let (tx, rx) = mpsc::channel(8);
+    fleet.manager.readiness_rx = Some(rx);
+    for withdraw in [false, true] {
+        let source = Ipv4Addr::new(192, 0, 2, 54);
+        let mut flowspec: Vec<_> = (1..=2).map(|_| make_flowspec_route(source)).collect();
+        flowspec[1].rule.components[0] = rustbgpd_wire::FlowSpecComponent::DestinationPrefix(
+            rustbgpd_wire::FlowSpecPrefix::V4(Ipv4Prefix::new(Ipv4Addr::new(198, 18, 54, 0), 24)),
+        );
+        let evpn: Vec<_> = (1..=2).map(|index| make_evpn_imet(source, index)).collect();
+        let bgpls: Vec<_> = (1..=2)
+            .map(|index| make_bgpls_route(source, index, 100))
+            .collect();
+        let vpn: Vec<_> = (1..=2)
+            .map(|index| make_vpn_rib_route(source, index, 100, 100))
+            .collect();
+        let labeled: Vec<_> = (1..=2)
+            .map(|index| make_labeled_rib_route(source, index, 100, 100))
+            .collect();
+        let rtc: Vec<_> = (1..=2)
+            .map(|index| make_rtc_rib_route(source, index, 100))
+            .collect();
+        let batch = if withdraw {
+            OutboundCommitBatch {
+                flowspec_withdraw: flowspec.iter().map(FlowSpecRoute::selection_key).collect(),
+                evpn_withdraw: evpn.iter().map(EvpnRibRoute::key).collect(),
+                bgpls_withdraw: bgpls.iter().map(BgpLsRibRoute::key).collect(),
+                vpn_withdraw: vpn.iter().map(VpnRibRoute::key).collect(),
+                labeled_withdraw: labeled
+                    .iter()
+                    .map(crate::route::LabeledRibRoute::key)
+                    .collect(),
+                rtc_withdraw: rtc.iter().map(crate::route::RtcRibRoute::key).collect(),
+                ..OutboundCommitBatch::default()
+            }
+        } else {
+            OutboundCommitBatch {
+                flowspec_announce: flowspec,
+                evpn_announce: evpn,
+                bgpls_announce: bgpls,
+                vpn_announce: vpn,
+                labeled_announce: labeled,
+                rtc_announce: rtc,
+                ..OutboundCommitBatch::default()
+            }
+        };
+        let visits = Arc::new(AtomicUsize::new(0));
+        let pending = Arc::new(Mutex::new(None::<oneshot::Receiver<_>>));
+        fleet.manager.replacement_readiness_test_hook = Some(Arc::new({
+            let tx = tx.clone();
+            let visits = Arc::clone(&visits);
+            let pending = Arc::clone(&pending);
+            move |stage| {
+                if stage == "family_commit" {
+                    let mut pending = pending.lock().unwrap();
+                    if let Some(response) = pending.as_mut() {
+                        assert_eq!(response.try_recv().unwrap(), Ok(4));
+                    }
+                    *pending = Some(queue_replacement_readiness(&tx));
+                    visits.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+        fleet
+            .manager
+            .with_replacement_readiness_age(Duration::ZERO, |manager| {
+                assert!(manager.try_send_and_commit_outbound_update(peer, batch));
+            });
+        assert_eq!(visits.load(Ordering::Relaxed), 12);
+        assert_eq!(
+            pending
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .try_recv()
+                .unwrap(),
+            Ok(4)
+        );
+        let rib = &fleet.manager.adj_ribs_out[&peer];
+        assert_eq!(
+            [
+                rib.flowspec_len(),
+                rib.evpn_len(),
+                rib.bgpls_len(),
+                rib.vpn_len(),
+                rib.labeled_len(),
+                rib.rtc_len()
+            ],
+            retained.map(|count| count + if withdraw { 0 } else { 2 })
+        );
+        assert_eq!(fleet.manager.loc_rib.len(), 4);
+        assert!(outbound.try_recv().is_ok());
+        assert!(
+            outbound.try_recv().is_err(),
+            "all families must share one outbound envelope"
+        );
+    }
 }
 
 fn batch_replacements(

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -6732,6 +6732,46 @@ fn batched_pcb_fleet(export_policy: Option<&PolicyChain>) -> BatchedPcbFleet {
     batched_pcb_fleet_n(export_policy, 4)
 }
 
+#[test]
+fn replacement_cleanup_skips_scalar_walks_and_interleaves_owned_drops() {
+    for len in [0, 1, 4_096] {
+        let mut values: Vec<usize> = (0..len).collect();
+        let mut checkpoints = 0;
+        super::super::retire_vec(&mut values, &mut || checkpoints += 1);
+        assert!(values.is_empty());
+        assert_eq!(values.capacity(), 0);
+        assert_eq!(checkpoints, 2, "scalar cleanup only needs allocation edges");
+
+        let mut values: HashSet<usize> = (0..len).collect();
+        let mut checkpoints = 0;
+        super::super::retire_hash_set(&mut values, &mut || checkpoints += 1);
+        assert!(values.is_empty());
+        assert_eq!(values.capacity(), 0);
+        assert_eq!(checkpoints, 2, "scalar cleanup only needs allocation edges");
+    }
+
+    let owners: Vec<_> = (0..8).map(Arc::new).collect();
+    let retired = || {
+        owners
+            .iter()
+            .filter(|value| Arc::strong_count(value) == 1)
+            .count()
+    };
+    let mut progress = Vec::new();
+    let mut values = owners.clone();
+    super::super::retire_vec(&mut values, &mut || progress.push(retired()));
+    assert!(values.is_empty());
+    assert_eq!(retired(), owners.len());
+    assert!((0..=owners.len()).all(|count| progress.contains(&count)));
+
+    progress.clear();
+    let mut values: HashSet<_> = owners.iter().cloned().collect();
+    super::super::retire_hash_set(&mut values, &mut || progress.push(retired()));
+    assert!(values.is_empty());
+    assert_eq!(retired(), owners.len());
+    assert!((0..=owners.len()).all(|count| progress.contains(&count)));
+}
+
 /// Four routes across both unicast families keep readiness counts distinct
 /// from either family's count without depending on scheduler timing.
 fn replacement_readiness_fleet(export_policy: &PolicyChain) -> BatchedPcbFleet {

--- a/crates/rib/src/manager/update_groups.rs
+++ b/crates/rib/src/manager/update_groups.rs
@@ -6,7 +6,7 @@
 //! owns ONE staged outbound table ([`GroupRibOut`]), the export tail
 //! runs once per (group, changed prefix) instead of once per (peer,
 //! prefix), and per-member updates are derived from the shared delta by
-//! the source-flip matrix ([`emit_group_deltas_for_member`]). Peers
+//! the source-flip matrix ([`emit_group_deltas_for_member_with_checkpoint`]). Peers
 //! hitting a v1 disqualifier keep today's per-peer path entirely — the
 //! fallback is structural, and the per-peer path remains the
 //! correctness oracle (design risk 1).
@@ -59,10 +59,18 @@ pub(in crate::manager) use payload::{
     CleanPolicyTransitionInventoryBuilder, GroupDelta, GroupEvalAccumulator, GroupStageOutput,
     LaneDelta, PerClientBestPrefixStage, PolicyTransitionGroupStart, RsTagTransition, RunnerUp,
     SharedUnicastPayload, VpnGroupDelta, VpnGroupStageOutput, capture_source_attrs,
-    emit_group_deltas_for_member, emit_lane_deltas_for_member, emit_rs_tag_transitions,
-    emit_vpn_group_deltas_for_member, rt_passes, source_control_input,
+    emit_group_deltas_for_member_with_checkpoint, emit_lane_deltas_for_member_with_checkpoint,
+    emit_rs_tag_transitions_with_checkpoint, emit_vpn_group_deltas_for_member_with_checkpoint,
+    rt_passes, source_control_input,
 };
-use payload::{BatchedTransitionCounters, VpnDenialRecord, bump_counter_row};
+use payload::{
+    BatchedTransitionCounters, VpnDenialRecord, bump_counter_row, bump_counter_row_with_checkpoint,
+};
+#[cfg(test)]
+use payload::{
+    emit_group_deltas_for_member, emit_lane_deltas_for_member, emit_rs_tag_transitions,
+    emit_vpn_group_deltas_for_member,
+};
 
 use super::helpers::{LOCAL_PEER, prefix_family, routes_equal, vpn_routes_equal};
 use super::{PolicyFilteredRouteKey, RibManager, RtcMembership};
@@ -404,6 +412,7 @@ impl UpdateGroupRegistry {
         self.groups.get(id)
     }
 
+    #[cfg(test)]
     fn retained_chain_count(&self) -> usize {
         self.chains.iter().filter(|chain| chain.is_some()).count()
     }
@@ -416,6 +425,63 @@ impl UpdateGroupRegistry {
 pub(in crate::manager) struct RegroupBaseline {
     pub(in crate::manager) unicast: FxHashMap<(Prefix, u32), Route>,
     pub(in crate::manager) vpn: FxHashMap<VpnRouteKey, VpnRibRoute>,
+}
+
+/// Preserve existing wire values on overlap without growing a populated bucket
+/// array. Both input maps remain owned by the actor throughout the move.
+pub(in crate::manager) fn ensure_map_capacity_with_checkpoint<
+    K: Eq + std::hash::Hash,
+    V,
+    S: std::hash::BuildHasher + Default,
+>(
+    base: &mut std::collections::HashMap<K, V, S>,
+    capacity: usize,
+    checkpoint: &mut impl FnMut(),
+) {
+    if capacity > base.capacity() {
+        checkpoint();
+        let mut replacement =
+            std::collections::HashMap::with_capacity_and_hasher(capacity, S::default());
+        let mut entries = std::mem::take(base).into_iter();
+        for (key, value) in entries.by_ref() {
+            checkpoint();
+            replacement.insert(key, value);
+            checkpoint();
+        }
+        checkpoint();
+        drop(entries);
+        checkpoint();
+        *base = replacement;
+    }
+}
+
+fn merge_owned_maps<K: Eq + std::hash::Hash, V, S: std::hash::BuildHasher + Default>(
+    base: &mut std::collections::HashMap<K, V, S>,
+    prior: std::collections::HashMap<K, V, S>,
+    checkpoint: &mut impl FnMut(),
+) {
+    ensure_map_capacity_with_checkpoint(base, base.len().saturating_add(prior.len()), checkpoint);
+    let mut entries = prior.into_iter();
+    for (key, value) in entries.by_ref() {
+        checkpoint();
+        drop(base.insert(key, value));
+        checkpoint();
+    }
+    checkpoint();
+    drop(entries);
+    checkpoint();
+}
+
+impl RegroupBaseline {
+    fn merge_prior(&mut self, prior: Self, checkpoint: &mut impl FnMut()) {
+        merge_owned_maps(&mut self.unicast, prior.unicast, checkpoint);
+        merge_owned_maps(&mut self.vpn, prior.vpn, checkpoint);
+    }
+
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        crate::adj_rib_out::release_hash_map(&mut self.unicast, checkpoint);
+        crate::adj_rib_out::release_hash_map(&mut self.vpn, checkpoint);
+    }
 }
 
 /// Extra (over-)withdraw keys a member must emit on its next resync:
@@ -574,6 +640,44 @@ pub(in crate::manager) struct GroupRibOut {
 const GROUP_FILTERED_PLACEHOLDER: IpAddr = LOCAL_PEER;
 
 impl GroupRibOut {
+    #[cfg(feature = "bench-internals")]
+    pub(in crate::manager) fn bench_otc_storage_shape(&self) -> (usize, usize) {
+        (self.otc_blocked.len(), self.otc_blocked.capacity())
+    }
+
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        use crate::adj_rib_out::release_hash_map;
+        self.table.retire_with(checkpoint);
+        release_hash_map(&mut self.nh_overrides, checkpoint);
+        release_hash_map(&mut self.source_attrs, checkpoint);
+        release_hash_map(&mut self.source_counts, checkpoint);
+        for (_, mut paths) in self.policy_filtered.drain() {
+            release_hash_map(&mut paths, checkpoint);
+        }
+        release_hash_map(&mut self.policy_filtered, checkpoint);
+        release_hash_map(&mut self.vpn_policy_denied, checkpoint);
+        release_hash_map(&mut self.otc_blocked, checkpoint);
+        release_hash_map(&mut self.otc_blocked_sources, checkpoint);
+        release_hash_map(&mut self.lane_otc_blocked_counts, checkpoint);
+        release_hash_map(&mut self.vpn_member_counts, checkpoint);
+        release_hash_map(&mut self.runner_up, checkpoint);
+        release_hash_map(&mut self.lane_counts, checkpoint);
+        for _ in self.tombstones.drain() {
+            checkpoint();
+        }
+        for _ in self.vpn_tombstones.drain() {
+            checkpoint();
+        }
+        for _ in self.members.drain() {
+            checkpoint();
+        }
+        for _ in self.dirty_members.drain() {
+            checkpoint();
+        }
+        checkpoint();
+        drop(self.export_chain.take());
+        checkpoint();
+    }
     #[expect(
         clippy::too_many_arguments,
         clippy::fn_params_excessive_bools,
@@ -648,15 +752,26 @@ impl GroupRibOut {
         self.sendable.contains(&(Afi::Ipv4, Safi::RtConstrain))
     }
 
-    fn record_otc_blocked(&mut self, prefixes: &HashSet<Prefix>, blocked: &[Route]) {
-        self.otc_blocked
-            .retain(|(prefix, _), _| !prefixes.contains(prefix));
-        self.otc_blocked.extend(
-            blocked
-                .iter()
-                .cloned()
-                .map(|route| ((route.prefix, route.path_id), route)),
-        );
+    fn record_otc_blocked(
+        &mut self,
+        prefixes: &HashSet<Prefix>,
+        blocked: &[Route],
+        checkpoint: &mut impl FnMut(),
+    ) {
+        self.otc_blocked.retain(|(prefix, _), _| {
+            checkpoint();
+            !prefixes.contains(prefix)
+        });
+        // Reserve a fresh table before moving entries: in-place growth
+        // rehashes the complete route map without an actor checkpoint.
+        let mut incoming =
+            FxHashMap::with_capacity_and_hasher(blocked.len(), rustc_hash::FxBuildHasher);
+        checkpoint();
+        for route in blocked {
+            checkpoint();
+            incoming.insert((route.prefix, route.path_id), route.clone());
+        }
+        merge_owned_maps(&mut self.otc_blocked, incoming, checkpoint);
         // Rebuild the count aggregates from the refreshed map — one
         // mutation seam keeps them exact, at O(blocked residue) per
         // pass (zero in the overwhelmingly common no-OTC case). Only
@@ -668,6 +783,7 @@ impl GroupRibOut {
         self.otc_blocked_sources.clear();
         if self.per_client_best {
             for route in self.otc_blocked.values() {
+                checkpoint();
                 let slot = Self::count_slot(&route.prefix);
                 self.otc_blocked_totals[slot] += 1;
                 self.otc_blocked_sources.entry(route.peer).or_default()[slot] += 1;
@@ -680,9 +796,19 @@ impl GroupRibOut {
         member: IpAddr,
         prefixes: Option<&HashSet<Prefix>>,
     ) -> Vec<Route> {
+        self.otc_blocked_for_member_with_checkpoint(member, prefixes, &mut || {})
+    }
+
+    pub(in crate::manager) fn otc_blocked_for_member_with_checkpoint(
+        &self,
+        member: IpAddr,
+        prefixes: Option<&HashSet<Prefix>>,
+        checkpoint: &mut impl FnMut(),
+    ) -> Vec<Route> {
         let mut blocked: Vec<Route> = self
             .otc_blocked
             .values()
+            .inspect(|_| checkpoint())
             .filter(|route| {
                 route.peer != member
                     && prefixes.is_none_or(|prefixes| prefixes.contains(&route.prefix))
@@ -712,6 +838,7 @@ impl GroupRibOut {
                 // at O(members × staged) rather than O(members × lane).
                 Some(prefixes) if prefixes.len() <= self.runner_up.len() => {
                     for prefix in prefixes {
+                        checkpoint();
                         #[cfg(any(test, feature = "bench-internals"))]
                         {
                             visits += 1;
@@ -729,6 +856,7 @@ impl GroupRibOut {
                 // reason.
                 _ => {
                     for (prefix, entry) in &self.runner_up {
+                        checkpoint();
                         #[cfg(any(test, feature = "bench-internals"))]
                         {
                             visits += 1;
@@ -975,12 +1103,17 @@ impl GroupRibOut {
 
     /// Commit a pass's tag-only transitions into the source-attribute
     /// residue (the delta-borne updates ride [`Self::apply_delta`]).
-    fn commit_rs_transitions(&mut self, transitions: &[RsTagTransition]) {
+    fn commit_rs_transitions(
+        &mut self,
+        transitions: &[RsTagTransition],
+        checkpoint: &mut impl FnMut(),
+    ) {
         if self.source_control_passthrough {
             debug_assert!(transitions.is_empty());
             return;
         }
         for transition in transitions {
+            checkpoint();
             let key = (transition.prefix, transition.path_id);
             match &transition.source_attrs {
                 Some(attrs) => {
@@ -1134,11 +1267,12 @@ impl GroupRibOut {
         &mut self,
         member: IpAddr,
         filter: Option<&RtcMembership>,
+        checkpoint: &mut impl FnMut(),
     ) {
         if !self.rtc_negotiated() {
             return;
         }
-        let counts = self.vpn_member_counts_from_table(member, filter);
+        let counts = self.vpn_member_counts_from_table(member, filter, checkpoint);
         self.vpn_member_counts.insert(member, counts);
     }
 
@@ -1148,9 +1282,11 @@ impl GroupRibOut {
         &self,
         member: IpAddr,
         filter: Option<&RtcMembership>,
+        checkpoint: &mut impl FnMut(),
     ) -> [i64; 2] {
         let mut counts = [0i64; 2];
         for route in self.table.iter_vpn() {
+            checkpoint();
             if route.peer != member && rt_passes(filter, route) {
                 counts[Self::vpn_count_slot(&route.nlri.key()) - 2] += 1;
             }
@@ -1221,58 +1357,89 @@ impl GroupRibOut {
     /// from the lane's captured source attributes, exactly how staged
     /// entries are recorded), or the destination-side diff would
     /// compare wire state to a route the member never received.
+    #[cfg(test)]
     fn member_view_snapshot(
         &self,
         member: IpAddr,
         rs_control: Option<(u32, u32)>,
         rejected: &HashSet<ExactExportKey>,
     ) -> FxHashMap<(Prefix, u32), Route> {
-        use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_suppressed};
-        self.table
-            .iter()
-            .filter_map(|staged| {
-                let key = (staged.prefix, staged.path_id);
-                // The substitution shares the staged slot's key, so the
-                // member-local rejection overlay applies identically.
-                if rejected.contains(&ExactExportKey::Unicast(key.0, key.1)) {
-                    return None;
-                }
-                let entry = self.adv_entry(member, &staged.prefix, staged.path_id)?;
-                let (communities, large_communities) =
-                    self.source_control_for_route(entry.route, entry.source_attrs);
-                // LAN-474: a key whose SOURCE communities suppress it
-                // toward the member was never on its wire — the
-                // snapshot records true wire state, not the shared
-                // table.
-                if rs_control_suppressed(communities, large_communities, rs_control) {
-                    return None;
-                }
-                let mut route = entry.route.clone();
-                rs_control_route_rewrite(&mut route, large_communities, rs_control);
-                Some((key, route))
-            })
-            .collect()
+        self.member_view_snapshot_with_checkpoint(member, rs_control, rejected, &mut |_| {})
     }
 
-    /// VPN sibling of [`Self::member_view_snapshot`], filtered by the
+    fn member_view_snapshot_with_checkpoint(
+        &self,
+        member: IpAddr,
+        rs_control: Option<(u32, u32)>,
+        rejected: &HashSet<ExactExportKey>,
+        checkpoint: &mut impl FnMut(bool),
+    ) -> FxHashMap<(Prefix, u32), Route> {
+        use super::distribution::rs_control::{rs_control_route_rewrite, rs_control_suppressed};
+        checkpoint(true);
+        let mut snapshot =
+            FxHashMap::with_capacity_and_hasher(self.table.len(), rustc_hash::FxBuildHasher);
+        for entry in self.table.iter().filter_map(|staged| {
+            checkpoint(false);
+            let key = (staged.prefix, staged.path_id);
+            // The substitution shares the staged slot's key, so the
+            // member-local rejection overlay applies identically.
+            if rejected.contains(&ExactExportKey::Unicast(key.0, key.1)) {
+                return None;
+            }
+            let entry = self.adv_entry(member, &staged.prefix, staged.path_id)?;
+            let (communities, large_communities) =
+                self.source_control_for_route(entry.route, entry.source_attrs);
+            // LAN-474: a key whose SOURCE communities suppress it
+            // toward the member was never on its wire — the
+            // snapshot records true wire state, not the shared
+            // table.
+            if rs_control_suppressed(communities, large_communities, rs_control) {
+                return None;
+            }
+            let mut route = entry.route.clone();
+            rs_control_route_rewrite(&mut route, large_communities, rs_control);
+            Some((key, route))
+        }) {
+            snapshot.insert(entry.0, entry.1);
+        }
+        checkpoint(true);
+        snapshot
+    }
+
+    /// VPN sibling of [`Self::member_view_snapshot_with_checkpoint`], filtered by the
     /// member's Φ at snapshot time — the true advertised set (design
     /// §2.4). Empty when the group does not stage VPN (the substrate's
     /// VPN maps stay unused).
+    #[cfg(test)]
     fn member_vpn_view_snapshot(
         &self,
         member: IpAddr,
         filter: Option<&RtcMembership>,
         rejected: &HashSet<ExactExportKey>,
     ) -> FxHashMap<VpnRouteKey, VpnRibRoute> {
-        self.table
-            .iter_vpn()
-            .filter(|route| {
-                route.peer != member
-                    && rt_passes(filter, route)
-                    && !rejected.contains(&ExactExportKey::Vpn(route.key()))
-            })
-            .map(|route| (route.nlri.key(), route.clone()))
-            .collect()
+        self.member_vpn_view_snapshot_with_checkpoint(member, filter, rejected, &mut |_| {})
+    }
+
+    fn member_vpn_view_snapshot_with_checkpoint(
+        &self,
+        member: IpAddr,
+        filter: Option<&RtcMembership>,
+        rejected: &HashSet<ExactExportKey>,
+        checkpoint: &mut impl FnMut(bool),
+    ) -> FxHashMap<VpnRouteKey, VpnRibRoute> {
+        checkpoint(true);
+        let mut snapshot =
+            FxHashMap::with_capacity_and_hasher(self.table.vpn_len(), rustc_hash::FxBuildHasher);
+        for route in self.table.iter_vpn().filter(|route| {
+            checkpoint(false);
+            route.peer != member
+                && rt_passes(filter, route)
+                && !rejected.contains(&ExactExportKey::Vpn(route.key()))
+        }) {
+            snapshot.insert(route.nlri.key(), route.clone());
+        }
+        checkpoint(true);
+        snapshot
     }
 
     /// Refresh the persistent group-verdict denial set for one staging
@@ -1283,11 +1450,16 @@ impl GroupRibOut {
         &mut self,
         staged: &HashSet<Prefix>,
         current: &[(PolicyFilteredRouteKey, Option<PolicyLabel>)],
+        checkpoint: &mut impl FnMut(),
     ) {
         for prefix in staged {
-            self.policy_filtered.remove(prefix);
+            checkpoint();
+            if let Some(mut denials) = self.policy_filtered.remove(prefix) {
+                crate::adj_rib_out::release_hash_map(&mut denials, checkpoint);
+            }
         }
         for (key, label) in current {
+            checkpoint();
             self.policy_filtered
                 .entry(key.prefix)
                 .or_default()
@@ -1314,41 +1486,76 @@ impl GroupRibOut {
         member: IpAddr,
         prefixes: &HashSet<Prefix>,
     ) -> Vec<PolicyFilteredRouteKey> {
+        self.policy_filtered_for_member_with_checkpoint(member, prefixes, &mut || {})
+    }
+
+    pub(in crate::manager) fn policy_filtered_for_member_with_checkpoint(
+        &self,
+        member: IpAddr,
+        prefixes: &HashSet<Prefix>,
+        checkpoint: &mut impl FnMut(),
+    ) -> Vec<PolicyFilteredRouteKey> {
         #[cfg(any(test, feature = "bench-internals"))]
         let mut visits = 0_usize;
-        let mut restamped = Vec::new();
-        let mut collect =
-            |prefix: Prefix, denials: &FxHashMap<(IpAddr, u32), Option<PolicyLabel>>| {
-                restamped.extend(
-                    denials
-                        .keys()
-                        .filter(|(source_peer, _)| *source_peer != member)
-                        .map(|&(source_peer, path_id)| PolicyFilteredRouteKey {
-                            target_peer: member,
-                            source_peer,
-                            prefix,
-                            path_id,
-                        }),
-                );
-            };
+        let capacity = if prefixes.len() <= self.policy_filtered.len() {
+            prefixes
+                .iter()
+                .map(|prefix| {
+                    checkpoint();
+                    self.policy_filtered.get(prefix).map_or(0, FxHashMap::len)
+                })
+                .sum()
+        } else {
+            self.policy_filtered
+                .iter()
+                .map(|(prefix, denials)| {
+                    checkpoint();
+                    if prefixes.contains(prefix) {
+                        denials.len()
+                    } else {
+                        0
+                    }
+                })
+                .sum()
+        };
+        let mut restamped = Vec::with_capacity(capacity);
+        let mut collect = |prefix: Prefix,
+                           denials: &FxHashMap<(IpAddr, u32), Option<PolicyLabel>>,
+                           checkpoint: &mut dyn FnMut()| {
+            checkpoint();
+            restamped.extend(
+                denials
+                    .keys()
+                    .inspect(|_| checkpoint())
+                    .filter(|(source_peer, _)| *source_peer != member)
+                    .map(|&(source_peer, path_id)| PolicyFilteredRouteKey {
+                        target_peer: member,
+                        source_peer,
+                        prefix,
+                        path_id,
+                    }),
+            );
+        };
         if prefixes.len() <= self.policy_filtered.len() {
             for prefix in prefixes {
+                checkpoint();
                 #[cfg(any(test, feature = "bench-internals"))]
                 {
                     visits += 1;
                 }
                 if let Some(denials) = self.policy_filtered.get(prefix) {
-                    collect(*prefix, denials);
+                    collect(*prefix, denials, checkpoint);
                 }
             }
         } else {
             for (prefix, denials) in &self.policy_filtered {
+                checkpoint();
                 #[cfg(any(test, feature = "bench-internals"))]
                 {
                     visits += 1;
                 }
                 if prefixes.contains(prefix) {
-                    collect(*prefix, denials);
+                    collect(*prefix, denials, checkpoint);
                 }
             }
         }
@@ -1503,11 +1710,13 @@ impl RibManager {
         let residue = self
             .group_ribs
             .values()
+            .inspect(|_| self.replacement_checkpoint(false))
             .map(|group| group.tombstones.len() + group.vpn_tombstones.len())
             .sum::<usize>()
             + self
                 .pending_extra_withdraws
                 .values()
+                .inspect(|_| self.replacement_checkpoint(false))
                 .map(|extras| extras.unicast.len() + extras.vpn.len())
                 .sum::<usize>();
         self.metrics
@@ -1522,8 +1731,16 @@ impl RibManager {
     /// Callers must have emitted the pending extra withdraws (or shown
     /// them empty/retained) before calling: this drops them.
     pub(in crate::manager) fn clear_grouped_member_synced(&mut self, peer: IpAddr) {
-        self.pending_regroup_baseline.remove(&peer);
-        self.pending_extra_withdraws.remove(&peer);
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint =
+            || super::replacement_readiness_checkpoint_at(&readiness, "retirement", false);
+        if let Some(mut baseline) = self.pending_regroup_baseline.remove(&peer) {
+            baseline.retire_with(&mut checkpoint);
+        }
+        if let Some(mut extras) = self.pending_extra_withdraws.remove(&peer) {
+            super::retire_hash_set(&mut extras.unicast, &mut checkpoint);
+            super::retire_hash_set(&mut extras.vpn, &mut checkpoint);
+        }
         // A completed resync leaves the member advertising exactly the
         // Φ-filtered table — the seam where the incremental per-member
         // VPN counters (which may have drifted across the dirty window)
@@ -1532,11 +1749,11 @@ impl RibManager {
         if let Some(gid) = self.grouped_member_of(peer)
             && let Some(group) = self.group_ribs.get_mut(&gid)
         {
-            group.recompute_vpn_member_counts(peer, filter.as_ref());
+            group.recompute_vpn_member_counts(peer, filter.as_ref(), &mut checkpoint);
             group.dirty_members.remove(&peer);
             if group.dirty_members.is_empty() {
-                group.tombstones.clear();
-                group.vpn_tombstones.clear();
+                super::retire_hash_set(&mut group.tombstones, &mut checkpoint);
+                super::retire_hash_set(&mut group.vpn_tombstones, &mut checkpoint);
             }
         }
         self.refresh_group_residue_gauge();
@@ -1587,6 +1804,8 @@ impl RibManager {
         old: &RtcMembership,
         new: &RtcMembership,
     ) {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
         let mut vpn_announce: Vec<VpnRibRoute> = Vec::new();
         let mut vpn_withdraw: Vec<VpnRibRouteKey> = Vec::new();
         let mut count_delta = [0i64; 2];
@@ -1607,6 +1826,7 @@ impl RibManager {
                 return;
             };
             for route in group.table.iter_vpn() {
+                checkpoint();
                 if route.peer == peer {
                     continue;
                 }
@@ -1622,7 +1842,12 @@ impl RibManager {
                         let key = route.nlri.key();
                         count_delta[GroupRibOut::vpn_count_slot(&key) - 2] += 1;
                         let label = group.permit_policy_label.clone();
-                        bump_counter_row(&mut permit_rows, label.as_ref(), PolicyAction::Permit);
+                        bump_counter_row_with_checkpoint(
+                            &mut permit_rows,
+                            label.as_ref(),
+                            PolicyAction::Permit,
+                            &mut || checkpoint(),
+                        );
                         vpn_announce.push(route.clone());
                     }
                     (true, false) => {
@@ -1643,9 +1868,18 @@ impl RibManager {
                     .entry(peer)
                     .or_default()
                     .vpn
-                    .extend(vpn_withdraw.iter().map(|key| key.nlri_key));
+                    .extend(
+                        vpn_withdraw
+                            .iter()
+                            .inspect(|_| checkpoint())
+                            .map(|key| key.nlri_key),
+                    );
                 self.refresh_group_residue_gauge();
             }
+            super::retire_vec(&mut vpn_announce, &mut || checkpoint());
+            super::retire_vec(&mut vpn_withdraw, &mut || checkpoint());
+            super::retire_vec(&mut permit_rows, &mut || checkpoint());
+            self.replacement_checkpoint(true);
             return;
         }
         if vpn_announce.is_empty() && vpn_withdraw.is_empty() {
@@ -1656,7 +1890,11 @@ impl RibManager {
             // resync recompute restores exactness.
             group.apply_vpn_member_count_delta(peer, count_delta);
         }
-        let withdraw_keys: Vec<VpnRouteKey> = vpn_withdraw.iter().map(|key| key.nlri_key).collect();
+        let mut withdraw_keys: Vec<VpnRouteKey> = vpn_withdraw
+            .iter()
+            .inspect(|_| checkpoint())
+            .map(|key| key.nlri_key)
+            .collect();
         if self.try_send_and_commit_outbound_update(
             peer,
             OutboundCommitBatch {
@@ -1676,17 +1914,22 @@ impl RibManager {
                 .entry(peer)
                 .or_default()
                 .vpn
-                .extend(withdraw_keys);
+                .extend(withdraw_keys.drain(..).inspect(|_| checkpoint()));
             self.refresh_group_residue_gauge();
         }
+        super::retire_vec(&mut withdraw_keys, &mut || checkpoint());
+        super::retire_vec(&mut permit_rows, &mut || checkpoint());
+        self.replacement_checkpoint(true);
     }
 
     /// Apply aggregated export-policy verdict rows to a peer's counters
     /// (integer adds — no per-(prefix × peer) prometheus lookups).
     fn bump_export_counters(&mut self, peer: IpAddr, rows: &[(Option<String>, PolicyAction, u64)]) {
+        let readiness = self.replacement_readiness.clone();
         let stats = self.export_policy_stats.entry(peer).or_default();
         let peer_label = peer.to_string();
         for (policy, action, n) in rows {
+            super::replacement_readiness_checkpoint(&readiness, false);
             if *n == 0 {
                 continue;
             }
@@ -1718,6 +1961,8 @@ impl RibManager {
     }
 
     fn leave_group_without_gauge_refresh(&mut self, gid: usize, peer: IpAddr) {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
         let Some(group) = self.group_ribs.get_mut(&gid) else {
             return;
         };
@@ -1725,11 +1970,20 @@ impl RibManager {
         group.vpn_member_counts.remove(&peer);
         group.dirty_members.remove(&peer);
         if group.dirty_members.is_empty() {
-            group.tombstones.clear();
-            group.vpn_tombstones.clear();
+            super::retire_hash_set(&mut group.tombstones, &mut || checkpoint());
+            super::retire_hash_set(&mut group.vpn_tombstones, &mut || checkpoint());
         }
         if group.members.is_empty() {
-            self.group_ribs.remove(&gid);
+            self.remove_group_with_readiness(gid);
+        }
+    }
+
+    fn remove_group_with_readiness(&mut self, gid: usize) {
+        if let Some(mut group) = self.group_ribs.remove(&gid) {
+            group.retire_with(&mut || self.replacement_checkpoint_at("retirement", false));
+            self.replacement_checkpoint_at("retirement", true);
+            drop(group);
+            self.replacement_checkpoint_at("retirement", true);
         }
     }
 
@@ -1945,13 +2199,19 @@ impl RibManager {
     /// bookkeeping.
     fn refresh_update_group_gauges(&mut self) {
         self.reclaim_unused_update_group_policies();
-        let mut member_counts: HashMap<usize, i64> = HashMap::new();
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        self.replacement_checkpoint(true);
+        let mut member_counts: HashMap<usize, i64> =
+            HashMap::with_capacity(self.update_groups.members.len());
+        self.replacement_checkpoint(true);
         let mut fallback = 0i64;
         // Recomputed for every member on each call, so the per-peer group
         // gauge is refreshed on every membership-change path (join, leave,
         // grouped↔grouped move, grouped↔fallback) — no guard. Peers that
         // left the map are dropped here and reaped on peer-down.
         for (peer, membership) in &self.update_groups.members {
+            checkpoint();
             let group_id = if let GroupMembership::Grouped(id) = membership {
                 *member_counts.entry(*id).or_default() += 1;
                 i64::try_from(*id).unwrap_or(i64::MAX)
@@ -1966,6 +2226,7 @@ impl RibManager {
             .set_update_groups(i64::try_from(member_counts.len()).unwrap_or(i64::MAX));
         self.metrics.set_update_group_fallback_peers(fallback);
         for id in 0..self.update_groups.groups.len() {
+            checkpoint();
             match member_counts.get(&id) {
                 Some(count) => self
                     .metrics
@@ -1973,6 +2234,9 @@ impl RibManager {
                 None => self.metrics.remove_update_group_members(&id.to_string()),
             }
         }
+        self.replacement_checkpoint(true);
+        crate::adj_rib_out::release_hash_map(&mut member_counts, &mut checkpoint);
+        self.replacement_checkpoint(true);
         // Group lifecycle (join builds a lane, the last leave drops
         // it) mutates lane state too, so the membership seams refresh
         // the lane gauge alongside the staging seam.
@@ -1985,8 +2249,19 @@ impl RibManager {
         if self.update_groups.reclamation_deferred {
             return;
         }
-        let mut groups: HashSet<usize> = self.group_ribs.keys().copied().collect();
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || super::replacement_readiness_checkpoint(&readiness, false);
+        let group_bound = self
+            .group_ribs
+            .len()
+            .saturating_add(self.update_groups.members.len())
+            .saturating_add(5);
+        self.replacement_checkpoint(true);
+        let mut groups: HashSet<usize> = HashSet::with_capacity(group_bound);
+        self.replacement_checkpoint(true);
+        groups.extend(self.group_ribs.keys().inspect(|_| checkpoint()).copied());
         groups.extend(self.update_groups.members.values().filter_map(|member| {
+            checkpoint();
             if let GroupMembership::Grouped(id) = member {
                 Some(*id)
             } else {
@@ -2000,23 +2275,42 @@ impl RibManager {
             groups.insert(prestage.destination);
         }
         groups.extend(self.prepared_destination);
-        let chains: HashSet<usize> = groups
-            .into_iter()
-            .filter_map(|id| self.update_groups.group_key(id).and_then(|key| key.chain))
-            .collect();
+        self.replacement_checkpoint(true);
+        let mut chains: HashSet<usize> = HashSet::with_capacity(groups.len());
+        self.replacement_checkpoint(true);
+        chains.extend(groups.drain().filter_map(|id| {
+            checkpoint();
+            self.update_groups.group_key(id).and_then(|key| key.chain)
+        }));
+        self.replacement_checkpoint(true);
+        drop(groups);
+        self.replacement_checkpoint(true);
         for (id, chain) in self.update_groups.chains.iter_mut().enumerate() {
+            checkpoint();
             if !chains.contains(&id) {
                 *chain = None;
             }
+            checkpoint();
         }
         // Heavy payloads reflect current ownership; small key slots remain
         // historical metadata, including rejected or discarded preparation.
         self.metrics.set_update_group_interned_chains(
-            i64::try_from(self.update_groups.retained_chain_count()).unwrap_or(i64::MAX),
+            i64::try_from(
+                self.update_groups
+                    .chains
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .filter(|chain| chain.is_some())
+                    .count(),
+            )
+            .unwrap_or(i64::MAX),
         );
         self.metrics.set_update_group_keys(
             i64::try_from(self.update_groups.groups.len()).unwrap_or(i64::MAX),
         );
+        self.replacement_checkpoint(true);
+        super::retire_hash_set(&mut chains, &mut checkpoint);
+        self.replacement_checkpoint(true);
     }
 
     /// Re-derive the ADR-0126 exception-lane gauge: total runner-up
@@ -2029,6 +2323,7 @@ impl RibManager {
         let entries = self
             .group_ribs
             .values()
+            .inspect(|_| self.replacement_checkpoint(false))
             .map(|group| group.runner_up.len())
             .sum::<usize>();
         self.metrics
@@ -2065,7 +2360,7 @@ impl RibManager {
                             .get(&peer)
                             .copied()
                             .unwrap_or_default(),
-                        group.vpn_member_counts_from_table(peer, filter.as_ref()),
+                        group.vpn_member_counts_from_table(peer, filter.as_ref(), &mut || {}),
                         "per-member VPN counters drifted from the table for {peer}"
                     );
                 }

--- a/crates/rib/src/manager/update_groups/membership.rs
+++ b/crates/rib/src/manager/update_groups/membership.rs
@@ -1,6 +1,6 @@
 use super::{
-    AdjRibOut, FxHashMap, GroupMembership, GroupRibOut, HashSet, IpAddr, PolicyChain, Prefix,
-    RegroupBaseline, RibManager, VpnRouteKey,
+    AdjRibOut, FxHashMap, GroupMembership, GroupRibOut, HashSet, IpAddr, PolicyChain,
+    RegroupBaseline, RibManager,
 };
 
 impl RibManager {
@@ -20,6 +20,9 @@ impl RibManager {
         reason = "the membership lifecycle keeps every residue-carry rule at one seam"
     )]
     pub(in crate::manager) fn recompute_update_group(&mut self, peer: IpAddr) {
+        let readiness = self.replacement_readiness.clone();
+        let mut checkpoint = || crate::manager::replacement_readiness_checkpoint(&readiness, false);
+        checkpoint();
         let membership = self.compute_update_group_membership(peer);
         let previous = self.update_groups.members.get(&peer).cloned();
         if previous.as_ref() == Some(&membership) {
@@ -69,8 +72,30 @@ impl RibManager {
                 Some(gid) => {
                     let group = self.group_ribs.get(&gid);
                     let base = group.map(|g| RegroupBaseline {
-                        unicast: g.member_view_snapshot(peer, rs_control, &rejected),
-                        vpn: g.member_vpn_view_snapshot(peer, rt_filter.as_ref(), &rejected),
+                        unicast: g.member_view_snapshot_with_checkpoint(
+                            peer,
+                            rs_control,
+                            &rejected,
+                            &mut |force| {
+                                if force {
+                                    self.replacement_checkpoint(true);
+                                } else {
+                                    self.replacement_checkpoint_at("fallback_baseline", false);
+                                }
+                            },
+                        ),
+                        vpn: g.member_vpn_view_snapshot_with_checkpoint(
+                            peer,
+                            rt_filter.as_ref(),
+                            &rejected,
+                            &mut |force| {
+                                if force {
+                                    self.replacement_checkpoint(true);
+                                } else {
+                                    self.replacement_checkpoint_at("fallback_baseline", false);
+                                }
+                            },
+                        ),
                     });
                     // A member that leaves while dirty may have missed
                     // withdrawals; carry the group tombstones along as
@@ -80,35 +105,58 @@ impl RibManager {
                         && (!g.tombstones.is_empty() || !g.vpn_tombstones.is_empty())
                     {
                         let extras = self.pending_extra_withdraws.entry(peer).or_default();
-                        extras.unicast.extend(g.tombstones.iter().copied());
-                        extras.vpn.extend(g.vpn_tombstones.iter().copied());
+                        extras
+                            .unicast
+                            .extend(g.tombstones.iter().inspect(|_| checkpoint()).copied());
+                        extras
+                            .vpn
+                            .extend(g.vpn_tombstones.iter().inspect(|_| checkpoint()).copied());
                     }
                     base
                 }
                 None if previous.is_some() => Some(
                     self.adj_ribs_out
                         .get(&peer)
-                        .map(|rib_out| RegroupBaseline {
-                            unicast: rib_out
-                                .iter()
-                                .map(|route| ((route.prefix, route.path_id), route.clone()))
-                                .collect(),
-                            // VPN moves to group ownership only for a
-                            // VPN-groupable peer; an RTC peer's VPN state
-                            // stays per-peer and must not be captured.
-                            vpn: if vpn_groupable {
-                                rib_out
-                                    .iter_vpn()
-                                    .map(|route| (route.nlri.key(), route.clone()))
-                                    .collect()
-                            } else {
-                                FxHashMap::default()
-                            },
+                        .map(|rib_out| {
+                            let mut unicast = FxHashMap::with_capacity_and_hasher(
+                                rib_out.len(),
+                                rustc_hash::FxBuildHasher,
+                            );
+                            checkpoint();
+                            for route in rib_out.iter() {
+                                self.replacement_checkpoint_at("fallback_baseline", false);
+                                unicast.insert((route.prefix, route.path_id), route.clone());
+                            }
+                            let mut vpn = FxHashMap::default();
+                            if vpn_groupable {
+                                vpn = FxHashMap::with_capacity_and_hasher(
+                                    rib_out.vpn_len(),
+                                    rustc_hash::FxBuildHasher,
+                                );
+                                checkpoint();
+                                for route in rib_out.iter_vpn() {
+                                    self.replacement_checkpoint_at("fallback_baseline", false);
+                                    vpn.insert(route.nlri.key(), route.clone());
+                                }
+                            }
+                            RegroupBaseline { unicast, vpn }
                         })
                         .unwrap_or_default(),
                 ),
                 None => None,
             };
+            if let Some(base) = &baseline {
+                self.replacement_capacity(
+                    "transient_baseline_unicast",
+                    base.unicast.len(),
+                    base.unicast.capacity(),
+                );
+                self.replacement_capacity(
+                    "transient_baseline_vpn",
+                    base.vpn.len(),
+                    base.vpn.capacity(),
+                );
+            }
             if let Some(gid) = prev_gid {
                 self.leave_group(gid, peer);
             } else if previous.is_some() {
@@ -121,9 +169,12 @@ impl RibManager {
                 // ownership into the bounded member set first.
                 self.carry_outbound_admitted_across_regroup(peer, true);
                 if let Some(rib_out) = self.adj_ribs_out.get_mut(&peer) {
-                    rib_out.release_unicast();
+                    let readiness = &self.replacement_readiness;
+                    let mut checkpoint =
+                        || crate::manager::replacement_readiness_checkpoint(readiness, true);
+                    rib_out.release_unicast_with(&mut checkpoint);
                     if vpn_groupable {
-                        rib_out.release_vpn();
+                        rib_out.release_vpn_with(&mut checkpoint);
                     }
                 }
             }
@@ -154,13 +205,34 @@ impl RibManager {
                 // per-peer destinations: neither gets a baseline /
                 // seeded Adj-RIB-Out to suppress against.
                 (Some(base), _) if prev_gid.is_some() && self.dirty_peers.contains(&peer) => {
-                    let extras = self.pending_extra_withdraws.entry(peer).or_default();
-                    if let Some(prev) = self.pending_regroup_baseline.remove(&peer) {
-                        extras.unicast.extend(prev.unicast.into_keys());
-                        extras.vpn.extend(prev.vpn.into_keys());
+                    let previous = self.pending_regroup_baseline.remove(&peer);
+                    if let Some(prev) = &previous {
+                        self.replacement_capacity(
+                            "transient_baseline_unicast",
+                            prev.unicast.len(),
+                            prev.unicast.capacity(),
+                        );
+                        self.replacement_capacity(
+                            "transient_baseline_vpn",
+                            prev.vpn.len(),
+                            prev.vpn.capacity(),
+                        );
                     }
-                    extras.unicast.extend(base.unicast.into_keys());
-                    extras.vpn.extend(base.vpn.into_keys());
+                    let extras = self.pending_extra_withdraws.entry(peer).or_default();
+                    for baseline in previous.into_iter().chain(std::iter::once(base)) {
+                        let mut unicast = baseline.unicast.into_keys();
+                        extras
+                            .unicast
+                            .extend(unicast.by_ref().inspect(|_| checkpoint()));
+                        crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                        drop(unicast);
+                        crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                        let mut vpn = baseline.vpn.into_keys();
+                        extras.vpn.extend(vpn.by_ref().inspect(|_| checkpoint()));
+                        crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                        drop(vpn);
+                        crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                    }
                 }
                 (Some(mut base), Some(_)) => {
                     // A grouped member keeps no per-family record of its
@@ -178,10 +250,21 @@ impl RibManager {
                     if self.dirty_peers.contains(&peer)
                         && let Some(prev) = self.pending_regroup_baseline.remove(&peer)
                     {
-                        base.unicast.extend(prev.unicast);
-                        base.vpn.extend(prev.vpn);
+                        base.merge_prior(prev, &mut checkpoint);
                     }
-                    self.pending_regroup_baseline.insert(peer, base);
+                    self.replacement_capacity(
+                        "transient_baseline_unicast",
+                        base.unicast.len(),
+                        base.unicast.capacity(),
+                    );
+                    self.replacement_capacity(
+                        "transient_baseline_vpn",
+                        base.vpn.len(),
+                        base.vpn.capacity(),
+                    );
+                    if let Some(mut replaced) = self.pending_regroup_baseline.insert(peer, base) {
+                        replaced.retire_with(&mut checkpoint);
+                    }
                 }
                 (Some(mut base), None) => {
                     // Back on the per-peer path: seed Adj-RIB-Out with
@@ -196,20 +279,41 @@ impl RibManager {
                     if self.dirty_peers.contains(&peer)
                         && let Some(prev) = self.pending_regroup_baseline.remove(&peer)
                     {
-                        base.unicast.extend(prev.unicast);
-                        base.vpn.extend(prev.vpn);
+                        base.merge_prior(prev, &mut checkpoint);
                     }
-                    let loc_rib_len = self.loc_rib.len();
+                    self.replacement_capacity(
+                        "transient_baseline_unicast",
+                        base.unicast.len(),
+                        base.unicast.capacity(),
+                    );
+                    self.replacement_capacity(
+                        "transient_baseline_vpn",
+                        base.vpn.len(),
+                        base.vpn.capacity(),
+                    );
+                    let loc_rib_len = self.loc_rib.len().max(base.unicast.len());
                     let rib_out = self
                         .adj_ribs_out
                         .entry(peer)
                         .or_insert_with(|| AdjRibOut::with_capacity(peer, loc_rib_len));
-                    for route in base.unicast.into_values() {
-                        rib_out.insert(route);
+                    rib_out.reserve_unicast_with(base.unicast.len(), &mut checkpoint);
+                    rib_out.reserve_vpn_with(base.vpn.len(), &mut checkpoint);
+                    let mut unicast = base.unicast.into_values();
+                    for route in unicast.by_ref() {
+                        checkpoint();
+                        rib_out.insert_with(route, &mut checkpoint);
                     }
-                    for route in base.vpn.into_values() {
+                    crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                    drop(unicast);
+                    crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                    let mut vpn = base.vpn.into_values();
+                    for route in vpn.by_ref() {
+                        checkpoint();
                         rib_out.insert_vpn(route);
                     }
+                    crate::manager::replacement_readiness_checkpoint(&readiness, true);
+                    drop(vpn);
+                    crate::manager::replacement_readiness_checkpoint(&readiness, true);
                 }
                 (None, _) => {}
             }
@@ -242,7 +346,10 @@ impl RibManager {
     /// correct only while the group is memberless). `peer` is the
     /// exemplar whose group-uniform staging inputs seed the profile.
     pub(in crate::manager) fn ensure_group_table(&mut self, gid: usize, peer: IpAddr) {
+        let readiness = self.replacement_readiness.clone();
+        let checkpoint = || crate::manager::replacement_readiness_checkpoint(&readiness, false);
         if !self.group_ribs.contains_key(&gid) {
+            self.replacement_checkpoint(true);
             let group = GroupRibOut::new(
                 // `share()`, not `clone()`: the snapshot must keep
                 // feeding the installed chain's ADR-0096 hit counters.
@@ -266,24 +373,57 @@ impl RibManager {
                     .is_some_and(|key| key.per_client_best),
                 self.loc_rib.len(),
             );
+            self.replacement_checkpoint(true);
             self.group_ribs.insert(gid, group);
-            let prefixes: HashSet<Prefix> = self.loc_rib.iter().map(|r| r.prefix).collect();
+            self.replacement_checkpoint(true);
+            let mut prefixes = HashSet::with_capacity(self.loc_rib.len());
+            self.replacement_checkpoint(true);
+            prefixes.extend(
+                self.loc_rib
+                    .iter()
+                    .inspect(|_| checkpoint())
+                    .map(|r| r.prefix),
+            );
             let mut memo = crate::manager::distribution::ExportMemo::default();
             // Deltas of the build passes are discarded: there are no
             // members yet, and the joining member replays the whole
             // table anyway.
-            let _ = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+            let mut staged = self.stage_group_prefixes(gid, &prefixes, &mut memo);
+            staged.retire_with(&mut |force| self.replacement_checkpoint(force));
+            drop(staged);
+            self.replacement_checkpoint(true);
             if self
                 .group_ribs
                 .get(&gid)
                 .is_some_and(GroupRibOut::stages_vpn)
             {
-                let keys: HashSet<VpnRouteKey> =
-                    self.loc_rib.iter_vpn().map(|r| r.nlri.key()).collect();
+                self.replacement_checkpoint(true);
+                let mut keys = HashSet::with_capacity(self.loc_rib.vpn_len());
+                self.replacement_checkpoint(true);
+                keys.extend(
+                    self.loc_rib
+                        .iter_vpn()
+                        .inspect(|_| checkpoint())
+                        .map(|r| r.nlri.key()),
+                );
                 if !keys.is_empty() {
-                    let _ = self.stage_group_vpn_keys(gid, &keys);
+                    let mut staged = self.stage_group_vpn_keys(gid, &keys);
+                    staged.retire_with(&mut |force| self.replacement_checkpoint(force));
                 }
+                self.replacement_checkpoint(true);
+                crate::manager::retire_hash_set(&mut keys, &mut || checkpoint());
+                self.replacement_checkpoint(true);
             }
+            self.replacement_checkpoint(true);
+            #[cfg(feature = "bench-internals")]
+            memo.record_replacement_capacities(self);
+            memo.retire_with(&mut || checkpoint());
+            self.replacement_checkpoint(true);
+            crate::manager::retire_hash_set(&mut prefixes, &mut || checkpoint());
+            self.replacement_checkpoint(true);
+            drop(memo);
+            drop(prefixes);
+            self.replacement_checkpoint(true);
         }
     }
 
@@ -314,12 +454,22 @@ impl RibManager {
         // The joining member's advertised-count seed (RTC groups only):
         // the O(table) walk rides the join replay's existing cost.
         let filter = self.member_rt_filter(peer);
+        let readiness = self.replacement_readiness.clone();
+        #[cfg(feature = "bench-internals")]
+        if let Some(group) = self.group_ribs.get(&gid) {
+            let (len, slots, capacity) = group.table.bench_unicast_storage_shape();
+            self.replacement_storage_shape("group_before_shrink", len, capacity, slots);
+        }
         if let Some(group) = self.group_ribs.get_mut(&gid) {
             if group.members.is_empty() {
+                super::super::replacement_readiness_checkpoint(&readiness, true);
                 group.table.shrink_unicast_to_fit();
+                super::super::replacement_readiness_checkpoint(&readiness, true);
             }
             group.members.insert(peer);
-            group.recompute_vpn_member_counts(peer, filter.as_ref());
+            group.recompute_vpn_member_counts(peer, filter.as_ref(), &mut || {
+                super::super::replacement_readiness_checkpoint(&readiness, false);
+            });
         }
     }
 }

--- a/crates/rib/src/manager/update_groups/payload.rs
+++ b/crates/rib/src/manager/update_groups/payload.rs
@@ -36,7 +36,7 @@ pub(in crate::manager) struct GroupDelta {
     pub(in crate::manager) source_attrs: Option<Arc<Vec<PathAttribute>>>,
     /// ADR-0126 Decision 5: the RECOMPUTED (post-pass) exception-lane
     /// entry for this delta's prefix, carried on per-client-best
-    /// announce deltas so [`emit_group_deltas_for_member`] stays a
+    /// announce deltas so [`emit_group_deltas_for_member_with_checkpoint`] stays a
     /// self-contained free fn. The `member == source(w_new)` arm reads
     /// it directly: a member becoming the winner's source receives the
     /// runner-up substitution (or a withdraw when the lane is empty)
@@ -102,7 +102,7 @@ pub(in crate::manager) struct AdvEntry<'a> {
 /// `(new, old_source)` shape as [`GroupDelta`]. Carried beside the
 /// winner deltas so the lane-only case (runner-up flips or retires
 /// while the winner is unchanged) has a first-class encoding, consumed
-/// per member by [`emit_lane_deltas_for_member`].
+/// per member by [`emit_lane_deltas_for_member_with_checkpoint`].
 #[derive(Debug, Clone)]
 pub(in crate::manager) struct LaneDelta {
     pub(in crate::manager) prefix: Prefix,
@@ -130,7 +130,7 @@ pub(in crate::manager) struct LaneDelta {
     /// The post-policy lane route is content-equal across the
     /// transition (`routes_equal`) — the transition was recorded only
     /// because the SOURCE control communities moved. The emit arm then
-    /// mirrors [`emit_rs_tag_transitions`]: nothing toward a non-rs
+    /// mirrors [`emit_rs_tag_transitions_with_checkpoint`]: nothing toward a non-rs
     /// target (its wire form is unchanged — the per-peer path would
     /// equality-suppress), withdraw/re-announce toward an rs-control
     /// target exactly when its suppress/prepend verdict flips.
@@ -221,6 +221,44 @@ pub(in crate::manager) struct CleanPolicyTransitionInventory {
     pub(in crate::manager) permit_by_source: HashMap<IpAddr, HashMap<Option<String>, u64>>,
 }
 
+impl CleanPolicyTransitionInventory {
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        retire_clean_policy_counts(
+            &mut self.permit_totals,
+            &mut self.permit_by_source,
+            checkpoint,
+        );
+        drop(std::mem::take(&mut self.announce));
+        checkpoint(true);
+        drop(std::mem::take(&mut self.next_hop_override));
+        checkpoint(true);
+    }
+}
+
+fn retire_clean_policy_counts(
+    permit_totals: &mut HashMap<Option<String>, u64>,
+    permit_by_source: &mut HashMap<IpAddr, HashMap<Option<String>, u64>>,
+    checkpoint: &mut impl FnMut(bool),
+) {
+    for row in permit_totals.drain() {
+        drop(row);
+        checkpoint(false);
+    }
+    for (_, mut rows) in permit_by_source.drain() {
+        for row in rows.drain() {
+            drop(row);
+            checkpoint(false);
+        }
+        checkpoint(false);
+    }
+    checkpoint(true);
+    drop(std::mem::take(permit_totals));
+    checkpoint(true);
+    drop(std::mem::take(permit_by_source));
+    checkpoint(true);
+}
+
 /// Pre-emission inventory accumulated by the actor-owned clean transition.
 /// The builder is private to that transaction and never represents committed
 /// peer-visible state.
@@ -233,10 +271,29 @@ pub(in crate::manager) struct CleanPolicyTransitionInventoryBuilder {
 }
 
 impl CleanPolicyTransitionInventoryBuilder {
-    pub(in crate::manager) fn finish(self) -> CleanPolicyTransitionInventory {
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        crate::manager::retire_vec(&mut self.announce, &mut || checkpoint(false));
+        crate::manager::retire_vec(&mut self.next_hop_override, &mut || checkpoint(false));
+        retire_clean_policy_counts(
+            &mut self.permit_totals,
+            &mut self.permit_by_source,
+            checkpoint,
+        );
+    }
+
+    pub(in crate::manager) fn finish(
+        self,
+        checkpoint: &mut impl FnMut(bool),
+    ) -> CleanPolicyTransitionInventory {
+        checkpoint(true);
+        let announce = self.announce.into();
+        checkpoint(true);
+        let next_hop_override = self.next_hop_override.into();
+        checkpoint(true);
         CleanPolicyTransitionInventory {
-            announce: self.announce.into(),
-            next_hop_override: self.next_hop_override.into(),
+            announce,
+            next_hop_override,
             permit_totals: self.permit_totals,
             permit_by_source: self.permit_by_source,
         }
@@ -282,7 +339,7 @@ pub(in crate::manager) struct GroupStageOutput {
     /// Deliberately outside `deltas` and the shared emission: exactly
     /// one member acts on a lane transition (its
     /// [`LaneDelta::emit_target`]), via
-    /// [`emit_lane_deltas_for_member`] in the per-member walk.
+    /// [`emit_lane_deltas_for_member_with_checkpoint`] in the per-member walk.
     pub(in crate::manager) lane_deltas: Vec<LaneDelta>,
     /// Members whose emission differs from the shared one: the new
     /// source of an announce delta (announce → substitution/withdraw),
@@ -303,10 +360,16 @@ pub(in crate::manager) struct GroupStageOutput {
 impl GroupStageOutput {
     /// Keys withdrawn by this pass — the tombstone contribution when a
     /// member is (or goes) dirty.
-    pub(in crate::manager) fn withdrawn_keys(&self) -> impl Iterator<Item = (Prefix, u32)> + '_ {
+    pub(in crate::manager) fn withdrawn_keys<'a>(
+        &'a self,
+        mut checkpoint: impl FnMut() + 'a,
+    ) -> impl Iterator<Item = (Prefix, u32)> + 'a {
         self.deltas
             .iter()
-            .filter(|d| d.new.is_none())
+            .filter(move |d| {
+                checkpoint();
+                d.new.is_none()
+            })
             .map(|d| (d.prefix, d.path_id))
     }
 
@@ -345,13 +408,23 @@ impl GroupStageOutput {
     /// on EITHER side of policy: source tags drive suppress/prepend,
     /// post-policy tags need scrubbing; a tag-only transition counts on
     /// either side of the pass. Callers memoize per (group, `rs_asn`).
+    #[cfg(test)]
     pub(in crate::manager) fn has_tagged_route(&self, rs_asn: u32) -> bool {
+        self.has_tagged_route_with_checkpoint(rs_asn, &mut || {})
+    }
+
+    pub(in crate::manager) fn has_tagged_route_with_checkpoint(
+        &self,
+        rs_asn: u32,
+        checkpoint: &mut impl FnMut(),
+    ) -> bool {
         use crate::manager::distribution::rs_control::rs_control_route_tagged;
         let attrs_tagged = |attrs: Option<&Arc<Vec<PathAttribute>>>| {
             let (communities, large_communities) = source_control_input(attrs);
             rs_control_route_tagged(communities, large_communities, rs_asn)
         };
         self.deltas.iter().any(|delta| {
+            checkpoint();
             delta.new.as_ref().is_some_and(|(route, _)| {
                 attrs_tagged(delta.source_attrs.as_ref())
                     || rs_control_route_tagged(
@@ -361,9 +434,11 @@ impl GroupStageOutput {
                     )
             })
         }) || self.rs_transitions.iter().any(|transition| {
+            checkpoint();
             attrs_tagged(transition.prior_source_attrs.as_ref())
                 || attrs_tagged(transition.source_attrs.as_ref())
         }) || self.lane_deltas.iter().any(|delta| {
+            checkpoint();
             // ADR-0126: a tagged lane source must push `source(w)`
             // onto the per-member walk — the substituted announce
             // applies suppress/prepend/scrub from the LANE entry's
@@ -407,13 +482,15 @@ impl GroupStageOutput {
     /// Lost member-scoped ANNOUNCES (a lane flip or a substitution)
     /// leave no residue on purpose: announces are idempotent and the
     /// dirty resync re-derives them from `adv(m)`.
-    pub(in crate::manager) fn member_scoped_withdraws(
-        &self,
+    pub(in crate::manager) fn member_scoped_withdraws<'a>(
+        &'a self,
         member: IpAddr,
-    ) -> impl Iterator<Item = (Prefix, u32)> + '_ {
+        checkpoint: impl Fn() + Copy + 'a,
+    ) -> impl Iterator<Item = (Prefix, u32)> + 'a {
         self.deltas
             .iter()
             .filter_map(move |delta| {
+                checkpoint();
                 (delta
                     .new
                     .as_ref()
@@ -422,6 +499,7 @@ impl GroupStageOutput {
                 .then_some((delta.prefix, delta.path_id))
             })
             .chain(self.lane_deltas.iter().filter_map(move |delta| {
+                checkpoint();
                 (delta.new.is_none() && delta.emit_target == Some(member))
                     .then_some((delta.prefix, 0))
             }))
@@ -429,10 +507,26 @@ impl GroupStageOutput {
 
     /// Build the shared emission from the committed deltas (one `Route`
     /// shell clone per delta, TOTAL — not per member).
-    pub(super) fn build_shared_emit(&mut self) {
-        let mut announce: Vec<Route> = Vec::new();
-        let mut nh: Vec<Option<NextHopAction>> = Vec::new();
+    pub(super) fn build_shared_emit(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        let announce_count = self
+            .deltas
+            .iter()
+            .filter(|delta| {
+                checkpoint(false);
+                delta.new.is_some()
+            })
+            .count();
+        checkpoint(true);
+        let mut announce: Vec<Route> = Vec::with_capacity(announce_count);
+        checkpoint(true);
+        let mut nh: Vec<Option<NextHopAction>> = Vec::with_capacity(announce_count);
+        checkpoint(true);
+        self.shared_withdraw
+            .reserve_exact(self.deltas.len() - announce_count);
+        checkpoint(true);
         for delta in &self.deltas {
+            checkpoint(false);
             if let Some((route, flag)) = &delta.new {
                 self.exceptions.insert(route.peer);
                 if delta.old_source.is_some() || delta.lane.is_some() {
@@ -457,13 +551,42 @@ impl GroupStageOutput {
         // (inserted above) or exactly served by the shared payload
         // (the flip-away arm announces `w'` to it).
         for delta in &self.lane_deltas {
+            checkpoint(false);
             if let Some(target) = delta.emit_target {
                 self.exceptions.insert(target);
                 self.source_exclusion_unsafe.insert(target);
             }
         }
+        checkpoint(true);
         self.shared_announce = announce.into();
+        checkpoint(true);
         self.shared_nh = nh.into();
+        checkpoint(true);
+    }
+
+    /// Retire discarded staging shells while the replacement fence is held.
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        crate::manager::retire_vec(&mut self.deltas, &mut || checkpoint(false));
+        crate::manager::retire_vec(&mut self.otc_blocked, &mut || checkpoint(false));
+        crate::manager::retire_vec(&mut self.rs_transitions, &mut || checkpoint(false));
+        crate::manager::retire_vec(&mut self.lane_deltas, &mut || checkpoint(false));
+        self.evals.retire_with(checkpoint);
+        crate::manager::retire_vec(&mut self.shared_withdraw, &mut || checkpoint(false));
+        crate::manager::retire_hash_set(&mut self.exceptions, &mut || checkpoint(false));
+        crate::manager::retire_hash_set(&mut self.source_exclusion_unsafe, &mut || {
+            checkpoint(false);
+        });
+        for _ in self.shared_source_counts.drain() {
+            checkpoint(false);
+        }
+        checkpoint(true);
+        drop(std::mem::take(&mut self.shared_source_counts));
+        checkpoint(true);
+        drop(std::mem::take(&mut self.shared_announce));
+        checkpoint(true);
+        drop(std::mem::take(&mut self.shared_nh));
+        checkpoint(true);
     }
 }
 
@@ -487,6 +610,27 @@ pub(in crate::manager) struct BatchedTransitionInventory {
     /// (announce) and the displaced/retired own-sourced slot (withdraw).
     pub(in crate::manager) supplements: FxHashMap<IpAddr, BatchedMemberSupplement>,
     pub(super) counters: BatchedTransitionCounters,
+}
+
+impl BatchedTransitionInventory {
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        crate::manager::retire_vec(&mut self.withdraw, &mut || checkpoint(false));
+        for (_, mut supplement) in self.supplements.drain() {
+            checkpoint(false);
+            crate::manager::retire_vec(&mut supplement.announce, &mut || checkpoint(false));
+            crate::manager::retire_vec(&mut supplement.withdraw, &mut || checkpoint(false));
+        }
+        checkpoint(true);
+        drop(std::mem::take(&mut self.supplements));
+        checkpoint(true);
+        self.counters.retire_with(checkpoint);
+        checkpoint(true);
+        drop(std::mem::take(&mut self.announce));
+        checkpoint(true);
+        drop(std::mem::take(&mut self.next_hop_override));
+        checkpoint(true);
+    }
 }
 
 /// One member's corrections beside the shared batched-transition payload.
@@ -514,6 +658,34 @@ pub(super) struct BatchedTransitionCounters {
 }
 
 impl BatchedTransitionCounters {
+    pub(super) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        for totals in [&mut self.permit_totals, &mut self.deny_totals] {
+            for row in totals.drain() {
+                drop(row);
+                checkpoint(false);
+            }
+            checkpoint(true);
+            drop(std::mem::take(totals));
+            checkpoint(true);
+        }
+        for by_source in [
+            &mut self.permit_by_source,
+            &mut self.lane_by_winner_source,
+            &mut self.deny_by_source,
+        ] {
+            for (_, mut rows) in by_source.drain() {
+                for row in rows.drain() {
+                    drop(row);
+                    checkpoint(false);
+                }
+                checkpoint(false);
+            }
+            checkpoint(true);
+            drop(std::mem::take(by_source));
+            checkpoint(true);
+        }
+    }
+
     pub(super) fn record_permit(&mut self, source: IpAddr, label: Option<PolicyLabel>) {
         *self
             .permit_by_source
@@ -548,18 +720,27 @@ impl BatchedTransitionCounters {
     /// [`RibManager::apply_group_join_counters`](super::RibManager::apply_group_join_counters)
     /// derives per member from
     /// a full table walk.
-    pub(super) fn rows_for(&self, peer: IpAddr) -> Vec<(Option<String>, PolicyAction, u64)> {
+    pub(super) fn rows_for(
+        &self,
+        peer: IpAddr,
+        checkpoint: &mut impl FnMut(),
+    ) -> Vec<(Option<String>, PolicyAction, u64)> {
         let mut rows = Vec::new();
         let own_permits = self.permit_by_source.get(&peer);
         let lane = self.lane_by_winner_source.get(&peer);
-        let mut labels: Vec<&Option<PolicyLabel>> = self.permit_totals.keys().collect();
+        let mut labels: Vec<&Option<PolicyLabel>> = self
+            .permit_totals
+            .keys()
+            .inspect(|_| checkpoint())
+            .collect();
         if let Some(lane) = lane {
-            labels.extend(
-                lane.keys()
-                    .filter(|label| !self.permit_totals.contains_key(*label)),
-            );
+            labels.extend(lane.keys().filter(|label| {
+                checkpoint();
+                !self.permit_totals.contains_key(*label)
+            }));
         }
         for label in labels {
+            checkpoint();
             let total = self.permit_totals.get(label).copied().unwrap_or(0);
             let own = own_permits
                 .and_then(|counts| counts.get(label))
@@ -580,6 +761,7 @@ impl BatchedTransitionCounters {
         }
         let own_denies = self.deny_by_source.get(&peer);
         for (label, total) in &self.deny_totals {
+            checkpoint();
             let own = own_denies
                 .and_then(|counts| counts.get(label))
                 .copied()
@@ -636,10 +818,19 @@ pub(super) fn bump_counter_row(
     policy: Option<&PolicyLabel>,
     action: PolicyAction,
 ) {
-    if let Some((_, _, n)) = rows
-        .iter_mut()
-        .find(|(p, a, _)| *a == action && p.as_deref() == policy.map(AsRef::as_ref))
-    {
+    bump_counter_row_with_checkpoint(rows, policy, action, &mut || {});
+}
+
+pub(super) fn bump_counter_row_with_checkpoint(
+    rows: &mut Vec<(Option<String>, PolicyAction, u64)>,
+    policy: Option<&PolicyLabel>,
+    action: PolicyAction,
+    checkpoint: &mut impl FnMut(),
+) {
+    if let Some((_, _, n)) = rows.iter_mut().find(|(p, a, _)| {
+        checkpoint();
+        *a == action && p.as_deref() == policy.map(AsRef::as_ref)
+    }) {
         *n += 1;
     } else {
         rows.push((policy.map(ToString::to_string), action, 1));
@@ -647,6 +838,17 @@ pub(super) fn bump_counter_row(
 }
 
 impl GroupEvalAccumulator {
+    fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        crate::manager::retire_vec(&mut self.totals, &mut || checkpoint(false));
+        for (_, mut rows) in self.per_source.drain() {
+            checkpoint(false);
+            crate::manager::retire_vec(&mut rows, &mut || checkpoint(false));
+        }
+        checkpoint(true);
+        drop(std::mem::take(&mut self.per_source));
+        checkpoint(true);
+    }
+
     /// Record one chain evaluation for the route sourced by `source`.
     pub(in crate::manager) fn record(&mut self, evaluation: &PolicyEvaluation, source: IpAddr) {
         bump_eval_row(
@@ -685,7 +887,7 @@ impl GroupEvalAccumulator {
 /// the displaced other-sourced entry otherwise. A member that ALREADY
 /// was the source (`old_source` = member) holds the lane substitution,
 /// which transitions only with the lane — its emissions ride
-/// [`emit_lane_deltas_for_member`] (same for the retiring source of a
+/// [`emit_lane_deltas_for_member_with_checkpoint`] (same for the retiring source of a
 /// withdraw delta, whose lane-retire withdraw rides the same arm).
 /// For a plain group `lane` is always `None`, reducing every cell to
 /// the historical matrix above it.
@@ -703,6 +905,7 @@ impl GroupEvalAccumulator {
 /// route is rewritten per target — prepend decided on the source,
 /// scrub on the post-policy route. `None` — or an untagged source and
 /// route — is byte-identical to the shared emission.
+#[cfg(test)]
 pub(in crate::manager) fn emit_group_deltas_for_member(
     deltas: &[GroupDelta],
     member: IpAddr,
@@ -711,10 +914,31 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
     withdraw: &mut Vec<(Prefix, u32)>,
     nh_override_flags: &mut Vec<Option<NextHopAction>>,
 ) {
+    emit_group_deltas_for_member_with_checkpoint(
+        deltas,
+        member,
+        rs_control,
+        announce,
+        withdraw,
+        nh_override_flags,
+        &mut || {},
+    );
+}
+
+pub(in crate::manager) fn emit_group_deltas_for_member_with_checkpoint(
+    deltas: &[GroupDelta],
+    member: IpAddr,
+    rs_control: Option<(u32, u32)>,
+    announce: &mut Vec<Route>,
+    withdraw: &mut Vec<(Prefix, u32)>,
+    nh_override_flags: &mut Vec<Option<NextHopAction>>,
+    checkpoint: &mut impl FnMut(),
+) {
     use crate::manager::distribution::rs_control::{
         rs_control_route_rewrite, rs_control_suppressed,
     };
     for delta in deltas {
+        checkpoint();
         match &delta.new {
             Some((route, nh)) => {
                 let (source_communities, source_large_communities) =
@@ -813,10 +1037,11 @@ pub(in crate::manager) fn emit_group_deltas_for_member(
 /// target's wire held (over-withdraw is the safe direction, as in the
 /// winner matrix), and a content-equal tag-only transition
 /// ([`LaneDelta::content_unchanged`]) mirrors
-/// [`emit_rs_tag_transitions`] — nothing toward a non-rs target,
+/// [`emit_rs_tag_transitions_with_checkpoint`] — nothing toward a non-rs target,
 /// withdraw/re-announce toward an rs target exactly on a
 /// suppress/prepend verdict flip. A no-op for every member other
 /// than the target, and for plain groups (no lane deltas exist).
+#[cfg(test)]
 pub(in crate::manager) fn emit_lane_deltas_for_member(
     lane_deltas: &[LaneDelta],
     member: IpAddr,
@@ -825,10 +1050,31 @@ pub(in crate::manager) fn emit_lane_deltas_for_member(
     withdraw: &mut Vec<(Prefix, u32)>,
     nh_override_flags: &mut Vec<Option<NextHopAction>>,
 ) {
+    emit_lane_deltas_for_member_with_checkpoint(
+        lane_deltas,
+        member,
+        rs_control,
+        announce,
+        withdraw,
+        nh_override_flags,
+        &mut || {},
+    );
+}
+
+pub(in crate::manager) fn emit_lane_deltas_for_member_with_checkpoint(
+    lane_deltas: &[LaneDelta],
+    member: IpAddr,
+    rs_control: Option<(u32, u32)>,
+    announce: &mut Vec<Route>,
+    withdraw: &mut Vec<(Prefix, u32)>,
+    nh_override_flags: &mut Vec<Option<NextHopAction>>,
+    checkpoint: &mut impl FnMut(),
+) {
     use crate::manager::distribution::rs_control::{
         rs_control_prepend_count, rs_control_route_rewrite, rs_control_suppressed,
     };
     for delta in lane_deltas {
+        checkpoint();
         if delta.emit_target != Some(member) {
             continue;
         }
@@ -893,6 +1139,7 @@ pub(in crate::manager) fn emit_lane_deltas_for_member(
 /// restage + Adj-RIB-Out diff would emit. A no-op for members without
 /// `rs_control_communities`: their wire form is the unchanged staged
 /// route.
+#[cfg(test)]
 pub(in crate::manager) fn emit_rs_tag_transitions(
     transitions: &[RsTagTransition],
     member: IpAddr,
@@ -901,6 +1148,26 @@ pub(in crate::manager) fn emit_rs_tag_transitions(
     withdraw: &mut Vec<(Prefix, u32)>,
     nh_override_flags: &mut Vec<Option<NextHopAction>>,
 ) {
+    emit_rs_tag_transitions_with_checkpoint(
+        transitions,
+        member,
+        rs_control,
+        announce,
+        withdraw,
+        nh_override_flags,
+        &mut || {},
+    );
+}
+
+pub(in crate::manager) fn emit_rs_tag_transitions_with_checkpoint(
+    transitions: &[RsTagTransition],
+    member: IpAddr,
+    rs_control: Option<(u32, u32)>,
+    announce: &mut Vec<Route>,
+    withdraw: &mut Vec<(Prefix, u32)>,
+    nh_override_flags: &mut Vec<Option<NextHopAction>>,
+    checkpoint: &mut impl FnMut(),
+) {
     use crate::manager::distribution::rs_control::{
         rs_control_prepend_count, rs_control_route_rewrite, rs_control_suppressed,
     };
@@ -908,6 +1175,7 @@ pub(in crate::manager) fn emit_rs_tag_transitions(
         return;
     };
     for transition in transitions {
+        checkpoint();
         if transition.route.peer == member {
             continue;
         }
@@ -969,6 +1237,14 @@ pub(in crate::manager) struct VpnGroupStageOutput {
 }
 
 impl VpnGroupStageOutput {
+    /// Retire a table-build pass's unused route shells cooperatively.
+    pub(in crate::manager) fn retire_with(&mut self, checkpoint: &mut impl FnMut(bool)) {
+        checkpoint(true);
+        crate::manager::retire_vec(&mut self.deltas, &mut || checkpoint(false));
+        self.evals.retire_with(checkpoint);
+        checkpoint(true);
+    }
+
     /// Member-scoped withdraw keys of this pass that the VPN tombstone
     /// feed (deltas with `new == None`) never records: `had ∧ ¬gets`
     /// entries whose delta still holds a staged route — a source flip
@@ -980,8 +1256,10 @@ impl VpnGroupStageOutput {
         &'a self,
         member: IpAddr,
         filter: Option<&'a RtcMembership>,
+        mut checkpoint: impl FnMut() + 'a,
     ) -> impl Iterator<Item = VpnRouteKey> + 'a {
         self.deltas.iter().filter_map(move |delta| {
+            checkpoint();
             let had = delta
                 .old
                 .as_ref()
@@ -1019,6 +1297,7 @@ pub(in crate::manager) fn rt_passes(filter: Option<&RtcMembership>, route: &VpnR
 /// `[vpnv4, vpnv6]` (`gets ∧ ¬had` = +1, `had ∧ ¬gets` = −1) — the
 /// incremental input for the per-member counters an RT filter makes
 /// non-derivable from the group's source counts (design §2.4).
+#[cfg(test)]
 pub(in crate::manager) fn emit_vpn_group_deltas_for_member(
     deltas: &[VpnGroupDelta],
     member: IpAddr,
@@ -1026,8 +1305,27 @@ pub(in crate::manager) fn emit_vpn_group_deltas_for_member(
     vpn_announce: &mut Vec<VpnRibRoute>,
     vpn_withdraw: &mut Vec<VpnRibRouteKey>,
 ) -> [i64; 2] {
+    emit_vpn_group_deltas_for_member_with_checkpoint(
+        deltas,
+        member,
+        filter,
+        vpn_announce,
+        vpn_withdraw,
+        &mut || {},
+    )
+}
+
+pub(in crate::manager) fn emit_vpn_group_deltas_for_member_with_checkpoint(
+    deltas: &[VpnGroupDelta],
+    member: IpAddr,
+    filter: Option<&RtcMembership>,
+    vpn_announce: &mut Vec<VpnRibRoute>,
+    vpn_withdraw: &mut Vec<VpnRibRouteKey>,
+    checkpoint: &mut impl FnMut(),
+) -> [i64; 2] {
     let mut count_delta = [0i64; 2];
     for delta in deltas {
+        checkpoint();
         let had = delta
             .old
             .as_ref()

--- a/crates/rib/src/manager/update_groups/policy_transition.rs
+++ b/crates/rib/src/manager/update_groups/policy_transition.rs
@@ -51,12 +51,19 @@ impl RibManager {
         if !clean(old) || !clean(new) || old.table.len() != new.table.len() {
             return None;
         }
-        Some(
-            new.table
-                .iter()
-                .map(|route| (route.prefix, route.path_id))
-                .collect(),
-        )
+        self.replacement_checkpoint(true);
+        let mut keys = Vec::with_capacity(new.table.len());
+        self.replacement_checkpoint(true);
+        for route in new.table.iter() {
+            crate::manager::replacement_readiness_checkpoint_at(
+                &self.replacement_readiness,
+                "shared_inventory",
+                false,
+            );
+            keys.push((route.prefix, route.path_id));
+        }
+        self.replacement_checkpoint(true);
+        Some(keys)
     }
 
     /// Accumulate one bounded key chunk. A withdrawal, source flip, or table
@@ -70,6 +77,10 @@ impl RibManager {
     /// shared cohort at zero extra passes; a tagged inventory hands the
     /// whole cohort to the authoritative per-peer path, whose emit seams
     /// apply the per-target filter.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "keep staging and its readiness-aware temporary retirement in one transaction"
+    )]
     pub(in crate::manager) fn extend_clean_policy_transition_inventory(
         &self,
         source: usize,
@@ -87,6 +98,7 @@ impl RibManager {
             inventory_degraded(source, destination, None, "destination group missing");
             return None;
         };
+        self.replacement_checkpoint(true);
         // Fold permit counts per chunk keyed by borrowed labels, then merge
         // into the owned builder maps once: the per-route path used to clone
         // the `Option<String>` label twice per route, which dominated this
@@ -101,6 +113,11 @@ impl RibManager {
         // touch the maps once per flip instead of twice per route.
         let mut run: Option<(IpAddr, Option<&str>, u64)> = None;
         for &(prefix, path_id) in keys {
+            crate::manager::replacement_readiness_checkpoint_at(
+                &self.replacement_readiness,
+                "shared_inventory",
+                false,
+            );
             let key = (prefix, path_id);
             let Some(route) = new.table.get(&prefix, path_id) else {
                 inventory_degraded(source, destination, Some(key), "destination table drift");
@@ -132,6 +149,13 @@ impl RibManager {
                         return None;
                     }
                 }
+                if inventory.announce.capacity() == 0 {
+                    self.replacement_checkpoint(true);
+                    inventory.announce.reserve_exact(new.table.len());
+                    self.replacement_checkpoint(true);
+                    inventory.next_hop_override.reserve_exact(new.table.len());
+                    self.replacement_checkpoint(true);
+                }
                 inventory.announce.push(route.clone());
                 inventory.next_hop_override.push(next_hop);
             }
@@ -162,17 +186,21 @@ impl RibManager {
                 .or_default() += count;
         }
         for (label, count) in chunk_totals {
+            self.replacement_checkpoint(false);
             *inventory
                 .permit_totals
                 .entry(label.map(str::to_owned))
                 .or_default() += count;
         }
         for (peer, counts) in chunk_by_source {
+            self.replacement_checkpoint(false);
             let by_source = inventory.permit_by_source.entry(peer).or_default();
             for (label, count) in counts {
+                self.replacement_checkpoint(false);
                 *by_source.entry(label.map(str::to_owned)).or_default() += count;
             }
         }
+        self.replacement_checkpoint(true);
         Some(())
     }
 
@@ -189,6 +217,7 @@ impl RibManager {
             .permit_totals
             .iter()
             .filter_map(|(label, total)| {
+                self.replacement_checkpoint(false);
                 let count = total.saturating_sub(
                     own.and_then(|counts| counts.get(label))
                         .copied()
@@ -366,6 +395,7 @@ impl RibManager {
         if self.group_ribs.contains_key(&gid) {
             return PolicyTransitionGroupStart::Maintained;
         }
+        self.replacement_checkpoint(true);
         let group = GroupRibOut::new(
             export_policy.map(PolicyChain::share),
             self.peer_is_ebgp.get(&peer).copied().unwrap_or(false),
@@ -390,15 +420,21 @@ impl RibManager {
                 .is_some_and(|key| key.per_client_best),
             self.loc_rib.len(),
         );
+        self.replacement_checkpoint(true);
         self.group_ribs.insert(gid, group);
-        PolicyTransitionGroupStart::Created(
-            self.loc_rib
-                .iter()
-                .map(|route| route.prefix)
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect(),
-        )
+        let mut prefixes = HashSet::with_capacity(self.loc_rib.len());
+        self.replacement_checkpoint(true);
+        for route in self.loc_rib.iter() {
+            self.replacement_checkpoint(false);
+            prefixes.insert(route.prefix);
+        }
+        self.replacement_checkpoint(true);
+        let snapshot = prefixes
+            .into_iter()
+            .inspect(|_| self.replacement_checkpoint(false))
+            .collect();
+        self.replacement_checkpoint(true);
+        PolicyTransitionGroupStart::Created(snapshot)
     }
 
     /// Stage one bounded prefix chunk into an unowned destination group.
@@ -408,8 +444,20 @@ impl RibManager {
         prefixes: &[Prefix],
         memo: &mut crate::manager::distribution::ExportMemo,
     ) {
-        let prefixes = prefixes.iter().copied().collect::<HashSet<_>>();
-        let _ = self.stage_group_prefixes(gid, &prefixes, memo);
+        self.replacement_checkpoint(true);
+        let mut prefixes = prefixes
+            .iter()
+            .inspect(|_| self.replacement_checkpoint(false))
+            .copied()
+            .collect::<HashSet<_>>();
+        self.replacement_checkpoint(true);
+        let mut output = self.stage_group_prefixes(gid, &prefixes, memo);
+        output.retire_with(&mut |force| self.replacement_checkpoint(force));
+        crate::manager::retire_hash_set(&mut prefixes, &mut || self.replacement_checkpoint(false));
+        self.replacement_checkpoint(true);
+        drop(output);
+        drop(prefixes);
+        self.replacement_checkpoint(true);
     }
 
     /// Remove a partially or fully staged, still-unowned destination before
@@ -429,7 +477,7 @@ impl RibManager {
             .get(&gid)
             .is_none_or(|group| group.members.is_empty());
         if removable {
-            self.group_ribs.remove(&gid);
+            self.remove_group_with_readiness(gid);
         }
         removable
     }
@@ -492,6 +540,7 @@ impl RibManager {
         source: &GroupRibOut,
         destination: &GroupRibOut,
         rs_asns: &[u32],
+        checkpoint: &mut impl FnMut(bool),
     ) -> Option<BatchedTransitionInventory> {
         use crate::manager::distribution::rs_control::rs_control_route_tagged;
         // RFC 9234 OTC residue on either side means blocked staged
@@ -520,11 +569,17 @@ impl RibManager {
         let blocked = |route: &Route| {
             crate::manager::distribution::otc_egress_blocked(route, destination.local_role)
         };
-        let mut announce: Vec<Route> = Vec::new();
-        let mut next_hop_override: Vec<Option<NextHopAction>> = Vec::new();
+        checkpoint(true);
+        let mut announce: Vec<Route> = Vec::with_capacity(destination.table.len());
+        checkpoint(true);
+        let mut next_hop_override: Vec<Option<NextHopAction>> =
+            Vec::with_capacity(destination.table.len());
+        checkpoint(true);
         let mut supplements: FxHashMap<IpAddr, BatchedMemberSupplement> = FxHashMap::default();
         let mut counters = BatchedTransitionCounters::default();
-        for route in destination.table.iter() {
+        let mut rejected = false;
+        'destination: for route in destination.table.iter() {
+            checkpoint(false);
             let key = (route.prefix, route.path_id);
             let next_hop = destination.nh_override(key);
             let prior = source.table.get(&route.prefix, route.path_id);
@@ -541,7 +596,8 @@ impl RibManager {
                             || attrs_tagged(destination.source_control(key))
                             || attrs_tagged(source.source_control(key))))
                 {
-                    return None;
+                    rejected = true;
+                    break 'destination;
                 }
                 next_hop_override.push(next_hop);
                 announce.push(route.clone());
@@ -574,11 +630,20 @@ impl RibManager {
                                     attrs_tagged(source_control_input(prev.source_attrs.as_ref()))
                                 })))
                     {
-                        return None;
+                        rejected = true;
+                        break 'destination;
                     }
-                    supplements
-                        .entry(route.peer)
-                        .or_default()
+                    let supplement = supplements.entry(route.peer).or_default();
+                    if supplement.announce.capacity() == 0 {
+                        let source_count = destination
+                            .source_counts
+                            .get(&route.peer)
+                            .map_or(0, |counts| counts[0] + counts[1]);
+                        checkpoint(true);
+                        supplement.announce.reserve_exact(source_count);
+                        checkpoint(true);
+                    }
+                    supplement
                         .announce
                         .push((entry.route.clone(), entry.nh.clone()));
                 }
@@ -591,16 +656,43 @@ impl RibManager {
                 let had_wire =
                     prior.is_some() && (prior_source != Some(route.peer) || lane_old.is_some());
                 if had_wire {
-                    supplements
-                        .entry(route.peer)
-                        .or_default()
-                        .withdraw
-                        .push(key);
+                    let supplement = supplements.entry(route.peer).or_default();
+                    if supplement.withdraw.capacity() == 0 {
+                        let source_count = destination
+                            .source_counts
+                            .get(&route.peer)
+                            .map_or(0, |counts| counts[0] + counts[1]);
+                        checkpoint(true);
+                        supplement.withdraw.reserve_exact(source_count);
+                        checkpoint(true);
+                    }
+                    supplement.withdraw.push(key);
                 }
             }
         }
-        let mut withdraw: Vec<(Prefix, u32)> = Vec::new();
+        if rejected {
+            checkpoint(true);
+            crate::manager::retire_vec(&mut announce, &mut || checkpoint(false));
+            crate::manager::retire_vec(&mut next_hop_override, &mut || checkpoint(false));
+            for (_, mut supplement) in supplements.drain() {
+                checkpoint(false);
+                crate::manager::retire_vec(&mut supplement.announce, &mut || checkpoint(false));
+                crate::manager::retire_vec(&mut supplement.withdraw, &mut || checkpoint(false));
+            }
+            checkpoint(true);
+            drop(announce);
+            drop(next_hop_override);
+            drop(supplements);
+            counters.retire_with(checkpoint);
+            drop(counters);
+            checkpoint(true);
+            return None;
+        }
+        checkpoint(true);
+        let mut withdraw: Vec<(Prefix, u32)> = Vec::with_capacity(source.table.len());
+        checkpoint(true);
         for route in source.table.iter() {
+            checkpoint(false);
             if destination
                 .table
                 .get(&route.prefix, route.path_id)
@@ -610,16 +702,24 @@ impl RibManager {
             }
         }
         for entry in destination.runner_up.values() {
+            checkpoint(false);
             counters.record_lane(entry.winner_source, entry.policy_label.clone());
         }
         for denials in destination.policy_filtered.values() {
+            checkpoint(false);
             for (&(source_peer, _), label) in denials {
+                checkpoint(false);
                 counters.record_deny(source_peer, label.clone());
             }
         }
+        checkpoint(true);
+        let announce = announce.into();
+        checkpoint(true);
+        let next_hop_override = next_hop_override.into();
+        checkpoint(true);
         Some(BatchedTransitionInventory {
-            announce: announce.into(),
-            next_hop_override: next_hop_override.into(),
+            announce,
+            next_hop_override,
             withdraw,
             supplements,
             counters,
@@ -637,7 +737,9 @@ impl RibManager {
         peer: IpAddr,
         inventory: &BatchedTransitionInventory,
     ) {
-        let rows = inventory.counters.rows_for(peer);
+        let rows = inventory
+            .counters
+            .rows_for(peer, &mut || self.replacement_checkpoint(false));
         if !rows.is_empty() {
             self.bump_export_counters(peer, &rows);
         }

--- a/crates/rib/src/manager/update_groups/staging.rs
+++ b/crates/rib/src/manager/update_groups/staging.rs
@@ -1,3 +1,5 @@
+use crate::manager::{replacement_readiness_checkpoint, retire_vec};
+
 use super::{
     GroupDelta, GroupRibOut, GroupStageOutput, HashMap, HashSet, IpAddr, LaneDelta, PolicyAction,
     PolicyChain, PolicyFilteredRouteKey, PolicyLabel, Prefix, RibManager, RunnerUp,
@@ -11,12 +13,12 @@ impl RibManager {
     /// only thing that makes this lookup infallible; a future
     /// re-entrant (async) staging pass would break that exclusivity
     /// silently, so assert the invariant rather than only unwrap it.
-    fn staged_group_mut(&mut self, gid: usize) -> &mut GroupRibOut {
+    fn staged_group_mut(groups: &mut HashMap<usize, GroupRibOut>, gid: usize) -> &mut GroupRibOut {
         debug_assert!(
-            self.group_ribs.contains_key(&gid),
+            groups.contains_key(&gid),
             "staging exclusivity: group {gid} read at the top of the pass must still exist at commit"
         );
-        self.group_ribs
+        groups
             .get_mut(&gid)
             .expect("group staged above still exists")
     }
@@ -46,11 +48,33 @@ impl RibManager {
         if self.group_ribs.is_empty() || (best_changed.is_empty() && all_affected.is_empty()) {
             return staged;
         }
+        self.replacement_checkpoint(true);
         let widened: Option<HashSet<Prefix>> = (!all_affected.is_empty()
-            && self.group_ribs.values().any(|group| group.per_client_best))
-        .then(|| best_changed.union(all_affected).copied().collect());
-        let gids: Vec<usize> = self.group_ribs.keys().copied().collect();
+            && self.group_ribs.values().any(|group| {
+                self.replacement_checkpoint(false);
+                group.per_client_best
+            }))
+        .then(|| {
+            let mut widened = HashSet::with_capacity(best_changed.len() + all_affected.len());
+            self.replacement_checkpoint(true);
+            for prefix in best_changed.iter().chain(all_affected) {
+                self.replacement_checkpoint(false);
+                widened.insert(*prefix);
+            }
+            widened
+        });
+        self.replacement_checkpoint(true);
+        let gids: Vec<usize> = self
+            .group_ribs
+            .keys()
+            .map(|gid| {
+                self.replacement_checkpoint(false);
+                *gid
+            })
+            .collect();
+        self.replacement_checkpoint(true);
         for gid in gids {
+            self.replacement_checkpoint(false);
             let prefixes = match (&widened, self.group_ribs.get(&gid)) {
                 (Some(widened), Some(group)) if group.per_client_best => widened,
                 _ => best_changed,
@@ -61,12 +85,15 @@ impl RibManager {
             let mut out = self.stage_group_prefixes(gid, prefixes, memo);
             // Built here (the fanout path) and not inside the staging
             // pass: `join_group`'s table-build pass discards its output.
-            out.build_shared_emit();
+            out.build_shared_emit(&mut |force| self.replacement_checkpoint(force));
             staged.insert(gid, out);
         }
         // The staging commit is the one lane mutation site outside the
         // membership lifecycle (which refreshes via the gauge sweep).
         self.refresh_lane_gauge();
+        self.replacement_checkpoint(true);
+        drop(widened);
+        self.replacement_checkpoint(true);
         staged
     }
 
@@ -87,7 +114,10 @@ impl RibManager {
         prefixes: &HashSet<Prefix>,
         memo: &mut crate::manager::distribution::ExportMemo,
     ) -> GroupStageOutput {
+        self.replacement_checkpoint(true);
         let mut out = GroupStageOutput::default();
+        out.deltas.reserve_exact(prefixes.len());
+        self.replacement_checkpoint(true);
         let mut labeled_filtered: Vec<(PolicyFilteredRouteKey, Option<PolicyLabel>)> = Vec::new();
         let mut lane_updates: Vec<(Prefix, Option<RunnerUp>)> = Vec::new();
         let mut result = crate::manager::distribution::UnicastDistributionResult::default();
@@ -99,11 +129,17 @@ impl RibManager {
                 return out;
             };
             per_client_best = group.per_client_best;
+            if per_client_best {
+                self.replacement_checkpoint(true);
+                lane_updates.reserve_exact(prefixes.len());
+                self.replacement_checkpoint(true);
+            }
             // `share()`, not `clone()`: evaluations through the group
             // handle must land in the installed chain's ADR-0096 term
             // hit counters, exactly like the per-peer path's handle.
             let chain = group.export_chain.as_ref().map(PolicyChain::share);
             for prefix in prefixes {
+                self.replacement_checkpoint(false);
                 let old_source = group.table.get(prefix, 0).map(|r| r.peer);
                 if group.per_client_best {
                     // ADR-0126 Decision 2: first-permitted winner walk
@@ -171,6 +207,11 @@ impl RibManager {
                         && let Some(transition) =
                             group.rs_tag_transition(*prefix, stage.winner_source_attrs.as_ref())
                     {
+                        if out.rs_transitions.capacity() == 0 {
+                            self.replacement_checkpoint(true);
+                            out.rs_transitions.reserve_exact(prefixes.len());
+                            self.replacement_checkpoint(true);
+                        }
                         out.rs_transitions.push(transition);
                     }
                     // Lane transition (ADR-0126 Decision 5), equality-
@@ -231,6 +272,11 @@ impl RibManager {
                             }
                             None => true,
                         });
+                        if out.lane_deltas.capacity() == 0 {
+                            self.replacement_checkpoint(true);
+                            out.lane_deltas.reserve_exact(prefixes.len());
+                            self.replacement_checkpoint(true);
+                        }
                         out.lane_deltas.push(LaneDelta {
                             prefix: *prefix,
                             new: stage.runner_up.clone(),
@@ -312,7 +358,17 @@ impl RibManager {
                     && let Some(transition) =
                         group.rs_tag_transition(*prefix, source_attrs.as_ref())
                 {
+                    if out.rs_transitions.capacity() == 0 {
+                        self.replacement_checkpoint(true);
+                        out.rs_transitions.reserve_exact(prefixes.len());
+                        self.replacement_checkpoint(true);
+                    }
                     out.rs_transitions.push(transition);
+                }
+                if labeled_filtered.capacity() == 0 && !result.policy_filtered.is_empty() {
+                    self.replacement_checkpoint(true);
+                    labeled_filtered.reserve_exact(prefixes.len());
+                    self.replacement_checkpoint(true);
                 }
                 labeled_filtered.extend(
                     result
@@ -325,22 +381,31 @@ impl RibManager {
         if per_client_best {
             labeled_filtered = per_client_best_result.policy_filtered;
         }
-        let group = self.staged_group_mut(gid);
+        self.replacement_checkpoint(true);
+        let readiness = &self.replacement_readiness;
+        let mut checkpoint = || replacement_readiness_checkpoint(readiness, false);
+        let group = Self::staged_group_mut(&mut self.group_ribs, gid);
         for delta in &out.deltas {
+            checkpoint();
             group.apply_delta(delta);
         }
         // Lane commits live in this commit block ON PURPOSE: the
         // `join_group` table-build pass discards the returned output
         // but must still leave a fully populated lane behind.
         for (prefix, entry) in lane_updates {
+            checkpoint();
             group.apply_lane(prefix, entry);
         }
-        group.commit_rs_transitions(&out.rs_transitions);
-        group.record_otc_blocked(prefixes, &out.otc_blocked);
-        group.record_policy_filtered(prefixes, &labeled_filtered);
+        group.commit_rs_transitions(&out.rs_transitions, &mut checkpoint);
+        group.record_otc_blocked(prefixes, &out.otc_blocked, &mut checkpoint);
+        group.record_policy_filtered(prefixes, &labeled_filtered, &mut checkpoint);
         if !group.dirty_members.is_empty() {
-            let withdrawn: Vec<(Prefix, u32)> = out.withdrawn_keys().collect();
-            group.tombstones.extend(withdrawn);
+            for delta in &out.deltas {
+                checkpoint();
+                if delta.new.is_none() {
+                    group.tombstones.insert((delta.prefix, delta.path_id));
+                }
+            }
             // A member ALREADY dirty when a source flip stages onto it
             // never reaches the per-member matrix (its pass takes the
             // resync arm), so its member-scoped withdraw of the displaced
@@ -349,19 +414,37 @@ impl RibManager {
             // Record it as an extra (over-)withdraw at staging; the
             // resync's `member_retains` guard drops it if the source
             // flips back before the resync runs.
-            let dirty: Vec<IpAddr> = group.dirty_members.iter().copied().collect();
+            let dirty: Vec<IpAddr> = group
+                .dirty_members
+                .iter()
+                .map(|member| {
+                    checkpoint();
+                    *member
+                })
+                .collect();
+            replacement_readiness_checkpoint(readiness, true);
             for member in dirty {
-                let lost: Vec<(Prefix, u32)> = out.member_scoped_withdraws(member).collect();
+                checkpoint();
+                let lost: Vec<(Prefix, u32)> = out
+                    .member_scoped_withdraws(member, || {
+                        replacement_readiness_checkpoint(readiness, false);
+                    })
+                    .collect();
                 if !lost.is_empty() {
                     self.pending_extra_withdraws
                         .entry(member)
                         .or_default()
                         .unicast
-                        .extend(lost);
+                        .extend(lost.into_iter().inspect(|_| checkpoint()));
                 }
             }
             self.refresh_group_residue_gauge();
         }
+        self.replacement_checkpoint(true);
+        retire_vec(&mut labeled_filtered, &mut || {
+            self.replacement_checkpoint(false);
+        });
+        self.replacement_checkpoint(true);
         out
     }
 
@@ -381,10 +464,14 @@ impl RibManager {
         let gids: Vec<usize> = self
             .group_ribs
             .iter()
-            .filter(|(_, group)| group.stages_vpn())
+            .filter(|(_, group)| {
+                self.replacement_checkpoint(false);
+                group.stages_vpn()
+            })
             .map(|(gid, _)| *gid)
             .collect();
         for gid in gids {
+            self.replacement_checkpoint(false);
             staged.insert(gid, self.stage_group_vpn_keys(gid, changed));
         }
         staged
@@ -396,12 +483,21 @@ impl RibManager {
     /// diff baseline — the SAME body as the per-peer path, parameterized,
     /// never copied (design risk 1). Deltas are committed before
     /// returning; VPN tombstones extend when a member is already dirty.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "keep staging and its readiness-aware temporary retirement in one transaction"
+    )]
     pub(super) fn stage_group_vpn_keys(
         &mut self,
         gid: usize,
         keys: &HashSet<VpnRouteKey>,
     ) -> VpnGroupStageOutput {
-        let mut out = VpnGroupStageOutput::default();
+        self.replacement_checkpoint(true);
+        let mut out = VpnGroupStageOutput {
+            deltas: Vec::with_capacity(keys.len()),
+            ..VpnGroupStageOutput::default()
+        };
+        self.replacement_checkpoint(true);
         let mut denials: Vec<(VpnRouteKey, VpnDenialRecord)> = Vec::new();
         {
             let Some(group) = self.group_ribs.get(&gid) else {
@@ -435,6 +531,7 @@ impl RibManager {
             // but the delta needs per-key `old` capture and eval labels.
             let mut key_set: HashSet<VpnRouteKey> = HashSet::with_capacity(1);
             for key in keys {
+                self.replacement_checkpoint(false);
                 key_set.clear();
                 key_set.insert(*key);
                 let mut target = crate::manager::distribution::ExportTarget::Group {
@@ -502,21 +599,41 @@ impl RibManager {
                     });
                 }
             }
+            retire_vec(&mut ignored_otc_blocked, &mut || {
+                self.replacement_checkpoint(false);
+            });
+            self.replacement_checkpoint(true);
         }
-        let group = self.staged_group_mut(gid);
+        self.replacement_checkpoint(true);
+        let readiness = &self.replacement_readiness;
+        let checkpoint = || replacement_readiness_checkpoint(readiness, false);
+        let group = Self::staged_group_mut(&mut self.group_ribs, gid);
         for delta in &out.deltas {
+            checkpoint();
             group.apply_vpn_delta(delta);
         }
         // Denial-residue transition scope: this pass's keys replace their
         // prior records (the `record_policy_filtered` shape).
-        group.vpn_policy_denied.retain(|key, _| !keys.contains(key));
-        group.vpn_policy_denied.extend(denials);
+        group.vpn_policy_denied.retain(|key, _| {
+            checkpoint();
+            !keys.contains(key)
+        });
+        group
+            .vpn_policy_denied
+            .extend(denials.into_iter().inspect(|_| checkpoint()));
         if !group.dirty_members.is_empty() {
-            group
-                .vpn_tombstones
-                .extend(out.deltas.iter().filter(|d| d.new.is_none()).map(|d| d.key));
+            group.vpn_tombstones.extend(
+                out.deltas
+                    .iter()
+                    .filter(|d| {
+                        checkpoint();
+                        d.new.is_none()
+                    })
+                    .map(|d| d.key),
+            );
             self.refresh_group_residue_gauge();
         }
+        self.replacement_checkpoint(true);
         out
     }
 }

--- a/crates/rib/src/manager/update_groups/tests.rs
+++ b/crates/rib/src/manager/update_groups/tests.rs
@@ -1577,10 +1577,11 @@ fn pcb_emit_consumers_ignore_lane_fields() {
     };
     let with_lane = (
         member_emit(&out.deltas),
-        out.withdrawn_keys().collect::<Vec<_>>(),
-        out.member_scoped_withdraws(MEMBER).collect::<Vec<_>>(),
+        out.withdrawn_keys(|| {}).collect::<Vec<_>>(),
+        out.member_scoped_withdraws(MEMBER, || {})
+            .collect::<Vec<_>>(),
     );
-    out.build_shared_emit();
+    out.build_shared_emit(&mut |_| {});
     let shared_with_lane: Vec<(Prefix, IpAddr)> = out
         .shared_announce
         .iter()
@@ -1591,10 +1592,11 @@ fn pcb_emit_consumers_ignore_lane_fields() {
     out.lane_deltas.clear();
     let without_lane = (
         member_emit(&out.deltas),
-        out.withdrawn_keys().collect::<Vec<_>>(),
-        out.member_scoped_withdraws(MEMBER).collect::<Vec<_>>(),
+        out.withdrawn_keys(|| {}).collect::<Vec<_>>(),
+        out.member_scoped_withdraws(MEMBER, || {})
+            .collect::<Vec<_>>(),
     );
-    out.build_shared_emit();
+    out.build_shared_emit(&mut |_| {});
     let shared_without_lane: Vec<(Prefix, IpAddr)> = out
         .shared_announce
         .iter()
@@ -2245,7 +2247,7 @@ fn pcb_steady_state_emission_matrix_matches_adv() {
                     seed(&mut m, cand(p, src, matrix_lp(src)));
                 }
                 let mut out = stage_pcb(&mut m, &[p]);
-                out.build_shared_emit();
+                out.build_shared_emit(&mut |_| {});
                 let group = m.group_ribs.get(&PCB_GID).unwrap();
                 let mut emitted: HashMap<IpAddr, usize> = HashMap::new();
                 for &member in &members {
@@ -2339,7 +2341,7 @@ fn pcb_lane_only_transition_targets_winner_source_only() {
     // Content flip: the runner-up is replaced in place.
     seed(&mut m, cand(p, OTHER2, 250));
     let mut out = stage_pcb(&mut m, &[p]);
-    out.build_shared_emit();
+    out.build_shared_emit(&mut |_| {});
     assert!(
         out.deltas.is_empty(),
         "winner must stay equality-suppressed"
@@ -2366,7 +2368,7 @@ fn pcb_lane_only_transition_targets_winner_source_only() {
     // Retire: the runner-up disappears.
     unseed(&mut m, OTHER2, p);
     let mut out = stage_pcb(&mut m, &[p]);
-    out.build_shared_emit();
+    out.build_shared_emit(&mut |_| {});
     assert!(out.deltas.is_empty());
     assert_eq!(out.lane_deltas.len(), 1);
     assert!(out.lane_deltas[0].new.is_none());
@@ -2400,7 +2402,7 @@ fn pcb_all_gone_with_lane_withdraws_old_winner_source() {
     unseed(&mut m, OTHER1, p);
     unseed(&mut m, OTHER2, p);
     let mut out = stage_pcb(&mut m, &[p]);
-    out.build_shared_emit();
+    out.build_shared_emit(&mut |_| {});
     assert_eq!(out.deltas.len(), 1);
     assert!(out.deltas[0].new.is_none());
     assert_eq!(out.lane_deltas.len(), 1);
@@ -2626,8 +2628,8 @@ fn pcb_empty_lane_emits_like_plain_group() {
     let mut memo = super::super::distribution::ExportMemo::default();
     let mut pcb = m.stage_group_prefixes(PCB_GID, &prefixes, &mut memo);
     let mut plain = m.stage_group_prefixes(PLAIN_GID, &prefixes, &mut memo);
-    pcb.build_shared_emit();
-    plain.build_shared_emit();
+    pcb.build_shared_emit(&mut |_| {});
+    plain.build_shared_emit(&mut |_| {});
 
     assert!(pcb.lane_deltas.is_empty());
     let shape = |out: &GroupStageOutput| {
@@ -3193,22 +3195,24 @@ fn lane_retire_records_member_scoped_withdraw() {
         content_unchanged: false,
     });
     assert_eq!(
-        out.member_scoped_withdraws(MEMBER).collect::<Vec<_>>(),
+        out.member_scoped_withdraws(MEMBER, || {})
+            .collect::<Vec<_>>(),
         vec![(p1, 0)],
         "only the retire toward MEMBER is recorded"
     );
     assert!(
-        out.member_scoped_withdraws(OTHER1).next().is_none(),
+        out.member_scoped_withdraws(OTHER1, || {}).next().is_none(),
         "a lane announce leaves no residue"
     );
-    assert!(out.member_scoped_withdraws(OTHER2).next().is_none());
+    assert!(out.member_scoped_withdraws(OTHER2, || {}).next().is_none());
 
     let mut out = GroupStageOutput::default();
     let mut delta = announce_delta(p1, MEMBER, Some(OTHER1));
     delta.lane = Some(lane_entry(route(p1, OTHER1), MEMBER, "lane", None));
     out.deltas.push(delta);
     assert_eq!(
-        out.member_scoped_withdraws(MEMBER).collect::<Vec<_>>(),
+        out.member_scoped_withdraws(MEMBER, || {})
+            .collect::<Vec<_>>(),
         vec![(p1, 0)],
         "the source-flip arm records regardless of the lane"
     );
@@ -3227,23 +3231,24 @@ fn pcb_channel_full_lost_emission_converges_to_adv() {
     let p = prefix(1);
     // Mimic the fanout driver's channel-full arm for `victim`,
     // then run its dirty resync and fold onto `wire`.
-    let lose_and_resync =
-        |m: &mut RibManager, victim: IpAddr, wire: &mut HashMap<(Prefix, u32), Route>| {
-            let out = stage_pcb(m, &[p]);
-            let group = m.group_ribs.get_mut(&PCB_GID).unwrap();
-            group.tombstones.extend(out.withdrawn_keys());
-            let extras: HashSet<(Prefix, u32)> = out.member_scoped_withdraws(victim).collect();
-            let group = m.group_ribs.get(&PCB_GID).unwrap();
-            let (announce, withdraw, _) = resync(group, victim, None, true, false, Some(&extras));
-            let announce_keys: HashSet<(Prefix, u32)> =
-                announce.iter().map(|r| (r.prefix, r.path_id)).collect();
-            assert!(
-                announce_keys.is_disjoint(&withdraw.iter().copied().collect()),
-                "announce+withdraw of one key escaped for {victim}"
-            );
-            fold_wire(wire, announce, &withdraw);
-            assert_wire_is_adv(group, victim, wire);
-        };
+    let lose_and_resync = |m: &mut RibManager,
+                           victim: IpAddr,
+                           wire: &mut HashMap<(Prefix, u32), Route>| {
+        let out = stage_pcb(m, &[p]);
+        let group = m.group_ribs.get_mut(&PCB_GID).unwrap();
+        group.tombstones.extend(out.withdrawn_keys(|| {}));
+        let extras: HashSet<(Prefix, u32)> = out.member_scoped_withdraws(victim, || {}).collect();
+        let group = m.group_ribs.get(&PCB_GID).unwrap();
+        let (announce, withdraw, _) = resync(group, victim, None, true, false, Some(&extras));
+        let announce_keys: HashSet<(Prefix, u32)> =
+            announce.iter().map(|r| (r.prefix, r.path_id)).collect();
+        assert!(
+            announce_keys.is_disjoint(&withdraw.iter().copied().collect()),
+            "announce+withdraw of one key escaped for {victim}"
+        );
+        fold_wire(wire, announce, &withdraw);
+        assert_wire_is_adv(group, victim, wire);
+    };
 
     // (a) Lane retire lost: OTHER1 sources the winner, its wire
     // holds the substitution, the runner-up disappears.
@@ -4213,10 +4218,10 @@ fn vpn_dirty_resync_rt_filter_dimension() {
 
     // Count recompute-from-table under Φ.
     assert_eq!(
-        group.vpn_member_counts_from_table(MEMBER, Some(&phi1)),
+        group.vpn_member_counts_from_table(MEMBER, Some(&phi1), &mut || {}),
         [1, 0]
     );
-    group.recompute_vpn_member_counts(MEMBER, Some(&phi1));
+    group.recompute_vpn_member_counts(MEMBER, Some(&phi1), &mut || {});
     assert_eq!(group.vpn_advertised_count_for(MEMBER), 1);
     assert_eq!(
         group.family_counts_for(MEMBER),
@@ -4324,7 +4329,7 @@ fn source_control_modifying_mode_preserves_historical_residue_and_transition() {
         &[CONTROL]
     );
     assert!(transition.source_attrs.is_none());
-    group.commit_rs_transitions(&[transition]);
+    group.commit_rs_transitions(&[transition], &mut || {});
     assert!(group.source_attrs.is_empty());
 
     group.apply_delta(&withdraw_delta(p, Some(OTHER1)));

--- a/crates/rib/src/manager/update_groups/views.rs
+++ b/crates/rib/src/manager/update_groups/views.rs
@@ -30,8 +30,8 @@ impl RibManager {
     /// baseline that records the key) — and announced entries are
     /// rewritten (prepend from the source, scrub post-policy) per
     /// target. Baselines snapshot through the same filter
-    /// ([`GroupRibOut::member_view_snapshot`]), so the regroup one-shot
-    /// diff compares wire state to wire state.
+    /// ([`GroupRibOut::member_view_snapshot_with_checkpoint`]), so the
+    /// regroup one-shot diff compares wire state to wire state.
     #[expect(
         clippy::too_many_arguments,
         reason = "the resync assembly takes the member's full pending-withdraw context"
@@ -245,6 +245,7 @@ impl RibManager {
         gid: usize,
         family: Option<(Afi, Safi)>,
     ) {
+        self.replacement_checkpoint(true);
         // The member's Φ: the per-peer path's RT gate precedes the policy
         // evaluation, so an RT-failed entry records NO eval — the replay
         // must count only Φ-passing permits and denials (design §2.4).
@@ -268,6 +269,7 @@ impl RibManager {
             // decision-attribution label is exactly what the walk recorded.
             // Nothing for an own-sourced slot with no substitution.
             for route in group.table.iter() {
+                self.replacement_checkpoint(false);
                 if !in_family(&route.prefix) {
                     continue;
                 }
@@ -277,10 +279,12 @@ impl RibManager {
                 bump(&adv.policy_label.cloned(), PolicyAction::Permit);
             }
             for (prefix, denials) in &group.policy_filtered {
+                self.replacement_checkpoint(false);
                 if !in_family(prefix) {
                     continue;
                 }
                 for (&(source_peer, _), label) in denials {
+                    self.replacement_checkpoint(false);
                     if source_peer == peer {
                         continue;
                     }
@@ -301,6 +305,7 @@ impl RibManager {
                 })
             };
             for route in group.table.iter_vpn() {
+                self.replacement_checkpoint(false);
                 if route.peer == peer
                     || !in_vpn_family(&route.nlri.key())
                     || !rt_passes(vpn_filter.as_ref(), route)
@@ -311,6 +316,7 @@ impl RibManager {
                 bump(&label, PolicyAction::Permit);
             }
             for (key, (source, label, rts)) in &group.vpn_policy_denied {
+                self.replacement_checkpoint(false);
                 if *source == peer
                     || !in_vpn_family(key)
                     || !vpn_filter.as_ref().is_none_or(|m| m.matches_any(rts))
@@ -320,7 +326,10 @@ impl RibManager {
                 bump(label, PolicyAction::Deny);
             }
         }
+        self.replacement_checkpoint(true);
         self.bump_export_counters(peer, &rows);
+        crate::manager::retire_vec(&mut rows, &mut || self.replacement_checkpoint(false));
+        self.replacement_checkpoint(true);
     }
 
     /// Borrowed synthesized advertised-route view for a grouped peer
@@ -336,18 +345,24 @@ impl RibManager {
         let group = self.group_ribs.get(&self.grouped_member_of(peer)?)?;
         let rejected = self.peer_unexportable.get(&peer);
         let limits = self.outbound_prefix_limits.get(&peer);
-        Some(group.table.iter().filter_map(move |staged| {
-            // The substitution sits at the same (prefix, path_id 0)
-            // slot, so the member-local overlays key identically for
-            // the staged entry and its lane replacement.
-            let route = group
-                .adv_entry_post_backstop(peer, &staged.prefix, staged.path_id)?
-                .route;
-            (!rejected.is_some_and(|keys| {
-                keys.contains(&ExactExportKey::Unicast(route.prefix, route.path_id))
-            }) && limits.is_none_or(|limits| limits.admits_grouped(&route.prefix)))
-            .then_some(route)
-        }))
+        Some(
+            group
+                .table
+                .iter()
+                .inspect(move |_| self.replacement_checkpoint(false))
+                .filter_map(move |staged| {
+                    // The substitution sits at the same (prefix, path_id 0)
+                    // slot, so the member-local overlays key identically for
+                    // the staged entry and its lane replacement.
+                    let route = group
+                        .adv_entry_post_backstop(peer, &staged.prefix, staged.path_id)?
+                        .route;
+                    (!rejected.is_some_and(|keys| {
+                        keys.contains(&ExactExportKey::Unicast(route.prefix, route.path_id))
+                    }) && limits.is_none_or(|limits| limits.admits_grouped(&route.prefix)))
+                    .then_some(route)
+                }),
+        )
     }
 
     /// Ordered sibling used by resumable route listings. The group table's
@@ -393,8 +408,18 @@ impl RibManager {
     /// Materialized sibling of [`Self::grouped_advertised_routes_iter`] for
     /// legacy full-snapshot and route-refresh callers.
     pub(in crate::manager) fn grouped_advertised_routes(&self, peer: IpAddr) -> Option<Vec<Route>> {
-        self.grouped_advertised_routes_iter(peer)
-            .map(|routes| routes.cloned().collect())
+        self.replacement_checkpoint(true);
+        let capacity = self
+            .group_ribs
+            .get(&self.grouped_member_of(peer)?)?
+            .table
+            .len();
+        let routes = self.grouped_advertised_routes_iter(peer)?;
+        let mut result = Vec::with_capacity(capacity);
+        self.replacement_checkpoint(true);
+        result.extend(routes.cloned());
+        self.replacement_checkpoint(true);
+        Some(result)
     }
 
     /// Synthesized advertised-route count for a grouped peer; `None`
@@ -417,6 +442,7 @@ impl RibManager {
         }
         let rejected = self.peer_unexportable.get(&peer).map_or(0, |keys| {
             keys.iter()
+                .inspect(|_| self.replacement_checkpoint(false))
                 .filter(|key| match key {
                     // A rejected key reduces the count only while the
                     // member's derived view holds a route at that slot
@@ -445,6 +471,7 @@ impl RibManager {
         let filter = self.rtc_vpn_filter(peer, self.peer_sendable_families.get(&peer));
         let rejected = self.peer_unexportable.get(&peer).map_or(0, |keys| {
             keys.iter()
+                .inspect(|_| self.replacement_checkpoint(false))
                 .filter(|key| match key {
                     ExactExportKey::Vpn(key) => group.table.get_vpn(key).is_some_and(|route| {
                         route.peer != peer && rt_passes(filter.as_ref(), route)
@@ -474,6 +501,7 @@ impl RibManager {
         let filter = self.rtc_vpn_filter(peer, self.peer_sendable_families.get(&peer));
         if let Some(rejected) = self.peer_unexportable.get(&peer) {
             for key in rejected {
+                self.replacement_checkpoint(false);
                 let family = match key {
                     // Subtract only while the member's derived view
                     // holds a backstop-delivered route at the rejected

--- a/crates/rib/src/prefix_map.rs
+++ b/crates/rib/src/prefix_map.rs
@@ -106,6 +106,36 @@ impl<V> FamilyPrefixMap<V> {
         self.v6.clear();
     }
 
+    /// Remove prefixes one at a time so the trie prunes each retired branch.
+    pub(crate) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        loop {
+            let next = self.iter_from(None).next().map(|(prefix, _)| prefix);
+            let Some(prefix) = next else {
+                break;
+            };
+            checkpoint();
+            let retired = self.remove(&prefix);
+            debug_assert!(retired.is_some(), "iterated prefix must still be present");
+            drop(retired);
+            checkpoint();
+        }
+    }
+
+    /// Retire every prefix, then release the empty trie roots.
+    pub(crate) fn release_with(&mut self, checkpoint: &mut impl FnMut()) {
+        self.retire_with(checkpoint);
+
+        let v4 = std::mem::replace(&mut self.v4, PrefixMap::new());
+        checkpoint();
+        drop(v4);
+        checkpoint();
+
+        let v6 = std::mem::replace(&mut self.v6, PrefixMap::new());
+        checkpoint();
+        drop(v6);
+        checkpoint();
+    }
+
     /// Iterate from `prefix` (inclusive) in [`Prefix`]'s derived order.
     ///
     /// Inclusive prefix traversal is intentional: a route-page cursor also
@@ -250,5 +280,23 @@ mod tests {
             map.iter_after(Some(prefixes[2])).next().is_none(),
             "the last prefix has no continuation"
         );
+    }
+
+    #[test]
+    fn retire_prunes_every_prefix_and_calls_back() {
+        let mut map = FamilyPrefixMap::<()>::default();
+        for prefix in [
+            Prefix::V4(Ipv4Prefix::new("10.0.0.0".parse().unwrap(), 8)),
+            Prefix::V4(Ipv4Prefix::new("10.0.1.0".parse().unwrap(), 24)),
+            Prefix::V6(Ipv6Prefix::new("2001:db8::".parse().unwrap(), 32)),
+        ] {
+            map.entry_or_default(prefix);
+        }
+        let mut checkpoints = 0;
+
+        map.retire_with(&mut || checkpoints += 1);
+
+        assert_eq!(checkpoints, 6);
+        assert!(map.iter_from(None).next().is_none());
     }
 }

--- a/crates/rib/src/slab.rs
+++ b/crates/rib/src/slab.rs
@@ -53,6 +53,34 @@ impl<T> RouteSlab<T> {
         }
     }
 
+    /// Ensure room for `additional` inserts without growing the slot Vec
+    /// during the subsequent commit. Rebuilding preserves every handle and
+    /// vacant slot while moving route ownership one slot at a time.
+    pub(crate) fn reserve_with(&mut self, additional: usize, checkpoint: &mut impl FnMut()) {
+        let new_slots = additional.saturating_sub(self.free.len());
+        let required = self
+            .slots
+            .len()
+            .checked_add(new_slots)
+            .expect("route slab exceeds addressable capacity");
+        if self.slots.capacity() >= required {
+            return;
+        }
+
+        let old_slots = std::mem::take(&mut self.slots);
+        let mut slots = Vec::with_capacity(required);
+        let mut entries = old_slots.into_iter();
+        for slot in entries.by_ref() {
+            checkpoint();
+            slots.push(slot);
+            checkpoint();
+        }
+        checkpoint();
+        drop(entries);
+        checkpoint();
+        self.slots = slots;
+    }
+
     /// Remove and return the value at `handle`, freeing the slot for reuse.
     pub(crate) fn remove(&mut self, handle: u32) -> Option<T> {
         let value = self.slots.get_mut(handle as usize)?.take();
@@ -95,7 +123,7 @@ impl<T> RouteSlab<T> {
 
     /// Total slots ever allocated (occupied + free). Test-only leak probe:
     /// steady-state churn must not grow this.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "bench-internals"))]
     pub(crate) fn slot_count(&self) -> usize {
         self.slots.len()
     }
@@ -104,6 +132,32 @@ impl<T> RouteSlab<T> {
     pub(crate) fn clear(&mut self) {
         self.slots.clear();
         self.free.clear();
+    }
+
+    /// Drop every slot, including vacancies, while retaining both backing
+    /// allocations for later reuse.
+    pub(crate) fn retire_with(&mut self, checkpoint: &mut impl FnMut()) {
+        self.free.clear();
+        while let Some(slot) = self.slots.pop() {
+            checkpoint();
+            drop(slot);
+            checkpoint();
+        }
+    }
+
+    /// Retire every slot, then release the empty backing allocations.
+    pub(crate) fn release_with(&mut self, checkpoint: &mut impl FnMut()) {
+        self.retire_with(checkpoint);
+
+        let slots = std::mem::take(&mut self.slots);
+        checkpoint();
+        drop(slots);
+        checkpoint();
+
+        let free = std::mem::take(&mut self.free);
+        checkpoint();
+        drop(free);
+        checkpoint();
     }
 
     /// Release only unused tail capacity while preserving logical slot
@@ -188,6 +242,49 @@ mod tests {
     }
 
     #[test]
+    fn reserve_rebuild_preserves_holes_handles_and_free_reuse() {
+        let mut slab = RouteSlab::with_capacity(3);
+        let first = slab.insert(10_u64);
+        let hole = slab.insert(20);
+        let last = slab.insert(30);
+        assert_eq!(slab.remove(hole), Some(20));
+        let free = slab.free.clone();
+        let old_capacity = slab.capacity();
+        let mut checkpoints = 0;
+
+        slab.reserve_with(4, &mut || checkpoints += 1);
+
+        assert!(slab.capacity() >= 6);
+        assert!(slab.capacity() > old_capacity);
+        assert_eq!(slab.slot_count(), 3);
+        assert_eq!(slab.free, free);
+        assert_eq!(slab.get(first), Some(&10));
+        assert_eq!(slab.get(hole), None);
+        assert_eq!(slab.get(last), Some(&30));
+        assert_eq!(
+            checkpoints, 8,
+            "each slot and the iterator tail is bracketed"
+        );
+        assert_eq!(slab.insert(40), hole, "the rebuilt free list stays LIFO");
+
+        assert_eq!(slab.remove(last), Some(30));
+        let slot_ptr = slab.slots.as_ptr();
+        let mut no_growth_checkpoints = 0;
+        slab.reserve_with(1, &mut || no_growth_checkpoints += 1);
+        assert_eq!(
+            slab.slots.as_ptr(),
+            slot_ptr,
+            "a free slot satisfies the batch"
+        );
+        assert_eq!(no_growth_checkpoints, 0);
+        assert_eq!(
+            slab.insert(50),
+            last,
+            "the existing free slot remains reusable"
+        );
+    }
+
+    #[test]
     fn set_replaces_in_place() {
         let mut slab: RouteSlab<u64> = RouteSlab::default();
         let h = slab.insert(1);
@@ -205,6 +302,27 @@ mod tests {
         assert_eq!(slab.get(h), None);
         // Fresh inserts after clear start from slot zero again.
         assert_eq!(slab.insert(8), 0);
+    }
+
+    #[test]
+    fn retire_visits_holes_and_preserves_capacity() {
+        let mut slab = RouteSlab::with_capacity(8);
+        let first = slab.insert(1_u64);
+        slab.insert(2);
+        slab.remove(first);
+        let capacity = slab.capacity();
+        let mut checkpoints = 0;
+
+        slab.retire_with(&mut || checkpoints += 1);
+
+        assert_eq!(
+            checkpoints, 4,
+            "both slots, including the hole, are bracketed"
+        );
+        assert!(slab.is_empty());
+        assert_eq!(slab.slot_count(), 0);
+        assert_eq!(slab.capacity(), capacity);
+        assert_eq!(slab.insert(3), 0);
     }
 
     /// The whole point of the slab is compactness: `Option<Route>` must not

--- a/crates/rib/src/update.rs
+++ b/crates/rib/src/update.rs
@@ -745,6 +745,22 @@ pub trait ExactExportSnapshot: Any + Send + Sync {
             .collect()
     }
 
+    /// Probe with synchronous actor checkpoints between individual candidates.
+    /// The default brackets the existing batch method, preserving custom batch
+    /// implementations. Implementations can override this method to checkpoint
+    /// each candidate while keeping whole-call caches and their cleanup.
+    /// The callback must not mutate or query the candidate tables.
+    fn probe_announcements_with_checkpoint(
+        &self,
+        candidates: &[ExactExportCandidate<'_>],
+        checkpoint: &mut dyn FnMut(),
+    ) -> Vec<Result<ExactExportResult, ExactExportError>> {
+        checkpoint();
+        let results = self.probe_announcements(candidates);
+        checkpoint();
+        results
+    }
+
     /// Reapply this target snapshot's ceiling and generation to successful
     /// exact probes produced by `source`.
     ///
@@ -764,6 +780,21 @@ pub trait ExactExportSnapshot: Any + Send + Sync {
     ) -> Option<Vec<Result<ExactExportResult, ExactExportError>>> {
         let _ = (source, encoded_lengths);
         None
+    }
+
+    /// Reuse successful probes with synchronous actor checkpoints. The default
+    /// preserves existing snapshot overrides; implementations may checkpoint
+    /// individual lengths while keeping their wire-equivalence proof intact.
+    fn reuse_successful_probes_with_checkpoint(
+        &self,
+        source: &dyn ExactExportSnapshot,
+        encoded_lengths: &[usize],
+        checkpoint: &mut dyn FnMut(),
+    ) -> Option<Vec<Result<ExactExportResult, ExactExportError>>> {
+        checkpoint();
+        let results = self.reuse_successful_probes(source, encoded_lengths);
+        checkpoint();
+        results
     }
 
     /// Concrete type hook used by the owning transport at the trust boundary.

--- a/crates/transport/src/session/export.rs
+++ b/crates/transport/src/session/export.rs
@@ -1982,7 +1982,18 @@ impl ExactExportSnapshot for SessionExportProfile {
         &self,
         candidates: &[ExactExportCandidate<'_>],
     ) -> Vec<Result<ExactExportResult, ExactExportError>> {
+        self.probe_announcements_with_checkpoint(candidates, &mut || {})
+    }
+
+    fn probe_announcements_with_checkpoint(
+        &self,
+        candidates: &[ExactExportCandidate<'_>],
+        checkpoint: &mut dyn FnMut(),
+    ) -> Vec<Result<ExactExportResult, ExactExportError>> {
+        checkpoint();
         let mut prepared_attr_cache = PreparedAttrCache::default();
+        prepared_attr_cache.entries.reserve(candidates.len());
+        checkpoint();
         // Exact length-reuse cache for unicast probes. A probed message's
         // length is a pure function of the prepared attribute bytes
         // (identified by `Arc` pointer — the prepared-attr cache keeps every
@@ -1995,11 +2006,13 @@ impl ExactExportSnapshot for SessionExportProfile {
         // result. Errors are never cached: they are the rare aborting case
         // and stay on the fully built path.
         let mut length_cache: FxHashMap<UnicastProbeShapeKey, ExactExportResult> =
-            FxHashMap::default();
+            FxHashMap::with_capacity_and_hasher(candidates.len(), rustc_hash::FxBuildHasher);
+        checkpoint();
         let local_ipv4 = self.local_ipv4();
-        candidates
+        let results = candidates
             .iter()
             .copied()
+            .inspect(|_| checkpoint())
             .map(|candidate| match candidate {
                 ExactExportCandidate::Unicast {
                     route,
@@ -2022,7 +2035,21 @@ impl ExactExportSnapshot for SessionExportProfile {
                 }
                 _ => <Self as ExactExportSnapshot>::probe_announcement(self, candidate),
             })
-            .collect()
+            .collect();
+        checkpoint();
+        for entry in prepared_attr_cache.entries.drain() {
+            drop(entry);
+            checkpoint();
+        }
+        drop(prepared_attr_cache);
+        checkpoint();
+        for entry in length_cache.drain() {
+            let _ = entry;
+            checkpoint();
+        }
+        drop(length_cache);
+        checkpoint();
+        results
     }
 
     fn reuse_successful_probes(
@@ -2030,6 +2057,16 @@ impl ExactExportSnapshot for SessionExportProfile {
         source: &dyn ExactExportSnapshot,
         encoded_lengths: &[usize],
     ) -> Option<Vec<Result<ExactExportResult, ExactExportError>>> {
+        self.reuse_successful_probes_with_checkpoint(source, encoded_lengths, &mut || {})
+    }
+
+    fn reuse_successful_probes_with_checkpoint(
+        &self,
+        source: &dyn ExactExportSnapshot,
+        encoded_lengths: &[usize],
+        checkpoint: &mut dyn FnMut(),
+    ) -> Option<Vec<Result<ExactExportResult, ExactExportError>>> {
+        checkpoint();
         let source = source.as_any().downcast_ref::<Self>()?;
         if !self.has_same_wire_encoding(source) {
             return None;
@@ -2038,6 +2075,7 @@ impl ExactExportSnapshot for SessionExportProfile {
         let max_len = self.max_message_len();
         let mut results = Vec::with_capacity(encoded_lengths.len());
         for &encoded_len in encoded_lengths {
+            checkpoint();
             let result = if encoded_len > max_len {
                 Err(ExactExportError::new(
                     ExactExportErrorCode::MessageTooLong,
@@ -2054,6 +2092,7 @@ impl ExactExportSnapshot for SessionExportProfile {
             };
             results.push(result);
         }
+        checkpoint();
         Some(results)
     }
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2603,6 +2603,12 @@ dedicated read-only RIB lane stays healthy for bounded progress, then returns
 seconds; commit or cleaned-up fallback restores readiness immediately. It does
 not require peers or routes to exist.
 
+Authoritative export-policy replacement and rollback service this same RIB
+readiness lane between construction, per-peer work, and cleanup steps. These
+operations preserve Loc-RIB cardinality, so readiness replies report its exact
+count while ordinary route queries and mutations remain queued. Nested
+replacements retain the original command's 30-second transition-age limit.
+
 ### Get Prometheus metrics via gRPC
 
 ```bash


### PR DESCRIPTION
## Summary

Export-policy replacement can prevent `GetHealth` from receiving its live RIB acknowledgement within the existing shared 200 ms deadline. Service the dedicated readiness lane throughout synchronous replacement and rollback, using the exact Loc-RIB count that remains invariant during this work.

## Changes

- Keep canonical state actor-owned and ordinary queries and mutations fenced. Nested helpers retain the original transition age; terminal acknowledgements follow cleanup and restoration of the readiness receiver.
- Checkpoint shared construction, per-family and per-peer work, prefix-limit bookkeeping, and temporary/table retirement. Existing batch export probes preserve their caches and override semantics.
- Skip element walks for scalar temporary collections while retaining allocation-edge checkpoints and incremental destruction of owning values.
- Exercise interior readiness servicing, exact dual-stack counts, queued reads and mutations, transition-age expiry, terminal and closed-reply paths, every outbound family, and sparse slab reservation. Optional diagnostic builds record servicing intervals and observed capacities.

## Testing

- [x] Broad local baseline: formatting, repository contracts, workspace Clippy, all workspace package tests, workspace doctests, and private-items library/binary rustdoc. Validation resumed after fixing diagnostic-only lint/logging issues and a rustdoc link; process tests ran with a 65,536 descriptor limit.
- [x] `just gate-rib` and `just gate-deps`
- [x] `just gate-contract`
- [x] Scalar-cleanup follow-up: 20 replacement tests, instrumented-build cleanup regression, and workspace library-test/Clippy/rustdoc hooks
- [ ] Hosted interoperability checks
- [ ] Pinned release acceptance: 200-member native harness passed all four reloads with zero health/query failures; strict checker and provenance closeout are pending. Normal 700-member acceptance and separate capacity diagnostics follow.
- [x] Paired performance A/B intentionally not applicable: this is operational correctness acceptance, with an explicitly non-isolated historical reference and no causal speedup claim. The measured receipt will follow the completed campaign.

## Docs / release notes

- [x] Changelog and API readiness documentation updated
- [x] Changelog entry appended within the existing subsection
- [x] Roadmap change intentionally unnecessary for this focused correctness fix
