### PR TITLE
fix(policy): bound policy RIB walks in total, not per peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,22 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Operator-visible:** a configuration reload could be rejected with no runtime
+  effect when one peer's session-state query was slow during heavy RIB load.
+  The slow peer was excluded from the batched export-policy cohort and fell to
+  the serial authoritative walk, where each per-peer RIB command was allowed
+  only five seconds — while that command performs a full Loc-RIB distribution
+  pass of its own and can legitimately take longer under load. The walk and the
+  RFC 8212 presence proofs that precede it now share one absolute two-minute
+  budget for the whole transaction, the same total the batched cohort already
+  promises for the equivalent work. Single-peer inline policy edits keep the
+  five-second deadline. Because the budget is now a total rather than a fresh
+  allowance per peer, a whole-fleet fallback that previously accumulated
+  unbounded time across peers is bounded and fails sooner; rollback is
+  unchanged and leaves no partial mutation. The graceful-shutdown and blackhole
+  knob fan-outs and the dataset dependent proofs carried the same per-peer
+  exposure and are bounded the same way.
+
 - The scale matrix now finishes and records each active management probe before
   shutting down the daemon, preventing orphaned CLI requests and missing final
   CSV rows. Cleanup waits for owned processes and retains the daemon exit status;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,14 +120,17 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   only five seconds — while that command performs a full Loc-RIB distribution
   pass of its own and can legitimately take longer under load. The walk and the
   RFC 8212 presence proofs that precede it now share one absolute two-minute
-  budget for the whole transaction, the same total the batched cohort already
-  promises for the equivalent work. Single-peer inline policy edits keep the
-  five-second deadline. Because the budget is now a total rather than a fresh
-  allowance per peer, a whole-fleet fallback that previously accumulated
-  unbounded time across peers is bounded and fails sooner; rollback is
-  unchanged and leaves no partial mutation. The graceful-shutdown and blackhole
-  knob fan-outs and the dataset dependent proofs carried the same per-peer
-  exposure and are bounded the same way.
+  deadline for RIB channel admission and replies across the walk, matching the
+  batched cohort's allowance for equivalent work. Session-only preflight and
+  hot-apply work before the first RIB command do not start the deadline.
+  Single-peer inline policy edits retain a five-second allowance, now covering
+  channel admission as well as the reply. Because the budget is now a total
+  rather than a fresh allowance per peer, a whole-fleet fallback that previously
+  accumulated unbounded time across peers is bounded and fails sooner. Rollback retains
+  its separate budget and existing exact-state restoration or fail-closed
+  handling. The graceful-shutdown and blackhole knob fan-outs and the dataset
+  dependent proofs carried the same per-peer exposure and are bounded the same
+  way.
 
 - The scale matrix now finishes and records each active management probe before
   shutting down the daemon, preventing orphaned CLI requests and missing final

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -197,6 +197,17 @@ pending flags and makes exact compensation unprovable. The bound does not cover
 sequential session commands, Route Refresh acknowledgements, or the RIB actor's
 detached late repair work.
 
+The authoritative forward walk follows the same discipline. Its per-peer RIB
+commands and the RFC 8212 presence proofs that precede them share one lazy
+absolute `RIB_BATCH_REPLY_TIMEOUT` for the whole transaction, so a transition
+that falls back to the serial walk is bounded by the same total RIB time the
+batched cohort promises rather than by a fresh deadline per peer, which would
+scale with the fleet and therefore bound nothing. A per-peer command is not a
+cheap inline operation: it performs its own full distribution pass, so a single
+reply can legitimately take seconds under load. The forward and rollback
+deadlines anchor independently, so a slow walk cannot consume the budget its
+own compensation needs.
+
 ### 5. Readiness and observability
 
 The read-only readiness lanes exist so a legitimate large transition does not

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -206,7 +206,11 @@ scale with the fleet and therefore bound nothing. A per-peer command is not a
 cheap inline operation: it performs its own full distribution pass, so a single
 reply can legitimately take seconds under load. The forward and rollback
 deadlines anchor independently, so a slow walk cannot consume the budget its
-own compensation needs.
+own compensation needs. The forward deadline starts at the first actual RIB
+command, after any session-only preflight, and covers both channel admission
+and the reply. Expiry cancels an unadmitted forward send; an admitted command
+remains ahead of its exact rollback in FIFO order. This bounds RIB waits, not
+all session and Route Refresh work in the transaction.
 
 ### 5. Readiness and observability
 

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -103,9 +103,9 @@ const PEER_SHUTDOWN_CONCURRENCY: usize = 64;
 /// progress while still keeping the unchanged 200 ms end-to-end deadline.
 const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 1;
 
-/// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
-/// actor for a genuinely single-peer inline operation (gRPC chain edit,
-/// per-peer outbound refresh). Bounded so a wedged RIB task cannot park the
+/// Hard deadline for RIB channel admission and reply on a single-peer policy
+/// edit. Also used by per-peer outbound refresh and other bounded RIB steps.
+/// Bounded so a wedged RIB task cannot park the
 /// peer-manager actor (and therefore SIGHUP reload / gRPC policy apply)
 /// forever.
 ///

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -104,10 +104,19 @@ const PEER_SHUTDOWN_CONCURRENCY: usize = 64;
 const READINESS_QUERY_BUDGET_PER_POLICY_STEP: usize = 1;
 
 /// Hard deadline for a RIB-manager reply awaited from the `PeerManager`
-/// actor (export-policy swap, per-peer outbound refresh). Generous — the
-/// RIB answers these inline and never legitimately takes seconds — but
-/// bounded so a wedged RIB task cannot park the peer-manager actor (and
-/// therefore SIGHUP reload / gRPC policy apply) forever.
+/// actor for a genuinely single-peer inline operation (gRPC chain edit,
+/// per-peer outbound refresh). Bounded so a wedged RIB task cannot park the
+/// peer-manager actor (and therefore SIGHUP reload / gRPC policy apply)
+/// forever.
+///
+/// It is not a claim that the RIB answers quickly. These commands queue on
+/// the RIB manager's primary lane, which is not polled while route chunks
+/// pend, and an export-policy replacement then performs a full Loc-RIB
+/// distribution pass of its own — seconds at route-server scale under load.
+/// Five seconds is therefore only defensible for one command whose latency
+/// an operator is waiting on directly. Every `O(peers)` policy walk shares
+/// one [`RIB_BATCH_REPLY_TIMEOUT`] budget across all of its steps instead,
+/// so the walk is bounded in total rather than per peer.
 const RIB_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Hard deadline for the batched authoritative export-policy apply

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -317,18 +317,33 @@ impl PolicySnapshotFailure {
     }
 }
 
+/// One absolute RIB budget covering a whole `O(peers)` policy walk, anchored
+/// on first use rather than at construction so session-side work that runs
+/// before the first RIB command does not consume it.
+///
+/// A serial walk must bound its RIB waits in total, not per peer: a fresh
+/// per-peer deadline multiplies by the fleet size and therefore bounds
+/// nothing, which is the opposite of what an actor-liveness deadline is for.
 #[derive(Default)]
-struct PolicyRollbackRibBudget {
-    deadline: Option<tokio::time::Instant>,
-    clean_state_window: CleanStateQueryWindow,
-}
+struct LazyRibBudget(Option<tokio::time::Instant>);
 
-impl PolicyRollbackRibBudget {
+impl LazyRibBudget {
     fn deadline(&mut self) -> tokio::time::Instant {
         *self
-            .deadline
+            .0
             .get_or_insert_with(|| tokio::time::Instant::now() + super::RIB_BATCH_REPLY_TIMEOUT)
     }
+}
+
+#[derive(Default)]
+struct PolicySnapshotRibBudget {
+    /// Shared by every per-peer RIB command of the authoritative forward walk.
+    forward: LazyRibBudget,
+    /// Shared by every rollback partition's registered RIB aggregate. Anchored
+    /// independently of [`Self::forward`] so a slow forward walk cannot spend
+    /// the compensation's budget.
+    rollback: LazyRibBudget,
+    clean_state_window: CleanStateQueryWindow,
 }
 
 struct PolicyRollbackPeerPlan {
@@ -518,6 +533,7 @@ impl PeerManager {
     async fn qualify_rfc8212_import_transition(
         &mut self,
         peer_key: &PeerKey,
+        rib_deadline: Option<tokio::time::Instant>,
     ) -> Result<bool, PolicyApplyFailure> {
         let Some(managed) = self.peers.get(peer_key) else {
             return Ok(false);
@@ -543,7 +559,9 @@ impl PeerManager {
                 });
             }
             StateQueryOutcome::SessionGone => {
-                let retained = self.query_peer_retained_stale(peer_key.address).await?;
+                let retained = self
+                    .query_peer_retained_stale(peer_key.address, rib_deadline)
+                    .await?;
                 if retained == 0 {
                     return Ok(false);
                 }
@@ -575,7 +593,9 @@ impl PeerManager {
             });
         }
 
-        let retained = self.query_peer_retained_stale(peer_key.address).await?;
+        let retained = self
+            .query_peer_retained_stale(peer_key.address, rib_deadline)
+            .await?;
         if retained > 0 {
             return Err(PolicyApplyFailure {
                 code: RuntimeConfigPolicyFailureCode::StateNonEstablished,
@@ -593,11 +613,17 @@ impl PeerManager {
     }
 
     /// One read-only RIB round trip for [`Self::qualify_rfc8212_import_transition`],
-    /// bounded by the same reply deadline the export replacement uses and
     /// servicing the dedicated readiness lane throughout.
+    ///
+    /// This proof rides the RIB manager's primary lane, so it waits behind the
+    /// same backlog an export replacement does and is bounded the same way:
+    /// `rib_deadline` is `Some` for a step of an `O(peers)` walk, whose steps
+    /// all share one absolute budget, and `None` for a single inline
+    /// qualification, which keeps [`super::RIB_REPLY_TIMEOUT`].
     async fn query_peer_retained_stale(
         &mut self,
         peer: IpAddr,
+        rib_deadline: Option<tokio::time::Instant>,
     ) -> Result<usize, PolicyApplyFailure> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let rib_tx = self.rib_tx.clone();
@@ -618,18 +644,19 @@ impl PeerManager {
                 refresh_delivery_began: false,
             });
         }
-        match tokio::time::timeout(
-            super::RIB_REPLY_TIMEOUT,
-            self.await_with_readiness(reply_rx),
-        )
-        .await
-        {
+        let reply = self.await_with_readiness(reply_rx);
+        let waited = match rib_deadline {
+            Some(deadline) => tokio::time::timeout_at(deadline, reply).await,
+            None => tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply).await,
+        };
+        match waited {
             Err(_) => Err(PolicyApplyFailure {
                 code: RuntimeConfigPolicyFailureCode::StateRibQueryFailed,
                 message: format!(
                     "{peer}: cannot apply an RFC 8212 import policy-presence change — the RIB \
                  manager did not report retained stale routes within {:?}",
-                    super::RIB_REPLY_TIMEOUT
+                    rib_deadline
+                        .map_or(super::RIB_REPLY_TIMEOUT, |_| super::RIB_BATCH_REPLY_TIMEOUT)
                 ),
                 refresh_delivery_began: false,
             }),
@@ -656,6 +683,7 @@ impl PeerManager {
     async fn preflight_rfc8212_import_transitions(
         &mut self,
         targets: &[ResolvedPeerPolicy],
+        rib_budget: &mut LazyRibBudget,
     ) -> Result<(), PolicyApplyFailure> {
         let transitioning: Vec<PeerKey> = targets
             .iter()
@@ -672,7 +700,11 @@ impl PeerManager {
 
         let mut rejections = Vec::new();
         for peer_key in &transitioning {
-            if let Err(error) = self.qualify_rfc8212_import_transition(peer_key).await {
+            let rib_deadline = rib_budget.deadline();
+            if let Err(error) = self
+                .qualify_rfc8212_import_transition(peer_key, Some(rib_deadline))
+                .await
+            {
                 rejections.push(error);
             }
         }
@@ -771,6 +803,9 @@ impl PeerManager {
             export_policy,
             RefreshFailureHandling::Fatal,
             None,
+            None,
+            // A genuinely single-peer inline edit, not a walk step: keep the
+            // ordinary per-command RIB deadline.
             None,
         )
         .await
@@ -881,11 +916,16 @@ impl PeerManager {
         // anything below can touch a peer, so one incapable peer rejects the
         // whole edit rather than being discovered mid-fanout and unwound.
         let preflight_started = Instant::now();
-        let preflight = self.preflight_rfc8212_import_transitions(&targets).await;
+        // One forward RIB budget for the whole transaction: the presence
+        // proofs below and the authoritative walk's per-peer applies both
+        // queue on the RIB's primary lane, so they are bounded in total.
+        let mut rollback_rib_budget = PolicySnapshotRibBudget::default();
+        let preflight = self
+            .preflight_rfc8212_import_transitions(&targets, &mut rollback_rib_budget.forward)
+            .await;
         phases.preflight_us = elapsed_us(preflight_started);
         preflight
             .map_err(|error| PolicySnapshotFailure::rejected_code(error.code, error.message))?;
-        let mut rollback_rib_budget = PolicyRollbackRibBudget::default();
         let total_targets = targets.len();
         let cohort_selection_started = Instant::now();
         let mut seen = BTreeSet::new();
@@ -1073,7 +1113,7 @@ impl PeerManager {
     async fn complete_policy_snapshot(
         &mut self,
         captured: Vec<CapturedResolvedPolicy>,
-        rollback_rib_budget: &mut PolicyRollbackRibBudget,
+        rollback_rib_budget: &mut PolicySnapshotRibBudget,
         require_clean_convergence: bool,
     ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
         let convergence_debt = require_clean_convergence
@@ -1245,7 +1285,7 @@ impl PeerManager {
     async fn apply_resolved_policy_snapshot_authoritatively(
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
-        rollback_rib_budget: &mut PolicyRollbackRibBudget,
+        rollback_rib_budget: &mut PolicySnapshotRibBudget,
         require_clean_convergence: bool,
     ) -> Result<Vec<CapturedResolvedPolicy>, PolicySnapshotFailure> {
         // Captured priors, in application order, for peers actually mutated.
@@ -1271,6 +1311,7 @@ impl PeerManager {
             };
             applied.push(prior);
             let applied_idx = applied.len() - 1;
+            let rib_deadline = rollback_rib_budget.forward.deadline();
             if let Err(apply_error) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -1280,6 +1321,7 @@ impl PeerManager {
                     None,
                     require_clean_convergence
                         .then_some(&mut rollback_rib_budget.clean_state_window),
+                    Some(rib_deadline),
                 )
                 .await
             {
@@ -1397,7 +1439,7 @@ impl PeerManager {
     async fn try_apply_export_only_policy_cohort(
         &mut self,
         targets: &[&ResolvedPeerPolicy],
-        rollback_rib_budget: &mut PolicyRollbackRibBudget,
+        rollback_rib_budget: &mut PolicySnapshotRibBudget,
         require_clean_convergence: bool,
         phase_timings: &mut PolicySnapshotPhaseTimings,
         allow_operator_reads: bool,
@@ -2031,12 +2073,17 @@ impl PeerManager {
     }
 
     /// Run one ordinary RIB export-policy replacement while servicing the
-    /// dedicated readiness lane and enforcing the existing five-second reply
-    /// deadline.
+    /// dedicated readiness lane.
+    ///
+    /// `rib_deadline` is `Some` when this command is one step of an
+    /// `O(peers)` policy walk: every step of that walk shares the one absolute
+    /// deadline so the walk is bounded in total. `None` is a genuinely
+    /// single-peer inline operation and keeps [`super::RIB_REPLY_TIMEOUT`].
     async fn replace_peer_export_policy_in_rib(
         &mut self,
         peer: IpAddr,
         export_policy: Option<PolicyChain>,
+        rib_deadline: Option<tokio::time::Instant>,
     ) -> Result<(), RibCommandError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let rib_tx = self.rib_tx.clone();
@@ -2051,16 +2098,23 @@ impl PeerManager {
         {
             return Err(RibCommandError::internal("RIB manager unavailable"));
         }
-        match tokio::time::timeout(
-            super::RIB_REPLY_TIMEOUT,
-            self.await_with_readiness(reply_rx),
-        )
-        .await
-        {
-            Err(_) => Err(RibCommandError::internal(format!(
-                "RIB manager did not reply within {:?} while updating export policy",
-                super::RIB_REPLY_TIMEOUT
-            ))),
+        let reply = self.await_with_readiness(reply_rx);
+        let waited = match rib_deadline {
+            Some(deadline) => tokio::time::timeout_at(deadline, reply).await,
+            None => tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply).await,
+        };
+        match waited {
+            Err(_) => Err(RibCommandError::internal(if rib_deadline.is_some() {
+                format!(
+                    "RIB manager did not reply within the {:?} shared policy-walk budget while updating export policy",
+                    super::RIB_BATCH_REPLY_TIMEOUT
+                )
+            } else {
+                format!(
+                    "RIB manager did not reply within {:?} while updating export policy",
+                    super::RIB_REPLY_TIMEOUT
+                )
+            })),
             Ok(Err(_)) => Err(RibCommandError::internal("RIB manager dropped reply")),
             Ok(Ok(Err(error))) => Err(error),
             Ok(Ok(Ok(()))) => Ok(()),
@@ -2153,7 +2207,7 @@ impl PeerManager {
     async fn register_policy_rollback_rib(
         &mut self,
         plans: &[PolicyRollbackPeerPlan],
-        budget: &mut PolicyRollbackRibBudget,
+        budget: &mut PolicySnapshotRibBudget,
     ) -> Result<Option<RegisteredPolicyRollbackRib>, RuntimeConfigPolicyFailureCode> {
         // `plans` is newest-first because session compensation already ran in
         // reverse application order. The RIB command owns the reversal, so
@@ -2182,7 +2236,7 @@ impl PeerManager {
             return Err(RuntimeConfigPolicyFailureCode::RollbackBatchDuplicate);
         }
 
-        let deadline = budget.deadline();
+        let deadline = budget.rollback.deadline();
         let rib_tx = self.rib_tx.clone();
         let (enqueued_tx, enqueued_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
@@ -2310,7 +2364,7 @@ impl PeerManager {
     async fn restore_resolved_policies(
         &mut self,
         priors: Vec<CapturedResolvedPolicy>,
-        budget: &mut PolicyRollbackRibBudget,
+        budget: &mut PolicySnapshotRibBudget,
         require_exact_pending: bool,
     ) -> Result<(), PolicyRollbackFailure> {
         let pending_priors = priors
@@ -2353,6 +2407,9 @@ impl PeerManager {
                     prior.policy.export_policy,
                     refresh_failure,
                     Some(&mut plan),
+                    None,
+                    // Rollback planning returns before the RIB step; the
+                    // registered aggregate below carries the rollback budget.
                     None,
                 )
                 .await
@@ -2852,8 +2909,11 @@ impl PeerManager {
         }
         dependents.sort_by(|left, right| left.peer.cmp(&right.peer));
         let mut window = CleanStateQueryWindow::default();
+        // Same shape as the policy walk: these proofs queue on the RIB's
+        // primary lane one dependent at a time, so bound the fan-out in total.
+        let mut rib_budget = LazyRibBudget::default();
         for dependent in &dependents {
-            self.qualify_dataset_dependent(dependent, &mut window)
+            self.qualify_dataset_dependent(dependent, &mut window, &mut rib_budget)
                 .await?;
         }
         Ok(dependents)
@@ -2864,6 +2924,7 @@ impl PeerManager {
         &mut self,
         dependent: &DatasetDependent,
         window: &mut CleanStateQueryWindow,
+        rib_budget: &mut LazyRibBudget,
     ) -> Result<bool, String> {
         let peer = &dependent.peer;
         let commands = self
@@ -2888,13 +2949,11 @@ impl PeerManager {
             StateQueryOutcome::State(_) => {
                 // The existing RFC 8212 presence-change preflight uses the
                 // same RIB proof: actor-local emptiness alone misses GR/LLGR.
-                let retained = tokio::time::timeout(
-                    RIB_REPLY_TIMEOUT,
-                    self.query_peer_retained_stale(peer.address),
-                )
-                .await
-                .map_err(|_| format!("dataset dependent {peer} retained-route query timed out"))?
-                .map_err(|error| error.message)?;
+                let rib_deadline = rib_budget.deadline();
+                let retained = self
+                    .query_peer_retained_stale(peer.address, Some(rib_deadline))
+                    .await
+                    .map_err(|error| error.message)?;
                 if retained != 0 {
                     return Err(format!(
                         "dataset dependent {peer} retains {retained} stale routes"
@@ -2979,10 +3038,13 @@ impl PeerManager {
             managed.pending_export_apply |= dependent.export;
         }
         let mut window = CleanStateQueryWindow::default();
+        // One budget for this whole settlement's RIB proofs, for the same
+        // reason the policy walk has one: they are serial and per dependent.
+        let mut rib_budget = LazyRibBudget::default();
         let mut established = Vec::with_capacity(dependents.len());
         for dependent in dependents {
             established.push(
-                self.qualify_dataset_dependent(dependent, &mut window)
+                self.qualify_dataset_dependent(dependent, &mut window, &mut rib_budget)
                     .await
                     .map_err(DatasetRefreshFailure::Ambiguous)?,
             );
@@ -2998,7 +3060,7 @@ impl PeerManager {
                     // A missing outbound registration is safe only while this
                     // exact managed session still positively reports down.
                     if self
-                        .qualify_dataset_dependent(dependent, &mut window)
+                        .qualify_dataset_dependent(dependent, &mut window, &mut rib_budget)
                         .await
                         .map_err(DatasetRefreshFailure::Ambiguous)?
                     {
@@ -3031,7 +3093,7 @@ impl PeerManager {
         }
         for (dependent, was_established) in dependents.iter().zip(&established) {
             let now_established = self
-                .qualify_dataset_dependent(dependent, &mut window)
+                .qualify_dataset_dependent(dependent, &mut window, &mut rib_budget)
                 .await
                 .map_err(DatasetRefreshFailure::Ambiguous)?;
             if !was_established && now_established {
@@ -3078,6 +3140,10 @@ impl PeerManager {
     /// on its prior chain (the cross-side carry case). Reading the installed
     /// chains afterwards reports that mixed state correctly; deriving the
     /// gauge from the candidate chains the caller passed in would not.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one live-apply seam carries both chains, refresh handling, rollback planning, and the caller's shared walk budgets"
+    )]
     async fn update_runtime_policies_for_peer_key(
         &mut self,
         peer_key: PeerKey,
@@ -3086,6 +3152,7 @@ impl PeerManager {
         refresh_failure: RefreshFailureHandling,
         rollback_plan: Option<&mut Option<PolicyRollbackPeerPlan>>,
         clean_state_window: Option<&mut CleanStateQueryWindow>,
+        rib_deadline: Option<tokio::time::Instant>,
     ) -> Result<(), PolicyApplyFailure> {
         let result = self
             .apply_runtime_policies_for_peer_key(
@@ -3095,6 +3162,7 @@ impl PeerManager {
                 refresh_failure,
                 rollback_plan,
                 clean_state_window,
+                rib_deadline,
             )
             .await;
         self.refresh_rfc8212_policy_metrics(&peer_key);
@@ -3105,6 +3173,10 @@ impl PeerManager {
         clippy::too_many_lines,
         reason = "runtime policy application keeps ordered import and export transitions together"
     )]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one live-apply seam carries both chains, refresh handling, rollback planning, and the caller's shared walk budgets"
+    )]
     async fn apply_runtime_policies_for_peer_key(
         &mut self,
         peer_key: PeerKey,
@@ -3113,6 +3185,7 @@ impl PeerManager {
         refresh_failure: RefreshFailureHandling,
         rollback_plan: Option<&mut Option<PolicyRollbackPeerPlan>>,
         clean_state_window: Option<&mut CleanStateQueryWindow>,
+        rib_deadline: Option<tokio::time::Instant>,
     ) -> Result<(), PolicyApplyFailure> {
         use std::fmt::Write as _;
         let address = peer_key.address;
@@ -3133,7 +3206,8 @@ impl PeerManager {
         // nothing retained owes no refresh, so the guard below must not fire
         // for it.
         let rfc8212_refresh_required = if rfc8212_fatal_transition {
-            self.qualify_rfc8212_import_transition(&peer_key).await?
+            self.qualify_rfc8212_import_transition(&peer_key, rib_deadline)
+                .await?
         } else {
             false
         };
@@ -3442,7 +3516,7 @@ impl PeerManager {
             // state query remains ambiguous and therefore fail-closed, as do
             // forward applies and peers still reporting Established.
             let rib_outcome = self
-                .replace_peer_export_policy_in_rib(address, export_policy)
+                .replace_peer_export_policy_in_rib(address, export_policy, rib_deadline)
                 .await;
             match rib_outcome {
                 Ok(()) => {}
@@ -4048,6 +4122,9 @@ impl PeerManager {
             .collect();
 
         let mut failures: Vec<String> = Vec::new();
+        // One absolute RIB budget for the whole fan-out, for the same reason
+        // the authoritative snapshot walk has one.
+        let mut rib_budget = LazyRibBudget::default();
         for peer_key in targets {
             let address = peer_key.address;
             let Some(managed) = self.peers.get(&peer_key) else {
@@ -4072,6 +4149,7 @@ impl PeerManager {
                     continue;
                 }
             };
+            let rib_deadline = rib_budget.deadline();
             if let Err(e) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -4080,6 +4158,7 @@ impl PeerManager {
                     RefreshFailureHandling::Fatal,
                     None,
                     None,
+                    Some(rib_deadline),
                 )
                 .await
             {
@@ -4138,6 +4217,9 @@ impl PeerManager {
             .collect();
 
         let mut failures: Vec<String> = Vec::new();
+        // One absolute RIB budget for the whole fan-out, for the same reason
+        // the authoritative snapshot walk has one.
+        let mut rib_budget = LazyRibBudget::default();
         for peer_key in targets {
             let address = peer_key.address;
             let Some(managed) = self.peers.get(&peer_key) else {
@@ -4162,6 +4244,7 @@ impl PeerManager {
                     continue;
                 }
             };
+            let rib_deadline = rib_budget.deadline();
             if let Err(e) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -4170,6 +4253,7 @@ impl PeerManager {
                     RefreshFailureHandling::Fatal,
                     None,
                     None,
+                    Some(rib_deadline),
                 )
                 .await
             {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -533,7 +533,7 @@ impl PeerManager {
     async fn qualify_rfc8212_import_transition(
         &mut self,
         peer_key: &PeerKey,
-        rib_deadline: Option<tokio::time::Instant>,
+        rib_budget: Option<&mut LazyRibBudget>,
     ) -> Result<bool, PolicyApplyFailure> {
         let Some(managed) = self.peers.get(peer_key) else {
             return Ok(false);
@@ -560,7 +560,7 @@ impl PeerManager {
             }
             StateQueryOutcome::SessionGone => {
                 let retained = self
-                    .query_peer_retained_stale(peer_key.address, rib_deadline)
+                    .query_peer_retained_stale(peer_key.address, rib_budget)
                     .await?;
                 if retained == 0 {
                     return Ok(false);
@@ -594,7 +594,7 @@ impl PeerManager {
         }
 
         let retained = self
-            .query_peer_retained_stale(peer_key.address, rib_deadline)
+            .query_peer_retained_stale(peer_key.address, rib_budget)
             .await?;
         if retained > 0 {
             return Err(PolicyApplyFailure {
@@ -617,59 +617,61 @@ impl PeerManager {
     ///
     /// This proof rides the RIB manager's primary lane, so it waits behind the
     /// same backlog an export replacement does and is bounded the same way:
-    /// `rib_deadline` is `Some` for a step of an `O(peers)` walk, whose steps
-    /// all share one absolute budget, and `None` for a single inline
-    /// qualification, which keeps [`super::RIB_REPLY_TIMEOUT`].
+    /// `rib_budget` is `Some` for a step of an `O(peers)` walk, whose steps
+    /// all share one absolute admission-and-reply budget, and `None` for a
+    /// single inline qualification, which keeps [`super::RIB_REPLY_TIMEOUT`].
     async fn query_peer_retained_stale(
         &mut self,
         peer: IpAddr,
-        rib_deadline: Option<tokio::time::Instant>,
+        rib_budget: Option<&mut LazyRibBudget>,
     ) -> Result<usize, PolicyApplyFailure> {
-        let (reply_tx, reply_rx) = oneshot::channel();
+        let allowance = if rib_budget.is_some() {
+            super::RIB_BATCH_REPLY_TIMEOUT
+        } else {
+            super::RIB_REPLY_TIMEOUT
+        };
+        let deadline = rib_budget.map_or_else(
+            || tokio::time::Instant::now() + allowance,
+            LazyRibBudget::deadline,
+        );
+        let failed = |detail: &str| PolicyApplyFailure {
+            code: RuntimeConfigPolicyFailureCode::StateRibQueryFailed,
+            message: format!(
+                "{peer}: cannot apply an RFC 8212 import policy-presence change — {detail}"
+            ),
+            refresh_delivery_began: false,
+        };
+        let timed_out = || {
+            failed(&format!(
+                "the RIB manager did not report retained stale routes within {allowance:?}"
+            ))
+        };
+        // An expired walk must not enqueue another command, even if the
+        // channel is immediately writable (timeout polls its future first).
+        if tokio::time::Instant::now() >= deadline {
+            return Err(timed_out());
+        }
         let rib_tx = self.rib_tx.clone();
-        if self
-            .await_with_readiness(rib_tx.send(RibUpdate::QueryPeerRetainedStale {
+        let round_trip = async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let permit = rib_tx
+                .reserve()
+                .await
+                .map_err(|_| failed("the RIB manager is unavailable, so its retained stale routes cannot be confirmed"))?;
+            if tokio::time::Instant::now() >= deadline {
+                return Err(timed_out());
+            }
+            permit.send(RibUpdate::QueryPeerRetainedStale {
                 peer,
                 reply: reply_tx,
-            }))
-            .await
-            .is_err()
-        {
-            return Err(PolicyApplyFailure {
-                code: RuntimeConfigPolicyFailureCode::StateRibQueryFailed,
-                message: format!(
-                    "{peer}: cannot apply an RFC 8212 import policy-presence change — the RIB \
-                 manager is unavailable, so its retained stale routes cannot be confirmed"
-                ),
-                refresh_delivery_began: false,
             });
-        }
-        let reply = self.await_with_readiness(reply_rx);
-        let waited = match rib_deadline {
-            Some(deadline) => tokio::time::timeout_at(deadline, reply).await,
-            None => tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply).await,
+            reply_rx
+                .await
+                .map_err(|_| failed("the RIB manager dropped the retained-stale reply"))
         };
-        match waited {
-            Err(_) => Err(PolicyApplyFailure {
-                code: RuntimeConfigPolicyFailureCode::StateRibQueryFailed,
-                message: format!(
-                    "{peer}: cannot apply an RFC 8212 import policy-presence change — the RIB \
-                 manager did not report retained stale routes within {:?}",
-                    rib_deadline
-                        .map_or(super::RIB_REPLY_TIMEOUT, |_| super::RIB_BATCH_REPLY_TIMEOUT)
-                ),
-                refresh_delivery_began: false,
-            }),
-            Ok(Err(_)) => Err(PolicyApplyFailure {
-                code: RuntimeConfigPolicyFailureCode::StateRibQueryFailed,
-                message: format!(
-                    "{peer}: cannot apply an RFC 8212 import policy-presence change — the RIB \
-                 manager dropped the retained-stale reply"
-                ),
-                refresh_delivery_began: false,
-            }),
-            Ok(Ok(retained)) => Ok(retained),
-        }
+        tokio::time::timeout_at(deadline, self.await_with_readiness(round_trip))
+            .await
+            .map_err(|_| timed_out())?
     }
 
     /// ADR-0112: qualify every target whose RFC 8212 import verdict would move,
@@ -700,9 +702,8 @@ impl PeerManager {
 
         let mut rejections = Vec::new();
         for peer_key in &transitioning {
-            let rib_deadline = rib_budget.deadline();
             if let Err(error) = self
-                .qualify_rfc8212_import_transition(peer_key, Some(rib_deadline))
+                .qualify_rfc8212_import_transition(peer_key, Some(&mut *rib_budget))
                 .await
             {
                 rejections.push(error);
@@ -1311,7 +1312,6 @@ impl PeerManager {
             };
             applied.push(prior);
             let applied_idx = applied.len() - 1;
-            let rib_deadline = rollback_rib_budget.forward.deadline();
             if let Err(apply_error) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -1321,7 +1321,7 @@ impl PeerManager {
                     None,
                     require_clean_convergence
                         .then_some(&mut rollback_rib_budget.clean_state_window),
-                    Some(rib_deadline),
+                    Some(&mut rollback_rib_budget.forward),
                 )
                 .await
             {
@@ -2075,7 +2075,7 @@ impl PeerManager {
     /// Run one ordinary RIB export-policy replacement while servicing the
     /// dedicated readiness lane.
     ///
-    /// `rib_deadline` is `Some` when this command is one step of an
+    /// `rib_budget` is `Some` when this command is one step of an
     /// `O(peers)` policy walk: every step of that walk shares the one absolute
     /// deadline so the walk is bounded in total. `None` is a genuinely
     /// single-peer inline operation and keeps [`super::RIB_REPLY_TIMEOUT`].
@@ -2083,28 +2083,15 @@ impl PeerManager {
         &mut self,
         peer: IpAddr,
         export_policy: Option<PolicyChain>,
-        rib_deadline: Option<tokio::time::Instant>,
+        rib_budget: Option<&mut LazyRibBudget>,
     ) -> Result<(), RibCommandError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        let rib_tx = self.rib_tx.clone();
-        if self
-            .await_with_readiness(rib_tx.send(RibUpdate::ReplacePeerExportPolicy {
-                peer,
-                export_policy,
-                reply: reply_tx,
-            }))
-            .await
-            .is_err()
-        {
-            return Err(RibCommandError::internal("RIB manager unavailable"));
-        }
-        let reply = self.await_with_readiness(reply_rx);
-        let waited = match rib_deadline {
-            Some(deadline) => tokio::time::timeout_at(deadline, reply).await,
-            None => tokio::time::timeout(super::RIB_REPLY_TIMEOUT, reply).await,
-        };
-        match waited {
-            Err(_) => Err(RibCommandError::internal(if rib_deadline.is_some() {
+        let shared = rib_budget.is_some();
+        let deadline = rib_budget.map_or_else(
+            || tokio::time::Instant::now() + super::RIB_REPLY_TIMEOUT,
+            LazyRibBudget::deadline,
+        );
+        let timed_out = || {
+            RibCommandError::internal(if shared {
                 format!(
                     "RIB manager did not reply within the {:?} shared policy-walk budget while updating export policy",
                     super::RIB_BATCH_REPLY_TIMEOUT
@@ -2114,11 +2101,35 @@ impl PeerManager {
                     "RIB manager did not reply within {:?} while updating export policy",
                     super::RIB_REPLY_TIMEOUT
                 )
-            })),
-            Ok(Err(_)) => Err(RibCommandError::internal("RIB manager dropped reply")),
-            Ok(Ok(Err(error))) => Err(error),
-            Ok(Ok(Ok(()))) => Ok(()),
+            })
+        };
+        // Do not admit fresh mutations after an earlier walk step spent the
+        // budget. An already-admitted command remains ordered before rollback.
+        if tokio::time::Instant::now() >= deadline {
+            return Err(timed_out());
         }
+        let rib_tx = self.rib_tx.clone();
+        let round_trip = async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let permit = rib_tx
+                .reserve()
+                .await
+                .map_err(|_| RibCommandError::internal("RIB manager unavailable"))?;
+            if tokio::time::Instant::now() >= deadline {
+                return Err(timed_out());
+            }
+            permit.send(RibUpdate::ReplacePeerExportPolicy {
+                peer,
+                export_policy,
+                reply: reply_tx,
+            });
+            reply_rx
+                .await
+                .map_err(|_| RibCommandError::internal("RIB manager dropped reply"))?
+        };
+        tokio::time::timeout_at(deadline, self.await_with_readiness(round_trip))
+            .await
+            .map_err(|_| timed_out())?
     }
 
     /// Apply a live-impact transaction that may include static neighbors and
@@ -2949,9 +2960,8 @@ impl PeerManager {
             StateQueryOutcome::State(_) => {
                 // The existing RFC 8212 presence-change preflight uses the
                 // same RIB proof: actor-local emptiness alone misses GR/LLGR.
-                let rib_deadline = rib_budget.deadline();
                 let retained = self
-                    .query_peer_retained_stale(peer.address, Some(rib_deadline))
+                    .query_peer_retained_stale(peer.address, Some(&mut *rib_budget))
                     .await
                     .map_err(|error| error.message)?;
                 if retained != 0 {
@@ -3152,7 +3162,7 @@ impl PeerManager {
         refresh_failure: RefreshFailureHandling,
         rollback_plan: Option<&mut Option<PolicyRollbackPeerPlan>>,
         clean_state_window: Option<&mut CleanStateQueryWindow>,
-        rib_deadline: Option<tokio::time::Instant>,
+        rib_budget: Option<&mut LazyRibBudget>,
     ) -> Result<(), PolicyApplyFailure> {
         let result = self
             .apply_runtime_policies_for_peer_key(
@@ -3162,7 +3172,7 @@ impl PeerManager {
                 refresh_failure,
                 rollback_plan,
                 clean_state_window,
-                rib_deadline,
+                rib_budget,
             )
             .await;
         self.refresh_rfc8212_policy_metrics(&peer_key);
@@ -3185,7 +3195,7 @@ impl PeerManager {
         refresh_failure: RefreshFailureHandling,
         rollback_plan: Option<&mut Option<PolicyRollbackPeerPlan>>,
         clean_state_window: Option<&mut CleanStateQueryWindow>,
-        rib_deadline: Option<tokio::time::Instant>,
+        mut rib_budget: Option<&mut LazyRibBudget>,
     ) -> Result<(), PolicyApplyFailure> {
         use std::fmt::Write as _;
         let address = peer_key.address;
@@ -3206,7 +3216,7 @@ impl PeerManager {
         // nothing retained owes no refresh, so the guard below must not fire
         // for it.
         let rfc8212_refresh_required = if rfc8212_fatal_transition {
-            self.qualify_rfc8212_import_transition(&peer_key, rib_deadline)
+            self.qualify_rfc8212_import_transition(&peer_key, rib_budget.as_deref_mut())
                 .await?
         } else {
             false
@@ -3516,7 +3526,7 @@ impl PeerManager {
             // state query remains ambiguous and therefore fail-closed, as do
             // forward applies and peers still reporting Established.
             let rib_outcome = self
-                .replace_peer_export_policy_in_rib(address, export_policy, rib_deadline)
+                .replace_peer_export_policy_in_rib(address, export_policy, rib_budget)
                 .await;
             match rib_outcome {
                 Ok(()) => {}
@@ -4149,7 +4159,6 @@ impl PeerManager {
                     continue;
                 }
             };
-            let rib_deadline = rib_budget.deadline();
             if let Err(e) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -4158,7 +4167,7 @@ impl PeerManager {
                     RefreshFailureHandling::Fatal,
                     None,
                     None,
-                    Some(rib_deadline),
+                    Some(&mut rib_budget),
                 )
                 .await
             {
@@ -4244,7 +4253,6 @@ impl PeerManager {
                     continue;
                 }
             };
-            let rib_deadline = rib_budget.deadline();
             if let Err(e) = self
                 .update_runtime_policies_for_peer_key(
                     peer_key,
@@ -4253,7 +4261,7 @@ impl PeerManager {
                     RefreshFailureHandling::Fatal,
                     None,
                     None,
-                    Some(rib_deadline),
+                    Some(&mut rib_budget),
                 )
                 .await
             {

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -410,7 +410,7 @@ async fn forward_walk_rib_reply_may_outlive_the_single_command_deadline() {
             panic!("expected the forward remainder command");
         };
         assert_eq!(target, peer);
-        tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_secs(6)).await;
+        tokio::time::sleep(RIB_REPLY_TIMEOUT + Duration::from_secs(6)).await;
         reply.send(Ok(())).unwrap();
     };
     let (result, ()) = tokio::join!(apply, rib);
@@ -490,7 +490,7 @@ async fn forward_walk_rib_budget_is_shared_across_the_whole_walk() {
             match rib_rx.recv().await.unwrap() {
                 RibUpdate::ReplacePeerExportPolicy { reply, .. } => {
                     served += 1;
-                    tokio::time::advance(per_peer_delay).await;
+                    tokio::time::sleep(per_peer_delay).await;
                     let _ = reply.send(Ok(()));
                 }
                 RibUpdate::RestorePeerExportPoliciesAuthoritatively {
@@ -512,21 +512,228 @@ async fn forward_walk_rib_budget_is_shared_across_the_whole_walk() {
             }
         }
     };
-    let (result, served) = tokio::join!(apply, drive_rib);
+    let (result, served) = tokio::time::timeout(RIB_BATCH_REPLY_TIMEOUT * 3, async {
+        tokio::join!(apply, drive_rib)
+    })
+    .await
+    .expect("the walk must reject and complete its rollback within the bound");
     assert!(
         per_peer_delay < RIB_BATCH_REPLY_TIMEOUT,
         "every individual reply must fit inside a fresh budget, so only a \
          shared one can reject this walk"
     );
     assert_eq!(
-        served,
-        usize::from(PEER_COUNT),
-        "every peer's own command must be issued and answered within a fresh budget"
+        served, 2,
+        "the second reply exhausts the shared budget; the third command must not be issued"
     );
     assert!(
         result
             .as_ref()
             .is_err_and(|error| error.contains("shared policy-walk budget")),
         "a walk whose cumulative RIB time exceeds the budget must still be rejected: {result:?}"
+    );
+}
+
+/// Session work before the first RIB command cannot spend its lazy budget.
+#[tokio::test(start_paused = true)]
+async fn forward_walk_rib_budget_starts_after_session_apply() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 41, 2, 1));
+    let (mut manager, mut rib_rx) = rfc8212_status_manager();
+    let (session_tx, mut session_rx) = mpsc::channel(16);
+    let session = tokio::spawn(async move {
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::QueryState { reply } => {
+                    let mut state = policy_test_peer_state(peer, SessionState::Established);
+                    state.negotiated_session = Some(test_negotiated_session(true));
+                    let _ = reply.send(state);
+                }
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    tokio::time::sleep(Duration::from_millis(400)).await;
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::UpdateImportPolicy { reply, .. }
+                | PeerCommand::SendRouteRefresh { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        PeerHandle::from_parts(session_tx, session),
+        false,
+    );
+    manager.peers.get_mut(&key(peer)).unwrap().import_policy = Some(
+        crate::config::reserved_rfc8212_deny_chain(crate::config::RFC8212_MISSING_IMPORT_POLICY),
+    );
+    let apply = manager.apply_resolved_policy_snapshot(vec![ResolvedPeerPolicy {
+        address: peer,
+        interface: None,
+        import_policy: Some(deny_policy_chain()),
+        export_policy: Some(deny_policy_chain()),
+    }]);
+    let rib = async {
+        let RibUpdate::ReplacePeerExportPolicy { reply, .. } = rib_rx.recv().await.unwrap() else {
+            panic!("expected forward export replacement");
+        };
+        tokio::time::sleep(
+            RIB_BATCH_REPLY_TIMEOUT
+                .checked_sub(Duration::from_millis(200))
+                .unwrap(),
+        )
+        .await;
+        reply
+            .send(Ok(()))
+            .expect("session work must not spend the RIB budget");
+    };
+    let (result, ()) = tokio::join!(apply, rib);
+    assert!(
+        result.is_ok(),
+        "first RIB use must get the whole budget: {result:?}"
+    );
+}
+
+/// Saturating the primary lane must bound both the read-only preflight and
+/// export admission. A canceled send must not become a late forward mutation.
+#[tokio::test(start_paused = true)]
+async fn forward_walk_rib_budget_bounds_full_channel_admission() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    for retained_proof in [false, true] {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 41, 3, 1));
+        let (mut manager, _) = rfc8212_status_manager();
+        let (rib_tx, mut rib_rx) = mpsc::channel(1);
+        let (marker_reply, _marker_rx) = oneshot::channel();
+        rib_tx
+            .send(RibUpdate::QueryPeerRetainedStale {
+                peer,
+                reply: marker_reply,
+            })
+            .await
+            .unwrap();
+        manager.rib_tx = rib_tx;
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            acking_policy_handle(
+                peer,
+                if retained_proof {
+                    SessionState::Idle
+                } else {
+                    SessionState::Established
+                },
+            ),
+            false,
+        );
+        if retained_proof {
+            manager.peers.get_mut(&key(peer)).unwrap().import_policy =
+                Some(crate::config::reserved_rfc8212_deny_chain(
+                    crate::config::RFC8212_MISSING_IMPORT_POLICY,
+                ));
+        }
+        let started = tokio::time::Instant::now();
+        let result = tokio::time::timeout(
+            RIB_BATCH_REPLY_TIMEOUT * 3,
+            manager.apply_resolved_policy_snapshot(vec![ResolvedPeerPolicy {
+                address: peer,
+                interface: None,
+                import_policy: retained_proof.then(deny_policy_chain),
+                export_policy: Some(deny_policy_chain()),
+            }]),
+        )
+        .await
+        .expect("full-channel admission must not park the snapshot forever");
+        assert!(result.is_err(), "an unserved RIB cannot commit");
+        assert_eq!(
+            started.elapsed(),
+            RIB_BATCH_REPLY_TIMEOUT * if retained_proof { 1 } else { 2 }
+        );
+        assert!(matches!(
+            rib_rx.recv().await.unwrap(),
+            RibUpdate::QueryPeerRetainedStale { .. }
+        ));
+        if retained_proof {
+            assert!(matches!(
+                rib_rx.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ));
+        } else {
+            let RibUpdate::RestorePeerExportPoliciesAuthoritatively {
+                reply,
+                replacements,
+            } = rib_rx.recv().await.unwrap()
+            else {
+                panic!("only the detached exact rollback may follow the canceled admission");
+            };
+            reply
+                .send(Ok(replacements
+                    .iter()
+                    .rev()
+                    .map(
+                        |replacement| rustbgpd_rib::PeerExportPolicyRestoreReceipt::Restored {
+                            peer: replacement.peer,
+                        },
+                    )
+                    .collect()))
+                .unwrap();
+            assert!(manager.peers.get(&key(peer)).unwrap().pending_export_apply);
+        }
+    }
+}
+
+/// Preflight reports every rejection, so later peers still reach the proof
+/// helper after the first timeout. They must not enqueue already-expired work.
+#[tokio::test(start_paused = true)]
+async fn forward_walk_rib_budget_stops_expired_retained_proofs() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let (mut manager, mut rib_rx) = rfc8212_status_manager();
+    let mut targets = Vec::new();
+    for last in 1..=3 {
+        let peer = IpAddr::V4(Ipv4Addr::new(10, 41, 4, last));
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            acking_policy_handle(peer, SessionState::Idle),
+            false,
+        );
+        manager.peers.get_mut(&key(peer)).unwrap().import_policy =
+            Some(crate::config::reserved_rfc8212_deny_chain(
+                crate::config::RFC8212_MISSING_IMPORT_POLICY,
+            ));
+        targets.push(ResolvedPeerPolicy {
+            address: peer,
+            interface: None,
+            import_policy: Some(deny_policy_chain()),
+            export_policy: None,
+        });
+    }
+    let rib = tokio::spawn(async move {
+        let mut served = 0;
+        while let Some(update) = rib_rx.recv().await {
+            let RibUpdate::QueryPeerRetainedStale { reply, .. } = update else {
+                panic!("preflight must reject without applying policies");
+            };
+            served += 1;
+            tokio::time::sleep(RIB_BATCH_REPLY_TIMEOUT * 2 / 3).await;
+            let _ = reply.send(0);
+        }
+        served
+    });
+    let started = tokio::time::Instant::now();
+    let result = manager.apply_resolved_policy_snapshot(targets).await;
+    assert!(result.is_err());
+    assert_eq!(started.elapsed(), RIB_BATCH_REPLY_TIMEOUT);
+    drop(manager);
+    assert_eq!(
+        rib.await.unwrap(),
+        2,
+        "the expired third proof must not be admitted"
     );
 }

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -356,3 +356,177 @@ async fn cohort_hot_apply_budget_still_bounds_a_stalled_session() {
     drop(manager);
     rib.await.unwrap();
 }
+
+/// The authoritative forward walk's RIB commands ride the RIB manager's
+/// primary lane, which is not polled while route chunks pend, and each one
+/// performs a full Loc-RIB distribution pass. A single peer's reply therefore
+/// legitimately outlives `RIB_REPLY_TIMEOUT` under load, and that must not
+/// reject the generation.
+///
+/// LOAD-BEARING: restoring a fresh per-peer `RIB_REPLY_TIMEOUT` on the walk
+/// makes this apply fail with `policy_rib_apply_rejected` instead of `Ok`.
+/// Coverage that the batched cohort path cannot provide: a single target can
+/// never form a cohort, so this exercises the fallback the fast path skips.
+#[tokio::test(start_paused = true)]
+async fn forward_walk_rib_reply_may_outlive_the_single_command_deadline() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    let peer = IpAddr::V4(Ipv4Addr::new(10, 41, 0, 1));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    insert_test_managed_peer(
+        &mut manager,
+        peer,
+        established_export_policy_test_session(peer, attempts, None),
+        false,
+    );
+
+    // One target can never reach the two-member cohort, so this snapshot takes
+    // the wholly authoritative walk.
+    let apply = manager.apply_resolved_policy_snapshot(vec![ResolvedPeerPolicy {
+        address: peer,
+        interface: None,
+        import_policy: None,
+        export_policy: Some(deny_policy_chain()),
+    }]);
+    let rib = async {
+        let RibUpdate::ReplacePeerExportPolicy {
+            peer: target,
+            reply,
+            ..
+        } = rib_rx.recv().await.unwrap()
+        else {
+            panic!("expected the forward remainder command");
+        };
+        assert_eq!(target, peer);
+        tokio::time::advance(RIB_REPLY_TIMEOUT + Duration::from_secs(6)).await;
+        reply.send(Ok(())).unwrap();
+    };
+    let (result, ()) = tokio::join!(apply, rib);
+    assert!(
+        result.is_ok(),
+        "an eleven-second forward walk reply must still apply: {result:?}"
+    );
+    let peer_state = manager.peers.get(&key(peer)).unwrap();
+    assert!(!peer_state.pending_export_apply);
+    assert!(!peer_state.pending_refresh);
+}
+
+/// The walk budget is one absolute deadline for the whole walk, not a fresh
+/// one per peer. A fleet-wide fallback whose cumulative RIB time exceeds the
+/// budget must still be rejected — otherwise the change above reads as
+/// "the walk timeout was removed", and a 1000-peer walk would tolerate hours.
+///
+/// Every peer here replies well inside a fresh `RIB_BATCH_REPLY_TIMEOUT`, so
+/// the rejection can only come from the budget they share.
+///
+/// LOAD-BEARING: anchoring the deadline inside the per-peer call (or handing
+/// each peer its own `RIB_BATCH_REPLY_TIMEOUT`) makes this apply succeed.
+#[tokio::test(start_paused = true)]
+async fn forward_walk_rib_budget_is_shared_across_the_whole_walk() {
+    use rustbgpd_api::peer_types::ResolvedPeerPolicy;
+
+    const PEER_COUNT: u8 = 3;
+    // Each peer alone fits inside the walk budget; two together exhaust it.
+    let per_peer_delay = RIB_BATCH_REPLY_TIMEOUT * 2 / 3;
+
+    let peers = (1..=PEER_COUNT)
+        .map(|last| IpAddr::V4(Ipv4Addr::new(10, 41, 1, last)))
+        .collect::<Vec<_>>();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let (rib_tx, mut rib_rx) = mpsc::channel(16);
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    );
+    for peer in peers.iter().copied() {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            established_export_policy_test_session(peer, Arc::clone(&attempts), None),
+            false,
+        );
+    }
+
+    // Distinct target chains: no two peers are export-identical, so cohort
+    // selection finds no two-member group and the whole fleet walks.
+    let apply = manager.apply_resolved_policy_snapshot(
+        peers
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, address)| ResolvedPeerPolicy {
+                address,
+                interface: None,
+                import_policy: None,
+                export_policy: Some(distinct_deny_policy_chain(index)),
+            })
+            .collect(),
+    );
+    let drive_rib = async {
+        let mut served = 0_usize;
+        // The walk stops at the peer that exhausts the shared budget, so only
+        // the commands actually issued are answered; the rollback aggregate
+        // that follows ends the dialogue.
+        loop {
+            match rib_rx.recv().await.unwrap() {
+                RibUpdate::ReplacePeerExportPolicy { reply, .. } => {
+                    served += 1;
+                    tokio::time::advance(per_peer_delay).await;
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::RestorePeerExportPoliciesAuthoritatively {
+                    replacements,
+                    reply,
+                } => {
+                    let _ = reply.send(Ok(replacements
+                        .iter()
+                        .rev()
+                        .map(
+                            |replacement| rustbgpd_rib::PeerExportPolicyRestoreReceipt::Restored {
+                                peer: replacement.peer,
+                            },
+                        )
+                        .collect()));
+                    break served;
+                }
+                _ => panic!("unexpected RIB command during the forward walk"),
+            }
+        }
+    };
+    let (result, served) = tokio::join!(apply, drive_rib);
+    assert!(
+        per_peer_delay < RIB_BATCH_REPLY_TIMEOUT,
+        "every individual reply must fit inside a fresh budget, so only a \
+         shared one can reject this walk"
+    );
+    assert_eq!(
+        served,
+        usize::from(PEER_COUNT),
+        "every peer's own command must be issued and answered within a fresh budget"
+    );
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|error| error.contains("shared policy-walk budget")),
+        "a walk whose cumulative RIB time exceeds the budget must still be rejected: {result:?}"
+    );
+}


### PR DESCRIPTION
A peer excluded from a batched export-policy cohort can fall back to a serial RIB replacement whose reply exceeds the old five-second limit. The reload then rejects even though the same class of work receives two minutes in the cohort path.

Forward policy walks now share one absolute two-minute RIB budget across the authoritative remainder, RFC 8212 preflight, graceful-shutdown/blackhole fan-outs, and dataset-dependent proofs. The clock starts at the first actual RIB command. Session-only qualification and hot-apply work before that point do not consume it; subsequent RIB admission and replies use the same deadline.

Both RIB helpers reserve channel capacity within that deadline and recheck expiry immediately before enqueueing. A full queue cannot wait indefinitely or admit a fresh mutation after expiry. Already admitted work remains ordered before exact rollback, which retains its separately anchored budget and existing restoration/fail-closed handling. Single-peer inline policy edits retain a five-second allowance, now covering admission as well as the reply.

This bounds RIB waits across a walk; it is not a deadline for every session or Route Refresh operation in the transaction. Whole-fleet serial fallback can now fail sooner than a fresh allowance per peer. The patch does not change cohort selection or remove the fallback's per-peer distribution cost.

Evidence is scoped: field errors establish a forward reply exceeded five seconds. The recorded 8–11-second authoritative remainder phase includes session work and rollback, so it is not a direct RIB reply measurement or a measured margin for the new budget. Local load reproduced cohort exclusion and a 4.48-second remainder phase, not the field rejection.

Validation: 444 peer-manager tests pass, including deterministic delayed-single and cumulative-walk cases, session-only lazy anchoring, saturated channel admission, expired proof rejection, and separate rollback-budget coverage. Mutation checks confirm that restoring five seconds fails the delayed-single regression and granting fresh per-peer two-minute allowances fails the cumulative-walk regression. Formatting and strict commit-hook Clippy pass. The full integrated `just gate` and `just gate-rib` also pass on the child instrumentation branch with this exact policy correction included. Normal parent push hooks pass; updated-head hosted results remain separate.
