### PR TITLE
fix(bench): drain matrix clients before daemon shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The scale matrix now finishes and records each active management probe before
   shutting down the daemon, preventing orphaned CLI requests and missing final
   CSV rows. Cleanup waits for owned processes and retains the daemon exit status.
+  After final evidence capture, BGP stubs stop churn, send Cease, and drain
+  incoming output before exiting; task failures or a fleet timeout fail the cell.
 
 - IPv4-unicast reflection with an unchanged IPv6 next hop now suppresses
   export to peers without Extended Next Hop support, instead of emitting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The scale matrix now finishes and records each active management probe before
+  shutting down the daemon, preventing orphaned CLI requests and missing final
+  CSV rows. Cleanup waits for owned processes and retains the daemon exit status.
+
 - IPv4-unicast reflection with an unchanged IPv6 next hop now suppresses
   export to peers without Extended Next Hop support, instead of emitting
   classic IPv4 NLRI without NEXT_HOP. Ordinary eBGP and export-policy rewrites

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,8 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The scale matrix now finishes and records each active management probe before
   shutting down the daemon, preventing orphaned CLI requests and missing final
-  CSV rows. Cleanup waits for owned processes and retains the daemon exit status.
+  CSV rows. Cleanup waits for owned processes and retains the daemon exit status;
+  a native daemon that exceeds its shutdown deadline is killed and the cell fails.
   After final evidence capture, BGP stubs stop churn, send Cease, and drain
   incoming output before exiting; task failures or a fleet timeout fail the cell.
 

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -302,6 +302,31 @@ probe_query_loop() {
     return 0
 }
 
+# Bound native process teardown independently of the daemon's actor deadlines.
+# The optional duration is for short companion fixtures; cells always use 60s.
+stop_native_daemon() {
+    local pid=$1 exit_file=$2 timeout_secs=${3:-60}
+    local deadline=$((SECONDS + timeout_secs)) timed_out=0 child_rc
+    kill "$pid" 2>/dev/null || true
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "daemon $pid did not exit within ${timeout_secs}s after SIGTERM; sending SIGKILL" >&2
+            timed_out=1
+            kill -KILL "$pid" 2>/dev/null || true
+            break
+        fi
+        sleep 0.1
+    done
+    wait "$pid"
+    child_rc=$?
+    printf '%s\n' "$child_rc" >"$exit_file" || return 1
+    if [ "$child_rc" -ne 0 ]; then
+        echo "daemon $pid exited $child_rc during cleanup" >&2
+        return 1
+    fi
+    [ "$timed_out" -eq 0 ]
+}
+
 # run_cell <cell>: everything for one matrix cell. Nonzero return = cell
 # failed; the campaign moves on.
 run_cell() {
@@ -461,14 +486,7 @@ run_cell() {
         # Peak resident set over the whole cell, from the kernel's own
         # high-water mark, before the daemon goes away.
         grep -E '^(VmHWM|VmRSS):' "/proc/$daemon_pid/status" >"$cdir/vmhwm" 2>/dev/null || cleanup_rc=1
-        kill "$daemon_pid" 2>/dev/null || true
-        wait "$daemon_pid"
-        child_rc=$?
-        printf '%s\n' "$child_rc" >"$cdir/daemon.exit" || cleanup_rc=1
-        if [ "$child_rc" -ne 0 ]; then
-            echo "cell $cell: daemon exited $child_rc during cleanup" >&2
-            cleanup_rc=1
-        fi
+        stop_native_daemon "$daemon_pid" "$cdir/daemon.exit" || cleanup_rc=1
     fi
     cp -r "$run" "$cdir/scenario" || cleanup_rc=1
     [ "$rc" -ne 0 ] || rc=$cleanup_rc

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -260,10 +260,13 @@ recheck_cell_provenance() {
 # `epoch_s,[prefix,]latency_ms,exit`. They measure responsiveness of the
 # management plane while the fleet reloads; they never gate the cell.
 probe_health_loop() {
-    local addr=$1 out=$2
+    local addr=$1 out=$2 stopping=0
+    # Bash runs this trap after the foreground CLI returns. Preserve that
+    # command's complete measurement before stopping; never orphan its RPC.
+    trap 'stopping=1' INT TERM
     echo "epoch_s,latency_ms,exit" >"$out"
     : >"$out.stderr.log"
-    while :; do
+    while [ "$stopping" -eq 0 ]; do
         local t0 t1 rc
         t0=$(date +%s.%N)
         printf "probe_start epoch_s=%s\n" "$t0" >>"$out.stderr.log"
@@ -272,16 +275,20 @@ probe_health_loop() {
         t1=$(date +%s.%N)
         awk -v a="$t0" -v b="$t1" -v rc="$rc" \
             'BEGIN {printf "%s,%.1f,%d\n", a, (b - a) * 1000, rc}' >>"$out"
+        [ "$stopping" -eq 0 ] || break
         sleep 0.05
     done
+    return 0
 }
 probe_query_loop() {
-    local addr=$1 out=$2
+    local addr=$1 out=$2 stopping=0
+    trap 'stopping=1' INT TERM
     shift 2
     echo "epoch_s,prefix,latency_ms,exit" >"$out"
-    while :; do
+    while [ "$stopping" -eq 0 ]; do
         local prefix t0 t1 rc
         for prefix in "$@"; do
+            [ "$stopping" -eq 0 ] || break
             t0=$(date +%s.%N)
             "$RBGP" --addr "$addr" rib --prefix "$prefix" >/dev/null 2>&1
             rc=$?
@@ -289,8 +296,10 @@ probe_query_loop() {
             awk -v a="$t0" -v p="$prefix" -v b="$t1" -v rc="$rc" \
                 'BEGIN {printf "%s,%s,%.1f,%d\n", a, p, (b - a) * 1000, rc}' >>"$out"
         done
+        [ "$stopping" -eq 0 ] || break
         sleep 0.25
     done
+    return 0
 }
 
 # run_cell <cell>: everything for one matrix cell. Nonzero return = cell
@@ -424,21 +433,46 @@ run_cell() {
     [ -z "$rc" ] && rc=$hrc
 
     # Collect artifacts, then teardown.
-    kill "$sampler_pid" 2>/dev/null
+    local cleanup_rc=0 child_rc p
+    kill "$sampler_pid" 2>/dev/null || true
     for p in "${probe_pids[@]}"; do
-        kill "$p" 2>/dev/null
+        kill "$p" 2>/dev/null || true
     done
+    # Signal every probe before waiting. Each loop owns its current CLI until
+    # the response and CSV row finish, so no client survives daemon shutdown.
+    for p in "${probe_pids[@]}"; do
+        wait "$p"
+        child_rc=$?
+        if [ "$child_rc" -ne 0 ]; then
+            echo "cell $cell: probe loop $p exited $child_rc during cleanup" >&2
+            cleanup_rc=1
+        fi
+    done
+    wait "$sampler_pid"
+    child_rc=$?
+    if [ "$child_rc" -ne 0 ] && [ "$child_rc" -ne 143 ]; then
+        echo "cell $cell: RSS sampler exited $child_rc during cleanup" >&2
+        cleanup_rc=1
+    fi
     if [ -n "$container" ]; then
-        docker logs "$container" >"$cdir/daemon.log" 2>&1
-        docker rm -f "$container" >/dev/null 2>&1
+        docker logs "$container" >"$cdir/daemon.log" 2>&1 || cleanup_rc=1
+        docker rm -f "$container" >/dev/null 2>&1 || cleanup_rc=1
     else
         # Peak resident set over the whole cell, from the kernel's own
         # high-water mark, before the daemon goes away.
-        grep -E '^(VmHWM|VmRSS):' "/proc/$daemon_pid/status" >"$cdir/vmhwm" 2>/dev/null
-        kill "$daemon_pid" 2>/dev/null
+        grep -E '^(VmHWM|VmRSS):' "/proc/$daemon_pid/status" >"$cdir/vmhwm" 2>/dev/null || cleanup_rc=1
+        kill "$daemon_pid" 2>/dev/null || true
+        wait "$daemon_pid"
+        child_rc=$?
+        printf '%s\n' "$child_rc" >"$cdir/daemon.exit" || cleanup_rc=1
+        if [ "$child_rc" -ne 0 ]; then
+            echo "cell $cell: daemon exited $child_rc during cleanup" >&2
+            cleanup_rc=1
+        fi
     fi
-    cp -r "$run" "$cdir/scenario"
-    echo "cell $cell: harness rc=$rc (artifacts: $cdir)"
+    cp -r "$run" "$cdir/scenario" || cleanup_rc=1
+    [ "$rc" -ne 0 ] || rc=$cleanup_rc
+    echo "cell $cell: harness rc=$hrc cleanup rc=$cleanup_rc cell rc=$rc (artifacts: $cdir)"
     [ "$rc" -ne 0 ] || recheck_cell_provenance "$cell" || return 1
     return "$rc"
 }

--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -40,6 +40,12 @@ evidence barrier and churn begin; convergence-only keeps it armed through the
 ready/ack evidence boundary and rechecks it before exiting. One
 `first_exact_bitmap` receipt records the mode and fleet coverage.
 
+After all measurements and any final evidence acknowledgment, successful runs
+stop and join churn tasks, send each stub a final Cease, and keep receiving
+daemon output until EOF. One 15-second deadline bounds the fleet cleanup.
+Read, write, or task failures and cleanup timeouts fail the run; remaining
+reader, writer, and refresh tasks are canceled and joined before exit.
+
 Depends only on `crates/wire` (wire encode/decode for the stub sessions).
 
 ## Backs

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -141,11 +141,12 @@ use rustbgpd_wire::constants::{AS_TRANS, HEADER_LEN, MAX_MESSAGE_LEN};
 use rustbgpd_wire::header::peek_message_length;
 use rustbgpd_wire::message::{decode_message, encode_message, Message};
 use rustbgpd_wire::nlri::{NlriEntry, Prefix};
+use rustbgpd_wire::notification::cease_subcode;
 use rustbgpd_wire::open::OpenMessage;
 use rustbgpd_wire::update::{Ipv4UnicastMode, ParsedUpdate, UpdateMessage};
 use rustbgpd_wire::{
     AsPath, AsPathSegment, Ipv4NlriEntry, Ipv4Prefix, Ipv6Prefix, MpReachNlri, MpUnreachNlri,
-    Origin, PathAttribute, RouteRefreshMessage,
+    NotificationCode, NotificationMessage, Origin, PathAttribute, RouteRefreshMessage,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpSocket, TcpStream};
@@ -202,6 +203,7 @@ const TRIP_TEARDOWN_WINDOW: Duration = Duration::from_secs(60);
 /// accepts and then silently holds the socket must not wedge the retry
 /// loop (the loop itself runs until the configured re-establish deadline).
 const TRIP_ATTEMPT_WINDOW: Duration = Duration::from_secs(30);
+const FLEET_FINISH_TIMEOUT: Duration = Duration::from_secs(15);
 const EVIDENCE_TIMEOUT: Duration = Duration::from_secs(15);
 const PRE_CHURN_EVIDENCE_TIMEOUT: Duration = Duration::from_secs(60);
 const METRICS_DEADLINE: Duration = Duration::from_secs(5);
@@ -459,8 +461,97 @@ impl Obs {
 /// (dropping both split halves closes the fd).
 struct Stub {
     tx: mpsc::Sender<Message>,
-    reader: tokio::task::JoinHandle<()>,
-    writer: tokio::task::JoinHandle<()>,
+    reader: tokio::task::JoinHandle<Result<(), String>>,
+    writer: tokio::task::JoinHandle<Result<(), String>>,
+    refreshes: Arc<Mutex<tokio::task::JoinSet<()>>>,
+}
+
+/// Finish only after measurement/evidence has completed. Every peer receives
+/// Cease before any reader is joined, so slow drain cannot strand another
+/// peer's live writer. A single deadline bounds the entire fleet.
+async fn finish_fleet(
+    stubs: Vec<Stub>,
+    churn_tasks: Vec<tokio::task::JoinHandle<()>>,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut errors = Vec::new();
+    for task in &churn_tasks {
+        task.abort();
+    }
+    for task in churn_tasks {
+        if let Err(error) = task.await {
+            if !error.is_cancelled() {
+                errors.push(format!("churn task: {error}"));
+            }
+        }
+    }
+    for (i, stub) in stubs.iter().enumerate() {
+        let cease = Message::Notification(NotificationMessage::new(
+            NotificationCode::Cease,
+            cease_subcode::ADMINISTRATIVE_SHUTDOWN,
+            bytes::Bytes::new(),
+        ));
+        match tokio::time::timeout_at(deadline, stub.tx.send(cease)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => errors.push(format!("stub {i} writer channel closed")),
+            Err(_) => {
+                errors.push(format!("fleet finish timed out sending Cease to stub {i}"));
+                break;
+            }
+        }
+    }
+    let mut tasks = Vec::new();
+    let mut refreshes = Vec::new();
+    for (i, stub) in stubs.into_iter().enumerate() {
+        tasks.push((i, "reader", stub.reader));
+        tasks.push((i, "writer", stub.writer));
+        refreshes.push(stub.refreshes);
+    }
+    while let Some((i, kind, mut task)) = tasks.pop() {
+        match tokio::time::timeout_at(deadline, &mut task).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(error))) => errors.push(format!("stub {i} {kind}: {error}")),
+            Ok(Err(error)) => errors.push(format!("stub {i} {kind} task: {error}")),
+            Err(_) => {
+                errors.push(format!("fleet finish timed out draining stub {i} {kind}"));
+                task.abort();
+                for (_, _, remaining) in &tasks {
+                    remaining.abort();
+                }
+                let _ = task.await;
+                for (_, _, remaining) in tasks.drain(..) {
+                    let _ = remaining.await;
+                }
+                break;
+            }
+        }
+    }
+    // Readers can no longer spawn responses. Take ownership before awaiting;
+    // channel closure/abort ends every remaining refresh sender.
+    for refreshes in refreshes {
+        let mut refreshes = std::mem::take(&mut *refreshes.lock().unwrap());
+        refreshes.abort_all();
+        while let Some(result) = refreshes.join_next().await {
+            if let Err(error) = result {
+                if !error.is_cancelled() {
+                    errors.push(format!("refresh task: {error}"));
+                }
+            }
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+async fn finish_or_exit(stubs: Vec<Stub>, churn_tasks: Vec<tokio::task::JoinHandle<()>>) {
+    if let Err(error) = finish_fleet(stubs, churn_tasks, FLEET_FINISH_TIMEOUT).await {
+        eprintln!("FAIL: final BGP fleet cleanup failed: {error}");
+        std::process::exit(1);
+    }
 }
 
 #[derive(Default)]
@@ -1386,56 +1477,80 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
         .established
         .store(true, Ordering::Relaxed);
 
+    Ok((start_stub(ctx, i, stream), retries))
+}
+
+fn start_stub(ctx: Arc<Ctx>, i: u32, stream: TcpStream) -> Stub {
     let (tx, mut tx_rx) = mpsc::channel::<Message>(256);
     let (mut reader, mut writer) = stream.into_split();
+    let refreshes = Arc::new(Mutex::new(tokio::task::JoinSet::new()));
 
-    // Writer task: outbound messages + periodic keepalive.
+    // Writer task: outbound messages + periodic keepalive. A final Cease
+    // drains queued messages, half-closes TCP, and stops keepalives while
+    // the reader continues consuming the daemon's pending output to EOF.
     let writer_ctx = Arc::clone(&ctx);
     let writer_handle = tokio::spawn(async move {
-        let mut ka_tick = tokio::time::interval(Duration::from_secs(u64::from(HOLD_TIME) / 3));
-        ka_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        ka_tick.tick().await;
-        loop {
-            tokio::select! {
-                Some(msg) = tx_rx.recv() => {
-                    let Ok(bytes) = encode_message(&msg) else { break };
-                    if writer.write_all(&bytes).await.is_err() { break; }
-                    if dualstack() && i >= writer_ctx.n_peers - CHURNERS {
-                        let written_at = now_us(&writer_ctx);
-                        let family = churn_family(&msg, i - (writer_ctx.n_peers - CHURNERS));
-                        if family != 0 {
-                            if let Some(writes) = writer_ctx.churn_writes.lock().unwrap().as_mut() {
-                                writes.push((written_at, family));
+        let result = async {
+            let mut ka_tick = tokio::time::interval(Duration::from_secs(u64::from(HOLD_TIME) / 3));
+            ka_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            ka_tick.tick().await;
+            loop {
+                tokio::select! {
+                    Some(msg) = tx_rx.recv() => {
+                        let bytes = encode_message(&msg).map_err(|e| format!("encode: {e}"))?;
+                        writer.write_all(&bytes).await.map_err(|e| format!("write: {e}"))?;
+                        if matches!(msg, Message::Notification(_)) {
+                            writer.shutdown().await.map_err(|e| format!("shutdown: {e}"))?;
+                            return Ok(());
+                        }
+                        if dualstack() && i >= writer_ctx.n_peers - CHURNERS {
+                            let written_at = now_us(&writer_ctx);
+                            let family = churn_family(&msg, i - (writer_ctx.n_peers - CHURNERS));
+                            if family != 0 {
+                                if let Some(writes) = writer_ctx.churn_writes.lock().unwrap().as_mut() {
+                                    writes.push((written_at, family));
+                                }
                             }
                         }
                     }
+                    _ = ka_tick.tick() => {
+                        let bytes = encode_message(&Message::Keepalive).unwrap();
+                        writer.write_all(&bytes).await.map_err(|e| format!("keepalive write: {e}"))?;
+                    }
                 }
-                _ = ka_tick.tick() => {
-                    let bytes = encode_message(&Message::Keepalive).unwrap();
-                    if writer.write_all(&bytes).await.is_err() { break; }
-                }
-                else => break,
             }
-        }
+        }.await;
         writer_ctx.obs[i as usize]
             .established
             .store(false, Ordering::Relaxed);
+        result
     });
 
     // Reader task: frame, decode, record UPDATE arrivals, answer
     // ROUTE_REFRESH by re-sending the base slice.
     let tx_for_reader = tx.clone();
     let rctx = Arc::clone(&ctx);
+    let reader_refreshes = Arc::clone(&refreshes);
     let reader_handle = tokio::spawn(async move {
         let mut frame = BytesMut::with_capacity(1 << 16);
         let mut tmp = vec![0u8; 1 << 16];
         loop {
             let n = match reader.read(&mut tmp).await {
-                Ok(0) | Err(_) => {
+                Ok(0) => {
                     rctx.obs[i as usize]
                         .established
                         .store(false, Ordering::Relaxed);
-                    return;
+                    return if frame.is_empty() {
+                        Ok(())
+                    } else {
+                        Err("EOF in daemon frame".into())
+                    };
+                }
+                Err(error) => {
+                    rctx.obs[i as usize]
+                        .established
+                        .store(false, Ordering::Relaxed);
+                    return Err(format!("read: {error}"));
                 }
                 Ok(n) => n,
             };
@@ -1453,7 +1568,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                         rctx.obs[i as usize]
                             .established
                             .store(false, Ordering::Relaxed);
-                        return;
+                        return Err(error.to_string());
                     }
                 };
                 if frame.len() < total {
@@ -1468,7 +1583,7 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                         rctx.obs[i as usize]
                             .established
                             .store(false, Ordering::Relaxed);
-                        return;
+                        return Err(error.to_string());
                     }
                 };
                 match msg {
@@ -1647,7 +1762,16 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
                         }
                         let tx = tx_for_reader.clone();
                         let rc = Arc::clone(&rctx);
-                        tokio::spawn(async move {
+                        let mut refresh_tasks = reader_refreshes.lock().unwrap();
+                        while let Some(result) = refresh_tasks.try_join_next() {
+                            if let Err(error) = result {
+                                rctx.obs[i as usize]
+                                    .established
+                                    .store(false, Ordering::Relaxed);
+                                return Err(format!("refresh task: {error}"));
+                            }
+                        }
+                        refresh_tasks.spawn(async move {
                             let messages = if ipv6 {
                                 announce6_msgs(i, &own_slice6(&rc, i))
                             } else {
@@ -1668,14 +1792,12 @@ async fn establish_stub(ctx: Arc<Ctx>, i: u32) -> Result<(Stub, u32), String> {
         }
     });
 
-    Ok((
-        Stub {
-            tx,
-            reader: reader_handle,
-            writer: writer_handle,
-        },
-        retries,
-    ))
+    Stub {
+        tx,
+        reader: reader_handle,
+        writer: writer_handle,
+        refreshes,
+    }
 }
 
 /// Percentile over a sorted slice.
@@ -3063,6 +3185,7 @@ fn main() {
             println!(
                 "convergence_only_receipt,peers={n_peers},prefixes={total},per_peer={per_peer},expected={expected},min_unique={min_unique},max_unique={max_unique},sessions_up={up},parse_errors={parse_errors}"
             );
+            finish_or_exit(stubs, Vec::new()).await;
             std::process::exit(0);
         }
 
@@ -3075,6 +3198,7 @@ fn main() {
             }
         }
 
+        let mut churn_tasks = Vec::new();
         // --- Start churn: last CHURNERS stubs flap a dedicated block. ---
         for c in 0..CHURNERS {
             let i = n_peers - CHURNERS + c;
@@ -3082,7 +3206,7 @@ fn main() {
             let block: Vec<Ipv4Prefix> = (0..CHURN_BLOCK).map(|j| churn_prefix(c, j)).collect();
             let block6: Vec<Ipv6Prefix> = (0..CHURN_BLOCK).map(|j| churn_prefix6(c, j)).collect();
             let cctx = Arc::clone(&ctx);
-            tokio::spawn(async move {
+            churn_tasks.push(tokio::spawn(async move {
                 // Stagger churners across the interval.
                 tokio::time::sleep(Duration::from_millis(
                     u64::from(c) * CHURN_MS / u64::from(CHURNERS),
@@ -3116,7 +3240,7 @@ fn main() {
                     cctx.churn_cycles.fetch_add(1, Ordering::Relaxed);
                     tokio::time::sleep(Duration::from_millis(CHURN_MS)).await;
                 }
-            });
+            }));
         }
         // Let churn reach steady state.
         tokio::time::sleep(Duration::from_secs(3)).await;
@@ -3162,6 +3286,7 @@ fn main() {
                 );
                 std::process::exit(1);
             }
+            finish_or_exit(stubs, churn_tasks).await;
             std::process::exit(0);
         }
 
@@ -3176,6 +3301,7 @@ fn main() {
                 );
                 std::process::exit(1);
             }
+            finish_or_exit(stubs, churn_tasks).await;
             std::process::exit(0);
         }
 
@@ -3676,6 +3802,7 @@ fn main() {
                 );
                 std::process::exit(1);
             }
+            finish_or_exit(stubs, churn_tasks).await;
             std::process::exit(0);
         };
         let up = ctx
@@ -3701,6 +3828,7 @@ fn main() {
             std::process::exit(1);
         }
         println!("done rss_mib={}", rss_mib(pid));
+        finish_or_exit(stubs, churn_tasks).await;
         std::process::exit(0);
     });
 }
@@ -3708,6 +3836,224 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn finish_test_ctx() -> Arc<Ctx> {
+        Arc::new(Ctx {
+            t0: Instant::now(),
+            n_peers: CHURNERS,
+            per_peer: 1,
+            totals: [CHURNERS, CHURNERS],
+            churn_writes: Mutex::new(None),
+            daemon: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1),
+            obs: (0..CHURNERS).map(|_| Obs::new()).collect(),
+            extras: vec![Vec::new(); CHURNERS as usize],
+            parse_errors: AtomicU64::new(0),
+            churn_cycles: AtomicU64::new(0),
+            record_events: AtomicBool::new(true),
+        })
+    }
+
+    async fn finish_test_connection() -> (TcpStream, TcpStream) {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let (client, server) = tokio::join!(
+            TcpStream::connect(listener.local_addr().unwrap()),
+            listener.accept()
+        );
+        (client.unwrap(), server.unwrap().0)
+    }
+
+    #[tokio::test]
+    async fn fleet_finish_writes_queued_updates_and_cease_then_drains_to_eof() {
+        let (client, mut server) = finish_test_connection().await;
+        let stub = start_stub(finish_test_ctx(), 0, client);
+        let update = announce_msgs(0, &[base_prefix(0)]).pop().unwrap();
+        stub.tx.send(update.clone()).await.unwrap();
+        stub.tx.send(update).await.unwrap();
+        let peer = tokio::spawn(async move {
+            let mut sent = Vec::new();
+            server.read_to_end(&mut sent).await.unwrap();
+            let mut sent = bytes::Bytes::from(sent);
+            let mut updates = 0;
+            let mut ceased = false;
+            while !sent.is_empty() {
+                assert!(!ceased, "no messages may follow final Cease");
+                match decode_message(&mut sent, MAX_MESSAGE_LEN).unwrap() {
+                    Message::Update(_) => updates += 1,
+                    Message::Notification(notification) => {
+                        assert_eq!(notification.code, NotificationCode::Cease);
+                        assert_eq!(notification.subcode, cease_subcode::ADMINISTRATIVE_SHUTDOWN);
+                        ceased = true;
+                    }
+                    Message::Keepalive => {}
+                    other => panic!("unexpected message: {other:?}"),
+                }
+            }
+            assert_eq!(updates, 2);
+            assert!(ceased);
+            // The stub's write EOF must leave its reader alive to consume
+            // pending daemon output before the daemon closes its half.
+            server
+                .write_all(&encode_message(&Message::Keepalive).unwrap())
+                .await
+                .unwrap();
+            server.shutdown().await.unwrap();
+        });
+        finish_fleet(vec![stub], Vec::new(), Duration::from_secs(2))
+            .await
+            .unwrap();
+        peer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fleet_finish_rejects_truncated_daemon_eof() {
+        let (client, mut server) = finish_test_connection().await;
+        let stub = start_stub(finish_test_ctx(), 0, client);
+        let peer = tokio::spawn(async move {
+            let mut sent = Vec::new();
+            server.read_to_end(&mut sent).await.unwrap();
+            server.write_all(&[0xff]).await.unwrap();
+            server.shutdown().await.unwrap();
+        });
+        let error = finish_fleet(vec![stub], Vec::new(), Duration::from_secs(2))
+            .await
+            .unwrap_err();
+        assert!(error.contains("EOF in daemon frame"), "{error}");
+        peer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_task_marks_the_actual_reader_session_down() {
+        let (client, mut server) = finish_test_connection().await;
+        let ctx = finish_test_ctx();
+        ctx.obs[0].established.store(true, Ordering::Relaxed);
+        let stub = start_stub(Arc::clone(&ctx), 0, client);
+        let failed = stub.refreshes.lock().unwrap().spawn(async {
+            panic!("fixture refresh failure");
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !failed.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        server
+            .write_all(
+                &encode_message(&Message::RouteRefresh(RouteRefreshMessage::new(
+                    Afi::Ipv4,
+                    Safi::Unicast,
+                )))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let error = tokio::time::timeout(Duration::from_secs(2), stub.reader)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert!(error.contains("fixture refresh failure"), "{error}");
+        assert!(!ctx.obs[0].established.load(Ordering::Relaxed));
+        assert!(stub.refreshes.lock().unwrap().is_empty());
+        stub.writer.abort();
+        assert!(stub.writer.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn fleet_finish_reports_read_write_and_join_failures() {
+        for failure in ["read: fixture error", "write: fixture error", "join"] {
+            let (tx, mut rx) = mpsc::channel(1);
+            let reader = tokio::spawn(async move {
+                if failure == "join" {
+                    panic!("fixture task failure");
+                }
+                if failure.starts_with("read") {
+                    Err(failure.into())
+                } else {
+                    Ok(())
+                }
+            });
+            let writer = tokio::spawn(async move {
+                rx.recv().await.unwrap();
+                if failure.starts_with("write") {
+                    Err(failure.into())
+                } else {
+                    Ok(())
+                }
+            });
+            let stub = Stub {
+                tx,
+                reader,
+                writer,
+                refreshes: Arc::new(Mutex::new(tokio::task::JoinSet::new())),
+            };
+            let error = finish_fleet(vec![stub], Vec::new(), Duration::from_secs(2))
+                .await
+                .unwrap_err();
+            assert!(
+                error.contains(if failure == "join" {
+                    "fixture task failure"
+                } else {
+                    failure
+                }),
+                "{error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn fleet_finish_timeout_aborts_and_reaps_every_owned_task() {
+        struct TaskGuard(Arc<AtomicU32>);
+        impl Drop for TaskGuard {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let live = Arc::new(AtomicU32::new(4));
+        let reader_guard = TaskGuard(Arc::clone(&live));
+        let reader = tokio::spawn(async move {
+            let _guard = reader_guard;
+            std::future::pending::<Result<(), String>>().await
+        });
+        let (tx, mut rx) = mpsc::channel(1);
+        let writer_guard = TaskGuard(Arc::clone(&live));
+        let writer = tokio::spawn(async move {
+            let _guard = writer_guard;
+            rx.recv().await.unwrap();
+            std::future::pending::<Result<(), String>>().await
+        });
+        let refreshes = Arc::new(Mutex::new(tokio::task::JoinSet::new()));
+        let refresh_guard = TaskGuard(Arc::clone(&live));
+        refreshes.lock().unwrap().spawn(async move {
+            let _guard = refresh_guard;
+            std::future::pending::<()>().await;
+        });
+        let churn_guard = TaskGuard(Arc::clone(&live));
+        let churn = tokio::spawn(async move {
+            let _guard = churn_guard;
+            std::future::pending::<()>().await;
+        });
+        let error = finish_fleet(
+            vec![Stub {
+                tx,
+                reader,
+                writer,
+                refreshes,
+            }],
+            vec![churn],
+            Duration::from_millis(10),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("timed out"), "{error}");
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "all task futures must be dropped before cleanup returns"
+        );
+    }
 
     fn test_open(asn: u32) -> Vec<u8> {
         encode_message(&Message::Open(OpenMessage {

--- a/bench/tests/test-scale-provenance.sh
+++ b/bench/tests/test-scale-provenance.sh
@@ -452,5 +452,50 @@ for case, daemon_exit, failed_owner in [("normal", 0, 0), ("daemon-failure", 9, 
         process.wait()
         selector.close()
         os.close(events_fd)
+
+# A process that deliberately ignores TERM must still be killed and reaped.
+# Pass the short bound directly to the production helper, not an env knob.
+fixture = tmp / "daemon-timeout"
+fixture.mkdir()
+stubborn = fixture / "daemon.py"
+stubborn.write_text("""import signal
+import sys
+from pathlib import Path
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+Path(sys.argv[1]).write_text("ready\\n")
+while True:
+    signal.pause()
+""")
+timeout_driver = fixture / "driver.sh"
+timeout_driver.write_text('''#!/usr/bin/env bash
+set -u
+source "$1"
+python3 "$2/daemon.py" "$2/ready" &
+pid=$!
+printf '%s\\n' "$pid" >"$2/pid"
+while [ ! -e "$2/ready" ]; do sleep 0.01; done
+stop_native_daemon "$pid" "$2/daemon.exit" 1
+exit "$?"
+''')
+process = subprocess.Popen(["bash", str(timeout_driver), str(library), str(fixture)],
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           start_new_session=True)
+try:
+    stdout, stderr = process.communicate(timeout=5)
+    assert process.returncode == 1, (stdout, stderr)
+    assert (fixture / "daemon.exit").read_text() == "137\n"
+    assert "did not exit within 1s after SIGTERM; sending SIGKILL" in stderr.decode()
+    try:
+        os.kill(int((fixture / "pid").read_text()), 0)
+    except ProcessLookupError:
+        pass
+    else:
+        raise AssertionError("TERM-ignoring daemon survived bounded cleanup")
+finally:
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
 PY
 echo "scale provenance tests pass"

--- a/bench/tests/test-scale-provenance.sh
+++ b/bench/tests/test-scale-provenance.sh
@@ -285,4 +285,172 @@ resume_rc=0
 RELOADSTALL_IPV4_PREFIXES=200200 run_resume_check || resume_rc=$?
 [[ $resume_rc == 10 ]]
 RELOADSTALL_IPV4_PREFIXES=360360 reject_resume
+
+# Exercise the real probe functions and teardown block without a daemon or
+# benchmark. FIFOs hold each foreground CLI until both loop owners are stopped.
+python3 - "$root" "$tmp" <<'PY'
+import csv
+import os
+from pathlib import Path
+import selectors
+import signal
+import subprocess
+import sys
+
+root, tmp = map(Path, sys.argv[1:])
+source = (root / "bench/scale/matrix/run-matrix.sh").read_text()
+probes = source.split("probe_health_loop() {", 1)[1].split("\n# run_cell ", 1)[0]
+cleanup = source.split("    # Collect artifacts, then teardown.\n", 1)[1].split(
+    "\n}\n\nfor cell ", 1
+)[0]
+library = tmp / "matrix-lifecycle.sh"
+library.write_text("probe_health_loop() {" + probes + "\nfinish_cell() {\n" + cleanup + "\n}\n")
+fake = tmp / "fake-rbgp"
+fake.write_text('''#!/usr/bin/env python3
+import os
+from pathlib import Path
+import signal
+import sys
+
+root = Path(os.environ["PROBE_FIXTURE"])
+mode = sys.argv[1] if sys.argv[1] == "daemon" else sys.argv[3]
+if mode == "daemon":
+    def stop(_signal, _frame):
+        for name in ("health", "rib"):
+            assert (root / (name + ".done")).exists(), name + " did not finish"
+            try:
+                os.kill(int((root / (name + ".pid")).read_text()), 0)
+            except ProcessLookupError:
+                pass
+            else:
+                raise AssertionError(name + " child survived its loop")
+        (root / "daemon.stopped").write_text("stopped\\n")
+        raise SystemExit(int(os.environ["DAEMON_EXIT"]))
+    signal.signal(signal.SIGTERM, stop)
+else:
+    (root / (mode + ".pid")).write_text(str(os.getpid()))
+    with (root / (mode + ".starts")).open("a") as stream:
+        stream.write("started\\n")
+    print(mode + " stderr started", file=sys.stderr, flush=True)
+with (root / "events").open("w") as events:
+    events.write("ready " + mode + "\\n")
+if mode == "daemon":
+    while True:
+        signal.pause()
+with (root / (mode + ".release")).open() as release:
+    release.readline()
+print(mode + " stderr finished", file=sys.stderr, flush=True)
+(root / (mode + ".done")).write_text("done\\n")
+raise SystemExit(7 if mode == "health" else 0)
+''')
+fake.chmod(0o755)
+driver = tmp / "matrix-lifecycle-driver.sh"
+driver.write_text('''#!/usr/bin/env bash
+set -u
+source "$1"
+cell=rustbgpd
+cdir=$PROBE_FIXTURE
+run=$cdir/run
+container=""
+rc=0
+hrc=0
+recheck_cell_provenance() { return 0; }
+"$RBGP" daemon >"$cdir/daemon.log" 2>&1 &
+daemon_pid=$!
+sleep 60 &
+sampler_pid=$!
+probe_health_loop fixture "$cdir/probes.csv" &
+probe_pids=($!)
+probe_query_loop fixture "$cdir/queries.csv" first-prefix second-prefix &
+probe_pids+=($!)
+printf '%s\\n' "${probe_pids[@]}" >"$cdir/loops"
+kill() {
+    builtin kill "$@"
+    local status=$?
+    printf 'signaled %s\\n' "$1" >"$cdir/events"
+    return "$status"
+}
+wait() {
+    printf 'waiting %s\\n' "$1" >"$cdir/events"
+    builtin wait "$1"
+}
+printf 'ready driver\\n' >"$cdir/events"
+read -r _ <"$cdir/cleanup"
+if [ "$FAIL_PROBE_OWNER" = 1 ]; then
+    (exit 23) &
+    probe_pids+=($!)
+fi
+finish_cell
+''')
+
+for case, daemon_exit, failed_owner in [("normal", 0, 0), ("daemon-failure", 9, 0), ("owner-failure", 0, 1)]:
+    fixture = tmp / case
+    (fixture / "run").mkdir(parents=True)
+    for name in ("events", "cleanup", "health.release", "rib.release"):
+        os.mkfifo(fixture / name)
+    events_fd = os.open(fixture / "events", os.O_RDWR | os.O_NONBLOCK)
+    selector = selectors.DefaultSelector()
+    selector.register(events_fd, selectors.EVENT_READ)
+    buffered = bytearray()
+
+    def event():
+        while b"\n" not in buffered:
+            assert selector.select(5), f"{case}: missing lifecycle event"
+            buffered.extend(os.read(events_fd, 4096))
+        line, _, rest = buffered.partition(b"\n")
+        buffered[:] = rest
+        return line.decode()
+
+    environment = dict(os.environ, RBGP=str(fake), PROBE_FIXTURE=str(fixture),
+                       DAEMON_EXIT=str(daemon_exit), FAIL_PROBE_OWNER=str(failed_owner))
+    process = subprocess.Popen(["bash", str(driver), str(library)], env=environment,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               start_new_session=True)
+    try:
+        assert {event() for _ in range(4)} == {
+            "ready health", "ready rib", "ready daemon", "ready driver"
+        }
+        loops = (fixture / "loops").read_text().splitlines()
+        with (fixture / "cleanup").open("w") as start:
+            start.write("stop\n")
+        signaled = []
+        while True:
+            next_event = event()
+            if next_event.startswith("waiting "):
+                assert next_event == "waiting " + loops[0]
+                break
+            signaled.append(next_event.removeprefix("signaled "))
+        assert all(pid in signaled for pid in loops), "must signal both loops before waiting"
+        assert not (fixture / "daemon.stopped").exists(), "daemon stopped during an active RPC"
+        for name, filename in [("health", "probes.csv"), ("rib", "queries.csv")]:
+            assert len((fixture / filename).read_text().splitlines()) == 1
+            os.kill(int((fixture / (name + ".pid")).read_text()), 0)
+            with (fixture / (name + ".release")).open("w") as release:
+                release.write("complete\n")
+        stdout, stderr = process.communicate(timeout=5)
+        assert process.returncode == (1 if daemon_exit or failed_owner else 0), (case, stdout, stderr)
+        expected_cleanup = 1 if daemon_exit or failed_owner else 0
+        assert f"harness rc=0 cleanup rc={expected_cleanup} cell rc={expected_cleanup}" in stdout.decode()
+        assert (fixture / "daemon.exit").read_text() == str(daemon_exit) + "\n"
+        assert (fixture / "daemon.stopped").exists(), (fixture / "daemon.log").read_text()
+        for name, filename, expected_exit in [("health", "probes.csv", "7"), ("rib", "queries.csv", "0")]:
+            with (fixture / filename).open() as stream:
+                rows = list(csv.DictReader(stream))
+            assert len(rows) == 1 and rows[0]["exit"] == expected_exit, (case, rows)
+            assert float(rows[0]["latency_ms"]) >= 0
+            assert (fixture / (name + ".starts")).read_text() == "started\n"
+        assert rows[0]["prefix"] == "first-prefix", "query loop started another prefix after stop"
+        health_stderr = (fixture / "probes.csv.stderr.log").read_text()
+        assert health_stderr.count("probe_start epoch_s=") == 1
+        assert "health stderr started\nhealth stderr finished\n" in health_stderr
+    finally:
+        # Only this fixture's session: leave no fake child behind on assertion failure.
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+        selector.close()
+        os.close(events_fd)
+PY
 echo "scale provenance tests pass"


### PR DESCRIPTION
## Summary

The scale matrix could lose the last foreground probe result and race gRPC shutdown. Its native harness also exited with live BGP clients after collecting final evidence, producing teardown write errors. Complete and reap both probe loops before stopping the daemon, and drain the harness's owned BGP sessions after final evidence capture.

## Changes

- Retain each active probe's result and stderr, then stop and join both loops before daemon shutdown.
- Reap the sampler and native daemon, retain `daemon.exit`, and report harness, cleanup, and combined cell results separately. Kill and reap a native daemon that exceeds the fixed shutdown deadline, failing cleanup.
- Stop owned churn tasks after final evidence, drain queued UPDATEs followed by Administrative Shutdown, and read sessions to EOF under one fleet deadline.
- Reap reader, writer, and refresh tasks on success or failure; fail incomplete cleanup.

## Testing

- [x] Scale-provenance companion covers active probe completion, retained failed results, owner failure, nonzero daemon exit, and a TERM-ignoring daemon killed and reaped at the terminal deadline.
- [x] All 47 reloadstall tests pass, including queued UPDATE/CEASE delivery, reverse-direction drain, reader and writer failures, truncated EOF, refresh-task failure, and deadline cleanup.
- [x] `just gate-deps`, focused strict Clippy, formatting, links, shell syntax, ShellCheck, developer-tooling checks, public-document checks, and diff checks pass.
- [x] Normal commit and push hooks passed: formatting, strict Clippy, workspace library tests, and rustdoc.
- [x] Fresh pinned 200-member operating acceptance passes on the final source: all four dual-stack reloads, 1,910 completely retained successful health invocations, 866 successful query rows, clean native shutdown, and unchanged source/binary provenance. The identical-source 700-member cell also passes: all four reloads, 2,027 completely retained successful health invocations, 913 successful query rows, clean native shutdown, and unchanged source/binary provenance. Workload parameters, measurement ordering, and the strict gate are unchanged; the accompanying receipt retains earlier failed attempts.
- A performance A/B and external protocol interoperability matrix are not applicable to this post-measurement harness cleanup.

## Docs / release notes

- [x] CHANGELOG.md and harness README updated.
- [x] Roadmap and operator-reference changes are not needed for measurement teardown.

## Related issues

Follow-up to #2440's scale-matrix validation.
