### PR TITLE
fix(bench): verify daemon settlement before reload completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,11 @@ jobs:
           # renderer, so make that prerequisite explicit on a clean runner.
           cargo build --locked -p rs-config-render
           cargo test --locked --test reloadstall_scenario_emitted_check
+          cargo build --manifest-path bench/scale/Cargo.toml --locked -p reloadstall
+          python3 bench/tests/test-reloadstall-settlement.py \
+            --daemon target/debug/rustbgpd \
+            --harness bench/scale/target/debug/reloadstall \
+            --artifact-dir "$RUNNER_TEMP/reloadstall-settlement"
           python3 bench/scale/irrreload/verify-receipt.py self-test
           python3 bench/scale/irrreload/verify-receipt.py authoritative-publication \
             --artifact-dir docs/perf/artifacts/reload-authoritative-batch-discriminator-2026-08
@@ -512,6 +517,12 @@ jobs:
             cd docs/perf/artifacts/enhanced-route-refresh-2026-07
             sha256sum -c SHA256SUMS
           )
+      - name: Upload reload settlement regression logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: reloadstall-settlement
+          path: ${{ runner.temp }}/reloadstall-settlement
   check:
     name: check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   cleanup. Ordinary queries remain fenced, and readiness replies retain the
   exact Loc-RIB count and the existing transition-age limit.
 
+- Native SIGHUP measurement and flagship soak runners now require terminal
+  daemon success as well as receiver delivery before recording a reload as
+  complete. Rejection or rollback fails that cycle before A/B alternation can
+  turn it into a misleading later re-advertisement stall.
+
 ### Upgrade notes
 
 - Consumers of `GetPolicyStats` or `rbgp policy stats` should use the installed

--- a/bench/scale/irrreload/run-irr-reload.sh
+++ b/bench/scale/irrreload/run-irr-reload.sh
@@ -829,6 +829,9 @@ run_cell() {
     final_barrier="$run/final-evidence"
     [ ! -e "$final_barrier" ] || return 1
     local -a henv=(RELOADSTALL_EVIDENCE_DIR="$final_barrier")
+    if [ -z "$reload_cmd" ] && [ "$RELOADS" -gt 0 ]; then
+        henv+=(RELOADSTALL_RELOAD_METRICS_ADDR=127.0.0.1:9179)
+    fi
     [ -z "$dataset_stage_cmd" ] || henv+=(RELOADSTALL_STAGE_CMD="$dataset_stage_cmd")
     # The generator emits overlap.tsv only at OVERLAP_FRACTION > 0; every
     # cell's stubs must announce the same second-announcer allocation.

--- a/bench/scale/matrix/run-matrix.sh
+++ b/bench/scale/matrix/run-matrix.sh
@@ -434,7 +434,11 @@ run_cell() {
     [ -n "$FLAPSTORM" ] && hargs+=(--flapstorm "$FLAPSTORM")
 
     # Harness in the background so the RSS guard can abort the cell.
-    "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
+    local settlement_env=()
+    if [ "$cell" = rustbgpd ] && [ -z "$FLAPSTORM" ] && [ "$RELOADS" -gt 0 ]; then
+        settlement_env+=(RELOADSTALL_RELOAD_METRICS_ADDR=127.0.0.1:9179)
+    fi
+    env "${settlement_env[@]}" "$HARNESS" "${hargs[@]}" >"$cdir/reloadstall.log" 2>&1 &
     local hpid=$!
     local rc=""
     while kill -0 "$hpid" 2>/dev/null; do

--- a/bench/scale/reloadstall/README.md
+++ b/bench/scale/reloadstall/README.md
@@ -32,6 +32,23 @@ reload is rejected before its CSV row if any session is down, post-completion
 stable-marker evidence is missing, or a daemon UPDATE fails to decode. Each
 valid reload emits a `reloadstall_csv` record for durable raw receipts.
 
+Native SIGHUP reloads also require a terminal daemon success from
+`bgp_sighup_reload_outcomes_total`. Receiver delivery alone can precede a
+failed apply acknowledgement and rollback. The driver snapshots the counters
+before staging and timing each signal, then checks them while waiting for
+receiver completion. A rejected, partial, ignored, or failed outcome aborts
+that reload before its CSV row and before the next A/B policy copy. Missing,
+decreasing, duplicate, or malformed evidence also fails closed.
+
+The metrics address defaults to `127.0.0.1:9179`, matching the scenario
+generators; set `RELOADSTALL_RELOAD_METRICS_ADDR` for another loopback address.
+Scrapes have a five-second deadline and run at most once per second while
+settlement is pending. This is additional measurement load. Receiver timings
+retain their signal/UPDATE timestamps; the `daemon_applied` marker records the
+separate settlement check. Older daemons without these counters cannot supply
+this proof. Command-driven peer implementations keep their command exit-status
+and receiver checks; these are not rustbgpd SIGHUP settlement evidence.
+
 Reload, flapstorm, and `--convergence-only` runs gate initial convergence on
 exact unique-prefix bitmap coverage at every observer: the full table minus its
 own slice. Duplicate, own-slice, and out-of-range announcements cannot advance

--- a/bench/scale/reloadstall/src/main.rs
+++ b/bench/scale/reloadstall/src/main.rs
@@ -39,6 +39,11 @@
 //!   timestamp, run one `sh -c` staging command. The selected generation is
 //!   exported as `RELOADSTALL_STAGE_GENERATION=a|b`. A nonzero exit fails
 //!   before SIGHUP, so native trigger timing remains unchanged.
+//! - `RELOADSTALL_RELOAD_METRICS_ADDR`: loopback `SocketAddr` for the native
+//!   daemon's metrics endpoint (default `127.0.0.1:9179`). Native reloads require
+//!   one terminal successful SIGHUP outcome
+//!   as well as receiver completion before publishing a reload row or advancing
+//!   A/B. Rejected, partial, ignored, failed, or missing evidence fails the run.
 //! - `--flapstorm K` (anywhere in argv): alternative mode replacing the
 //!   reload loop. After convergence + the control window, close the first
 //!   K stub sockets simultaneously, timestamp every survivor's receipt of
@@ -47,7 +52,8 @@
 //!   3 rounds, per-round percentiles + `flapstorm_csv` lines.
 //!
 //! Soak extensions (route-server flagship soak) — all additive env vars;
-//! every one absent reproduces the frozen one-shot contract exactly:
+//! their defaults retain the one-shot shape; native reloads also require
+//! terminal daemon settlement:
 //! - `RELOADSTALL_CYCLE_QUIESCE_SECS`: inter-reload quiesce (default 20).
 //!   The 24 h soak sets this to its reload interval so the existing
 //!   reload loop self-paces for the whole window.
@@ -251,10 +257,7 @@ fn metric_value(body: &str, name: &str) -> Result<u64, String> {
     found.ok_or_else(|| format!("missing {name}"))
 }
 
-async fn fetch_notification_depth(
-    addr: SocketAddr,
-    deadline: Instant,
-) -> Result<NotificationDepth, String> {
+async fn fetch_metrics(addr: SocketAddr, deadline: Instant) -> Result<String, String> {
     let work = async {
         let mut stream = TcpStream::connect(addr).await.map_err(|e| e.to_string())?;
         stream
@@ -301,16 +304,68 @@ async fn fetch_notification_depth(
         if length != Some(body.len()) {
             return Err("truncated or overlong metrics body".into());
         }
-        let current = metric_value(body, "bgp_session_notification_outstanding")?;
-        let high = metric_value(body, "bgp_session_notification_outstanding_high_watermark")?;
-        if current > high {
-            return Err("current exceeds high-water mark".into());
-        }
-        Ok(NotificationDepth { current, high })
+        Ok(body.to_owned())
     };
     tokio::time::timeout_at(deadline.into(), work)
         .await
         .map_err(|_| "metrics checkpoint exceeded 5 seconds".to_string())?
+}
+
+async fn fetch_notification_depth(
+    addr: SocketAddr,
+    deadline: Instant,
+) -> Result<NotificationDepth, String> {
+    let body = fetch_metrics(addr, deadline).await?;
+    let current = metric_value(&body, "bgp_session_notification_outstanding")?;
+    let high = metric_value(&body, "bgp_session_notification_outstanding_high_watermark")?;
+    if current > high {
+        return Err("current exceeds high-water mark".into());
+    }
+    Ok(NotificationDepth { current, high })
+}
+
+const RELOAD_OUTCOMES: [&str; 5] = [
+    "complete",
+    "known_partial",
+    "rejected_no_effect",
+    "ignored_in_flight",
+    "task_failed",
+];
+
+fn reload_outcomes(body: &str) -> Result<[u64; 5], String> {
+    let mut outcomes = [0; 5];
+    for (index, outcome) in RELOAD_OUTCOMES.iter().enumerate() {
+        outcomes[index] = metric_value(
+            body,
+            &format!("bgp_sighup_reload_outcomes_total{{outcome=\"{outcome}\"}}"),
+        )?;
+    }
+    Ok(outcomes)
+}
+
+fn reload_applied(before: [u64; 5], after: [u64; 5]) -> Result<bool, String> {
+    for (index, outcome) in RELOAD_OUTCOMES.iter().enumerate() {
+        let delta = after[index]
+            .checked_sub(before[index])
+            .ok_or_else(|| format!("SIGHUP outcome counter decreased: {outcome}"))?;
+        if index != 0 && delta != 0 {
+            return Err(format!("daemon SIGHUP outcome {outcome} (+{delta})"));
+        }
+        if index == 0 && delta > 1 {
+            return Err("multiple SIGHUP completions for one trigger".into());
+        }
+    }
+    Ok(after[0] > before[0])
+}
+
+async fn fetch_reload_outcomes(addr: SocketAddr, reload: u32) -> [u64; 5] {
+    let result = fetch_metrics(addr, Instant::now() + METRICS_DEADLINE)
+        .await
+        .and_then(|body| reload_outcomes(&body));
+    result.unwrap_or_else(|error| {
+        eprintln!("FAIL: reload {reload} daemon settlement evidence: {error}");
+        std::process::exit(1)
+    })
 }
 
 async fn notification_checkpoint(
@@ -2687,6 +2742,25 @@ fn main() {
     let overlap_file = std::env::var_os("RELOADSTALL_OVERLAP_FILE").map(PathBuf::from);
     let received_view_file = std::env::var_os("RELOADSTALL_RECEIVED_VIEW_FILE").map(PathBuf::from);
     let stage_cmd = std::env::var("RELOADSTALL_STAGE_CMD").ok();
+    let native_sighup =
+        reloads > 0 && reload_cmd.is_none() && flapstorm.is_none() && !convergence_only;
+    let reload_metrics_addr = std::env::var("RELOADSTALL_RELOAD_METRICS_ADDR")
+        .ok()
+        .or_else(|| native_sighup.then(|| "127.0.0.1:9179".to_owned()))
+        .map(|value| value.parse::<SocketAddr>())
+        .transpose()
+        .unwrap_or_else(|_| {
+            eprintln!(
+                "RELOADSTALL_RELOAD_METRICS_ADDR must be a loopback SocketAddr with nonzero port"
+            );
+            std::process::exit(2);
+        });
+    if reload_metrics_addr.is_some_and(|addr| !addr.ip().is_loopback() || addr.port() == 0)
+        || reload_metrics_addr.is_some() && !native_sighup
+    {
+        eprintln!("RELOADSTALL_RELOAD_METRICS_ADDR requires native SIGHUP reloads and a loopback SocketAddr with nonzero port");
+        std::process::exit(2);
+    }
     let notification_metrics_addr = std::env::var("RELOADSTALL_SESSION_NOTIFICATION_METRICS_ADDR")
         .ok()
         .map(|value| value.parse::<SocketAddr>())
@@ -3341,6 +3415,13 @@ fn main() {
 
         // --- Reload loop. ---
         for r in 1..=reloads {
+            // Snapshot before staging or timing the signal. Wire delivery may
+            // finish before an apply acknowledgement fails and compensation
+            // restores the prior generation; it is not a commit receipt.
+            let reload_before = match reload_metrics_addr {
+                Some(addr) => Some(fetch_reload_outcomes(addr, r).await),
+                None => None,
+            };
             let next = if r % 2 == 1 { &policy_b } else { &policy_a };
             let expected_community = if r % 2 == 1 {
                 COMMUNITY_GEN_B
@@ -3462,11 +3543,30 @@ fn main() {
             let mut last_unique = 0u64;
             let mut last_progress = Instant::now();
             let mut ticks = 0u32;
+            let mut applied = reload_before.is_none();
+            let mut delivery_reported = false;
+            let mut next_settlement_check = Instant::now();
             loop {
                 tokio::time::sleep(Duration::from_millis(100)).await;
+                if !applied && Instant::now() >= next_settlement_check {
+                    let after = fetch_reload_outcomes(reload_metrics_addr.unwrap(), r).await;
+                    applied = reload_applied(reload_before.unwrap(), after)
+                        .unwrap_or_else(|error| {
+                            eprintln!("FAIL: reload {r} {error}; see daemon log for rejection details");
+                            std::process::exit(1)
+                        });
+                    if applied {
+                        println!("reload {r} daemon_applied complete_before={} complete_after={}", reload_before.unwrap()[0], after[0]);
+                    }
+                    next_settlement_check = Instant::now() + Duration::from_secs(1);
+                }
                 let done =
                     (0..changed_peers as usize).all(|i| completion_us(&ctx, i).is_some());
-                if done {
+                if done && !applied && !delivery_reported {
+                    println!("reload {r} receiver_barriers_complete awaiting_daemon_settlement");
+                    delivery_reported = true;
+                }
+                if done && applied {
                     break;
                 }
                 ticks += 1;
@@ -3492,6 +3592,10 @@ fn main() {
                     last_unique = sum;
                     last_progress = Instant::now();
                 } else if last_progress.elapsed() > window {
+                    if done && !applied {
+                        eprintln!("FAIL: reload {r} receiver delivery completed but daemon SIGHUP settlement is missing");
+                        std::process::exit(1);
+                    }
                     println!(
                         "reload {r} STALLED: no re-advertisement progress for {}s",
                         window.as_secs()
@@ -4166,6 +4270,43 @@ mod tests {
         assert!(metric_value(&format!("{n} 1\n{n} 2\n"), n).is_err());
         for value in ["-1", "1.0", "1e2", "NaN", "1 2"] {
             assert!(metric_value(&format!("{n} {value}\n"), n).is_err());
+        }
+    }
+
+    #[test]
+    fn reload_settlement_requires_one_success_and_rejects_compensation() {
+        let before = [24, 0, 0, 0, 0];
+        // Receiver generation markers may already be complete here. Until
+        // the owning daemon operation finishes, completion remains false.
+        assert_eq!(reload_applied(before, before), Ok(false));
+        assert_eq!(reload_applied(before, [25, 0, 0, 0, 0]), Ok(true));
+        for index in 1..5 {
+            let mut after = before;
+            after[index] = 1;
+            let error = reload_applied(before, after).unwrap_err();
+            assert!(error.contains(RELOAD_OUTCOMES[index]), "{error}");
+            // An unexpected success cannot hide a rejection/partial result.
+            after[0] += 1;
+            assert!(reload_applied(before, after).is_err());
+        }
+        assert!(reload_applied(before, [23, 0, 0, 0, 0]).is_err());
+        assert!(reload_applied(before, [26, 0, 0, 0, 0]).is_err());
+        assert!(reload_applied([24, 1, 0, 0, 0], before).is_err());
+    }
+
+    #[test]
+    fn reload_outcome_evidence_rejects_missing_duplicate_and_invalid_samples() {
+        let body: String = RELOAD_OUTCOMES
+            .iter()
+            .map(|outcome| format!("bgp_sighup_reload_outcomes_total{{outcome=\"{outcome}\"}} 0\n"))
+            .collect();
+        assert_eq!(reload_outcomes(&body), Ok([0; 5]));
+        assert!(reload_outcomes("").is_err());
+        let first = body.lines().next().unwrap();
+        assert!(reload_outcomes(&body.replacen(first, "", 1)).is_err());
+        assert!(reload_outcomes(&format!("{body}{first}\n")).is_err());
+        for value in ["-1", "NaN", "0.5", "18446744073709551616", "1 123"] {
+            assert!(reload_outcomes(&body.replacen(" 0\n", &format!(" {value}\n"), 1)).is_err());
         }
     }
 

--- a/bench/tests/test-reloadstall-settlement.py
+++ b/bench/tests/test-reloadstall-settlement.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Exercise SIGHUP settlement with tiny real daemon/reloadstall sessions.
+
+The last case injects metrics: pending until the engine observes receiver
+barriers, then rejected_no_effect. It tests harness sequencing, NOT a real
+runtime rollback. Logs and generated inputs are retained in --artifact-dir.
+"""
+
+import argparse
+import hashlib
+import http.server
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+REPO = Path(__file__).resolve().parents[2]
+BARRIER = "reload 1 receiver_barriers_complete awaiting_daemon_settlement"
+
+
+def wait_ready(process, address):
+    for _ in range(200):
+        assert process.poll() is None, "daemon exited during startup; see daemon.log"
+        try:
+            with urllib.request.urlopen(f"http://{address}/readyz", timeout=0.5) as reply:
+                if reply.status == 200:
+                    return
+        except OSError:
+            pass
+        time.sleep(0.1)
+    raise AssertionError("daemon readiness deadline; see daemon.log")
+
+
+def run_case(args, name, *, dualstack=False, rejected=False, injected=False):
+    dest = args.artifact_dir / name
+    dest.mkdir()
+    env = {key: value for key, value in os.environ.items()
+           if not key.startswith(("GEN_", "RELOADSTALL_"))}
+    env.update(GEN_DUALSTACK=str(int(dualstack)), GEN_FILTER_COUNT="4" if dualstack else "0")
+    # Keep the generated UDS path below sun_path's limit, even in deep CI checkouts.
+    with tempfile.TemporaryDirectory(prefix="rls-", dir="/tmp") as temporary:
+        scenario = Path(temporary)
+        with socket.socket() as bgp, socket.socket() as metrics:
+            bgp.bind(("127.0.0.1", 0))
+            metrics.bind(("127.0.0.1", 0))
+            bgp_port = str(bgp.getsockname()[1])
+            metrics_address = f"127.0.0.1:{metrics.getsockname()[1]}"
+        with (dest / "generator.log").open("w") as log:
+            subprocess.run([sys.executable, str(REPO / "bench/scale/reloadstall/gen-scenario.py"),
+                            "12", str(scenario), bgp_port, "12"], env=env, check=True,
+                           stdout=log, stderr=subprocess.STDOUT)
+        config = scenario / "config.toml"
+        config.write_text(config.read_text().replace("127.0.0.1:9179", metrics_address))
+        with (dest / "check.log").open("w") as log:
+            subprocess.run([str(args.daemon), "--check", str(config)], check=True,
+                           stdout=log, stderr=subprocess.STDOUT, timeout=30)
+        with (dest / "daemon.log").open("w") as daemon_log:
+            daemon = subprocess.Popen([str(args.daemon), str(config)], stdout=daemon_log,
+                                      stderr=subprocess.STDOUT)
+            fixture = None
+            try:
+                wait_ready(daemon, metrics_address)
+                env.update(RELOADSTALL_DUALSTACK=str(int(dualstack)),
+                           RELOADSTALL_FILTER_COUNT="4" if dualstack else "0",
+                           RELOADSTALL_CYCLE_QUIESCE_SECS="1",
+                           RELOADSTALL_RELOAD_METRICS_ADDR=metrics_address)
+                if rejected:
+                    env["RELOADSTALL_STAGE_CMD"] = shlex.join([
+                        sys.executable, "-c",
+                        'from pathlib import Path; import sys; '
+                        'Path(sys.argv[1]).write_text("invalid policy input\\n")',
+                        str(scenario / "member.rpol")])
+                engine_log = dest / "reloadstall.log"
+                engine_log.touch()
+                if injected:
+                    class MetricsFixture(http.server.BaseHTTPRequestHandler):
+                        def log_message(self, *unused):
+                            pass
+
+                        def do_GET(self):
+                            # Synchronize on the actual barrier, never an elapsed-time guess.
+                            barrier_seen = BARRIER in engine_log.read_text()
+                            outcomes = dict(complete=0, known_partial=0,
+                                            rejected_no_effect=int(barrier_seen),
+                                            ignored_in_flight=0, task_failed=0)
+                            body = "".join(
+                                f'bgp_sighup_reload_outcomes_total{{outcome="{key}"}} {value}\n'
+                                for key, value in outcomes.items()).encode()
+                            with (dest / "injected-metrics.jsonl").open("a") as log:
+                                log.write(json.dumps({"receiver_barriers_complete": barrier_seen,
+                                                      "outcomes": outcomes}) + "\n")
+                            self.send_response(200)
+                            self.send_header("Content-Length", str(len(body)))
+                            self.end_headers()
+                            self.wfile.write(body)
+
+                    fixture = http.server.HTTPServer(("127.0.0.1", 0), MetricsFixture)
+                    thread = threading.Thread(target=fixture.serve_forever)
+                    thread.start()
+                    env["RELOADSTALL_RELOAD_METRICS_ADDR"] = f"127.0.0.1:{fixture.server_port}"
+                with engine_log.open("w") as log:
+                    result = subprocess.run([
+                        str(args.harness), "12", "600", bgp_port, str(daemon.pid),
+                        str(scenario / "member.rpol"), str(scenario / "gen-a.rpol"),
+                        str(scenario / "gen-b.rpol"), "2", "1", "12"], env=env,
+                        stdout=log, stderr=subprocess.STDOUT, timeout=120)
+                (dest / "engine.exit").write_text(f"{result.returncode}\n")
+                text = engine_log.read_text()
+                if rejected or injected:
+                    assert result.returncode == 1, text
+                    assert "reload 1 daemon SIGHUP outcome rejected_no_effect" in text, text
+                    assert "reloadstall_csv," not in text, text
+                    assert "reload 2 " not in text, text
+                    assert (scenario / "member.rpol").read_bytes() != (
+                        scenario / "gen-a.rpol").read_bytes(), "next A policy was staged"
+                    if rejected:
+                        assert "SIGHUP reload rejected without runtime effect" in (
+                            dest / "daemon.log").read_text()
+                    if injected:
+                        assert BARRIER in text, text
+                        assert (scenario / "member.rpol").read_bytes() == (
+                            scenario / "gen-b.rpol").read_bytes()
+                        samples = [json.loads(line) for line in
+                                   (dest / "injected-metrics.jsonl").read_text().splitlines()]
+                        assert not samples[0]["receiver_barriers_complete"], samples
+                        assert samples[-1]["receiver_barriers_complete"], samples
+                else:
+                    assert result.returncode == 0, text
+                    for reload in (1, 2):
+                        assert text.index(f"reload {reload} daemon_applied") < text.index(
+                            f"reloadstall_csv,{reload},"), text
+                # Use the runner's actual marker translation to check the soak receipt too.
+                shell = ('source "$1"; CYCLES_LOG="$2"; '
+                         'while IFS= read -r line; do handle_line "$line"; done < "$3"')
+                with (dest / "runner.log").open("w") as log:
+                    runner = subprocess.run([
+                        "bash", "-c", shell, "settlement-test",
+                        str(REPO / "tests/soak/run-soak-rs-flagship.sh"),
+                        str(dest / "cycles.log"), str(engine_log)],
+                        stdout=log, stderr=subprocess.STDOUT, timeout=15)
+                cycles = (dest / "cycles.log").read_text()
+                assert ("reload 1 complete" in cycles) == (not rejected and not injected), cycles
+                assert runner.returncode == (1 if rejected or injected else 0), cycles
+                if rejected or injected:
+                    assert "ABORT: reload 1 failed: daemon SIGHUP outcome rejected_no_effect" in cycles
+                summary = {"case": name, "engine_exit": result.returncode, "assertions": "pass",
+                           "metrics_injected_not_runtime_rollback": injected}
+                (dest / "result.json").write_text(json.dumps(summary, indent=2) + "\n")
+                print(json.dumps(summary), flush=True)
+            finally:
+                if fixture:
+                    fixture.shutdown()
+                    thread.join()
+                    fixture.server_close()
+                daemon.terminate()
+                try:
+                    daemon.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    daemon.kill()
+                    daemon.wait()
+                (dest / "daemon.exit").write_text(f"{daemon.returncode}\n")
+                for path in [config, *scenario.glob("*.rpol")]:
+                    shutil.copy2(path, dest / path.name)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--daemon", type=Path, required=True)
+    parser.add_argument("--harness", type=Path, required=True)
+    parser.add_argument("--artifact-dir", type=Path, required=True,
+                        help="new directory; retained on success and failure")
+    args = parser.parse_args()
+    args.daemon = args.daemon.resolve(strict=True)
+    args.harness = args.harness.resolve(strict=True)
+    args.artifact_dir = args.artifact_dir.resolve()
+    os.umask(0o077)
+    args.artifact_dir.mkdir(parents=True)
+    print(f"artifacts: {args.artifact_dir}", flush=True)
+    with (args.artifact_dir / "binaries.sha256").open("w") as log:
+        for binary in (args.daemon, args.harness):
+            with binary.open("rb") as source:
+                log.write(f"{hashlib.file_digest(source, 'sha256').hexdigest()}  {binary}\n")
+    run_case(args, "native-success")
+    run_case(args, "dualstack-filter-success", dualstack=True)
+    run_case(args, "native-rejection", rejected=True)
+    run_case(args, "receiver-complete-then-rejected", injected=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_ci_scale_split_contract.py
+++ b/scripts/check_ci_scale_split_contract.py
@@ -41,6 +41,7 @@ EXPECTED_STANDALONE_COMMANDS = (
         WORKFLOWS[0],
         "cargo clippy --manifest-path bench/scale/enhanced-route-refresh/Cargo.toml --locked --all-targets -- -D warnings",
     ),
+    (WORKFLOWS[0], "cargo build --manifest-path bench/scale/Cargo.toml --locked -p reloadstall"),
 )
 CARGO_COMMAND = re.compile(r"(?<![\w-])cargo(?:\s+\+\S+)?\s+(build|check|test|clippy|doc|bench|run)\b")
 LOCKED_TOKEN = re.compile(r"(?<!\S)--locked(?=\s|$)")

--- a/scripts/test_check_ci_scale_split_contract.py
+++ b/scripts/test_check_ci_scale_split_contract.py
@@ -129,6 +129,11 @@ class ScaleSplitContractTests(unittest.TestCase):
                 "cargo build --locked -p rs-config-render",
                 "true",
             ),
+            (
+                WORKFLOW,
+                "cargo build --manifest-path bench/scale/Cargo.toml --locked -p reloadstall",
+                "true",
+            ),
         )
         for workflow, old, new in cases:
             with self.subTest(workflow=workflow, seam=old):

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -984,13 +984,19 @@ the engine's steady churn running throughout. Two serialized injections:
 
 - a real SIGHUP policy-file reload every `RELOAD_INTERVAL_SEC`
   (default 1800 s), each verified by the engine's generation-marker
-  completion barriers;
+  completion barriers and terminal daemon SIGHUP outcome;
 - a max-prefix trip/timed-restart cycle every `TRIP_INTERVAL_SEC`
   (default 14 400 s) on the designated member (stub 0), with the
   runner asserting the daemon-side evidence chain per cycle:
   `bgp_max_prefix_exceeded_total` reaches exactly N → hold-down
   countdown visible in `rbgp neighbor -j` → re-Established within
   `max_prefix_restart_seconds` + 60 s → headroom sane.
+
+The reload engine checks `bgp_sighup_reload_outcomes_total` before recording
+completion or advancing its A/B alternation. A rejected generation fails the
+current cycle explicitly, even if receivers observed the candidate before the
+daemon restored the prior generation. Its bounded metrics checks run at most
+once per second while a reload is unsettled, in addition to the load below.
 
 After the engine's convergence barrier and before the measured window, the
 runner also starts an independent management-plane load process. It scrapes

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -4,7 +4,8 @@
 #
 # Injections (both serialized by the engine, churn running throughout):
 #   - a real SIGHUP policy-file reload every RELOAD_INTERVAL_SEC, each one
-#     verified by the engine's generation-marker completion barriers;
+#     verified by the engine's generation-marker barriers and terminal
+#     daemon SIGHUP outcome;
 #   - a max-prefix trip/timed-restart cycle every TRIP_INTERVAL_SEC on the
 #     designated member (stub 0, 127.1.0.1): announce over the configured
 #     max_prefixes bound -> Cease teardown -> hold-down countdown -> the
@@ -390,6 +391,8 @@ handle_line() {
         cycle_log "reload ${BASH_REMATCH[1]} issued"
     elif [[ $line =~ ^reloadstall_csv,([0-9]+), ]]; then
         cycle_log "reload ${BASH_REMATCH[1]} complete"
+    elif [[ $line =~ ^FAIL:\ reload\ ([0-9]+)\ (.*)$ ]]; then
+        abort "reload ${BASH_REMATCH[1]} failed: ${BASH_REMATCH[2]}"
     elif [[ $line =~ ^trip\ ([0-9]+)\ announce_over\  ]]; then
         trip_begin "${BASH_REMATCH[1]}"
     elif [[ $line =~ ^trip\ ([0-9]+)\ torn_down\  ]]; then
@@ -624,6 +627,7 @@ main() {
     log "daemon ready"
 
     RELOADSTALL_CYCLE_QUIESCE_SECS=$RELOAD_INTERVAL_SEC \
+        RELOADSTALL_RELOAD_METRICS_ADDR="127.0.0.1:${METRICS_PORT}" \
         RELOADSTALL_TRIP_EVERY=$TRIP_EVERY \
         RELOADSTALL_TRIP_PREFIXES=$TRIP_PREFIXES \
         RELOADSTALL_TRIP_REESTABLISH_SECS=$TRIP_REESTABLISH_SEC \


### PR DESCRIPTION
A native SIGHUP reload could reach every receiver before the daemon rejected its apply acknowledgement and restored the prior generation. The harness then recorded success and staged the next A/B policy, producing a misleading later re-advertisement stall.

Require exactly one terminal daemon success from the existing SIGHUP outcome counters, alongside the receiver barriers, before emitting a reload CSV row or staging the next policy. Rejected, partial, ignored, failed, or missing evidence fails the current cycle explicitly; the flagship runner carries that reason into its abort receipt. The shared engine covers native reloadstall, matrix/dual-stack, and IRR SIGHUP callers. Command-driven cells retain their command-status checks.

Metrics checks use the existing bounded HTTP reader and default to the scenario generators' loopback endpoint. Polling adds at most one scrape per second while settlement is pending; receiver timing timestamps remain unchanged.

Validation: full local gate components and scale-workspace gate-deps; 49 reloadstall tests; shell/provenance checks; four small end-to-end cases covering IPv4 success, dual-stack filtering success, actual daemon rejection, and receiver completion followed by an injected rejection counter. The last case tests harness ordering, not actual runtime rollback. CI runs the four cases and retains their logs.
