### PR TITLE
test(soak): retain periodic metrics snapshots in flagship runs

### DIFF
--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1053,13 +1053,24 @@ Smokes may lengthen the probe schedules with
 in `run.json` and the terminal summary, and the analyzer requires them to
 match. The management-plane load itself is not optional.
 
+`samples.csv` extracts ten scalars per sample; every family the daemon
+exposes, including the RIB actor work and readiness-wait histograms that
+diagnose reload stalls, is retained by `metrics-snapshots.txt.gz`. The
+runner appends the full `/metrics` body it already scraped for the sample
+every `METRICS_SNAPSHOT_EVERY` samples (default `10`, so every 5 minutes at
+the default 30 s sample interval; `0` disables retention), each headed by a
+`# snapshot <UTC> elapsed_sec=<n>` line; `zcat` reads the file as one
+stream. At the 1000-peer shape one body is about 4.4 MiB raw and about
+210 KiB gzipped, so a 24 h run keeps 288 snapshots in roughly 60 MB. Both
+flagship runners share this knob.
+
 Requires host ports 1790 (BGP) and 9179 (metrics) free — the runner
 refuses to start otherwise and never kills unknown processes — and
 file-descriptor headroom (see below). Output
 lands in `tests/soak/runs/soak-rs-flagship-<UTC>/` (`samples.csv`,
 `cycles.log`, `reloadstall.log`, `rustbgpd.log`,
 `management-plane-load.jsonl`, `management-plane-load.log`,
-`doctor-bundle.tar.gz`, `run.json`,
+`doctor-bundle.tar.gz`, `metrics-snapshots.txt.gz`, `run.json`,
 `verdict.json`, `runner.identity`, `cleanup.complete`); the analyzer is `analyze-soak-rs-flagship.py` and the
 precommitted gates are scenario 10 in
 `docs/soaks/soak-acceptance-gates.md`. Note the short scenario
@@ -1102,8 +1113,9 @@ Requires host ports 1790 (BGP) and 9179 (metrics) free — the runner
 refuses to start otherwise and never kills unknown processes — and
 file-descriptor headroom (see below). Output
 lands in `tests/soak/runs/soak-rr-flagship-<UTC>/` (`samples.csv`,
-`cycles.log`, `reloadstall.log`, `rustbgpd.log`, `run.json`, `verdict.json`,
-`runner.identity`, `cleanup.complete`); the analyzer is `analyze-soak-rr-flagship.py` and the
+`cycles.log`, `reloadstall.log`, `rustbgpd.log`, `metrics-snapshots.txt.gz`,
+`run.json`, `verdict.json`, `runner.identity`, `cleanup.complete`); the
+analyzer is `analyze-soak-rr-flagship.py` and the
 precommitted gates are scenario 11 in
 `docs/soaks/soak-acceptance-gates.md`. The same short-`/tmp`-scenario
 and fresh-per-run rules as the route-server flagship soak apply.

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1060,9 +1060,11 @@ runner appends the full `/metrics` body it already scraped for the sample
 every `METRICS_SNAPSHOT_EVERY` samples (default `10`, so every 5 minutes at
 the default 30 s sample interval; `0` disables retention), each headed by a
 `# snapshot <UTC> elapsed_sec=<n>` line; `zcat` reads the file as one
-stream. At the 1000-peer shape one body is about 4.4 MiB raw and about
-210 KiB gzipped, so a 24 h run keeps 288 snapshots in roughly 60 MB. Both
-flagship runners share this knob.
+stream. A failed append is rolled back so it cannot corrupt later snapshots;
+a member interrupted by a hard crash is not recovered. At the 1000-peer
+shape one body is about 4.4 MiB raw and about 210 KiB gzipped, so a 24 h
+run keeps 288 snapshots in roughly 60 MB. Both flagship runners share this
+knob.
 
 Requires host ports 1790 (BGP) and 9179 (metrics) free — the runner
 refuses to start otherwise and never kills unknown processes — and

--- a/tests/soak/run-soak-rr-flagship.sh
+++ b/tests/soak/run-soak-rr-flagship.sh
@@ -28,6 +28,7 @@
 #   - cycles.log       hold/terminal event lines + abort records
 #   - rustbgpd.log     daemon JSON logs
 #   - reloadstall.log  engine stdout/stderr (rr_hold lines, receipt)
+#   - metrics-snapshots.txt.gz     full /metrics body every METRICS_SNAPSHOT_EVERY samples
 #   - run.json         run metadata (analyzer input)
 #   - verdict.json     analyzer verdict
 
@@ -49,6 +50,10 @@ LISTEN_PORT="${LISTEN_PORT:-1790}"
 IBGP_ASN="${IBGP_ASN:-64512}" # shared local AS; must be u16-representable
 # gen-scenario.py pins prometheus_addr to 127.0.0.1:9179.
 readonly METRICS_PORT=9179
+# Retain the full /metrics body every Nth sample (0 disables). One body is
+# about 4.4 MiB raw / 210 KiB gzipped at 1000 peers, so 10 keeps a 24 h run
+# at 30 s sampling to 288 snapshots (about 60 MB compressed).
+METRICS_SNAPSHOT_EVERY="${METRICS_SNAPSHOT_EVERY:-10}"
 
 # --- Derived ---
 TOTAL_PREFIXES=$((SOAK_PEERS * SOAK_ROUTES_PER_PEER))
@@ -66,6 +71,10 @@ if ((SOAK_SECONDS < 60)); then
     echo "SOAK_SECONDS must be at least 60 (one rr_hold status interval)" >&2
     exit 2
 fi
+if [[ ! $METRICS_SNAPSHOT_EVERY =~ ^[0-9]+$ ]]; then
+    echo "METRICS_SNAPSHOT_EVERY must be a non-negative integer (0 disables snapshots)" >&2
+    exit 2
+fi
 OVERALL_CAP_SEC="${OVERALL_CAP_SEC:-$((SOAK_SECONDS + TERMINAL_CAP_SEC + 3600))}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -76,6 +85,7 @@ CYCLES_LOG="$RUN_DIR/cycles.log"
 RUN_JSON="$RUN_DIR/run.json"
 RUSTBGPD_LOG="$RUN_DIR/rustbgpd.log"
 RELOADSTALL_LOG="$RUN_DIR/reloadstall.log"
+METRICS_SNAPSHOTS_GZ="$RUN_DIR/metrics-snapshots.txt.gz"
 PROM_TMP="$RUN_DIR/.metrics.prom"
 
 # shellcheck source=tests/soak/host-lock.sh
@@ -174,6 +184,14 @@ prom_get() {
         END { if (!found) print "nan" }' <"$PROM_TMP"
 }
 
+# Append the current scrape body as one gzip member headed by a comment
+# line, so families the CSV never extracts (histograms, per-peer gauges)
+# reach the archive; `zcat` reads the members as a single stream.
+prom_snapshot() {
+    { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
+        gzip -c >>"$METRICS_SNAPSHOTS_GZ"
+}
+
 tree_rss_mb() {
     ps -eo pid=,ppid=,rss= --no-headers | awk -v root="$DAEMON_PID" '
         {parent[$1]=$2; rss[$1]=$3} END {for (pid in parent) {p=pid
@@ -206,6 +224,7 @@ process_log() {
 }
 
 SCRAPE_FAILS=0
+SAMPLE_ROWS=0
 sample_row() {
     local elapsed=$1
     # Sessions are held open by the engine; once it exits (or if it exits
@@ -254,6 +273,10 @@ sample_row() {
         "$code" \
         "$ms" \
         >>"$SAMPLES_CSV"
+    if ((METRICS_SNAPSHOT_EVERY > 0 && SAMPLE_ROWS % METRICS_SNAPSHOT_EVERY == 0)); then
+        prom_snapshot "$timestamp" "$elapsed" || cycle_log "metrics snapshot append failed"
+    fi
+    SAMPLE_ROWS=$((SAMPLE_ROWS + 1))
     local avail_kib
     avail_kib=$(df -Pk "$RUN_DIR" | awk 'NR==2 {print $4}')
     if ((avail_kib < 5 * 1024 * 1024)); then

--- a/tests/soak/run-soak-rr-flagship.sh
+++ b/tests/soak/run-soak-rr-flagship.sh
@@ -186,10 +186,24 @@ prom_get() {
 
 # Append the current scrape body as one gzip member headed by a comment
 # line, so families the CSV never extracts (histograms, per-peer gauges)
-# reach the archive; `zcat` reads the members as a single stream.
+# reach the archive; `zcat` reads the members as a single stream. A failed
+# append is rolled back to the prior length so a partial member cannot break
+# every later read; a member cut short by a hard kill is not recovered.
 prom_snapshot() {
-    { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
-        gzip -c >>"$METRICS_SNAPSHOTS_GZ"
+    local before
+    before=$(stat -c %s "$METRICS_SNAPSHOTS_GZ" 2>/dev/null || echo 0)
+    # gzip is the writer and the last stage, so its status is the write
+    # status; pipefail (set above) also surfaces a producer failure.
+    if { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
+        gzip -c >>"$METRICS_SNAPSHOTS_GZ"; then
+        return 0
+    fi
+    if ((before == 0)); then
+        rm -f "$METRICS_SNAPSHOTS_GZ"
+    else
+        truncate -c -s "$before" "$METRICS_SNAPSHOTS_GZ"
+    fi
+    return 1
 }
 
 tree_rss_mb() {

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -313,10 +313,24 @@ prom_peer_scope() {
 
 # Append the current scrape body as one gzip member headed by a comment
 # line, so families the CSV never extracts (histograms, per-peer gauges)
-# reach the archive; `zcat` reads the members as a single stream.
+# reach the archive; `zcat` reads the members as a single stream. A failed
+# append is rolled back to the prior length so a partial member cannot break
+# every later read; a member cut short by a hard kill is not recovered.
 prom_snapshot() {
-    { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
-        gzip -c >>"$METRICS_SNAPSHOTS_GZ"
+    local before
+    before=$(stat -c %s "$METRICS_SNAPSHOTS_GZ" 2>/dev/null || echo 0)
+    # gzip is the writer and the last stage, so its status is the write
+    # status; pipefail (set above) also surfaces a producer failure.
+    if { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
+        gzip -c >>"$METRICS_SNAPSHOTS_GZ"; then
+        return 0
+    fi
+    if ((before == 0)); then
+        rm -f "$METRICS_SNAPSHOTS_GZ"
+    else
+        truncate -c -s "$before" "$METRICS_SNAPSHOTS_GZ"
+    fi
+    return 1
 }
 
 tree_rss_mb() {

--- a/tests/soak/run-soak-rs-flagship.sh
+++ b/tests/soak/run-soak-rs-flagship.sh
@@ -33,6 +33,7 @@
 #   - management-plane-load.jsonl  bounded HTTP/CLI load evidence
 #   - management-plane-load.log    load-driver stdout/stderr
 #   - doctor-bundle.tar.gz         latest `rbgp doctor` support bundle
+#   - metrics-snapshots.txt.gz     full /metrics body every METRICS_SNAPSHOT_EVERY samples
 #   - run.json         run metadata (analyzer input)
 #   - verdict.json     analyzer verdict
 
@@ -69,6 +70,10 @@ MANAGEMENT_CLI_INTERVAL_SEC="${MANAGEMENT_CLI_INTERVAL_SEC:-5}"
 # that the daemon's run context is still sane, not load.
 MANAGEMENT_DOCTOR_INTERVAL_SEC="${MANAGEMENT_DOCTOR_INTERVAL_SEC:-600}"
 MANAGEMENT_TIMEOUT_SEC="${MANAGEMENT_TIMEOUT_SEC:-5}"
+# Retain the full /metrics body every Nth sample (0 disables). One body is
+# about 4.4 MiB raw / 210 KiB gzipped at 1000 peers, so 10 keeps a 24 h run
+# at 30 s sampling to 288 snapshots (about 60 MB compressed).
+METRICS_SNAPSHOT_EVERY="${METRICS_SNAPSHOT_EVERY:-10}"
 
 # Match reloadstall's base_prefix(idx) exactly for stub 1's first route:
 # own_slice(1) starts at global index SOAK_ROUTES_PER_PEER. Stub 1 is stable
@@ -128,6 +133,10 @@ if ((TRIP_FINAL_QUIESCE_SEC < 30)); then
     echo "TRIP_FINAL_QUIESCE_SEC must be >= 30 (the final-trip evidence drain runs inside it)" >&2
     exit 2
 fi
+if [[ ! $METRICS_SNAPSHOT_EVERY =~ ^[0-9]+$ ]]; then
+    echo "METRICS_SNAPSHOT_EVERY must be a non-negative integer (0 disables snapshots)" >&2
+    exit 2
+fi
 OVERALL_CAP_SEC="${OVERALL_CAP_SEC:-$((SOAK_SECONDS + RELOADS * 300 + PLANNED_TRIPS * (TRIP_RESTART_SECONDS + TRIP_REESTABLISH_SEC + 300) + 3600))}"
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -143,6 +152,7 @@ MANAGEMENT_LOAD_LOG="$RUN_DIR/management-plane-load.log"
 # One fixed path rewritten by every doctor attempt; a defaulted bundle name is
 # timestamped and would leave one tarball per attempt in the run directory.
 DOCTOR_BUNDLE="$RUN_DIR/doctor-bundle.tar.gz"
+METRICS_SNAPSHOTS_GZ="$RUN_DIR/metrics-snapshots.txt.gz"
 PROM_TMP="$RUN_DIR/.metrics.prom"
 
 # shellcheck source=tests/soak/host-lock.sh
@@ -301,6 +311,14 @@ prom_peer_scope() {
         END { if (!found) print "nan" }' <"$PROM_TMP"
 }
 
+# Append the current scrape body as one gzip member headed by a comment
+# line, so families the CSV never extracts (histograms, per-peer gauges)
+# reach the archive; `zcat` reads the members as a single stream.
+prom_snapshot() {
+    { printf '# snapshot %s elapsed_sec=%s\n' "$1" "$2"; cat "$PROM_TMP"; } |
+        gzip -c >>"$METRICS_SNAPSHOTS_GZ"
+}
+
 tree_rss_mb() {
     ps -eo pid=,ppid=,rss= --no-headers | awk -v root="$DAEMON_PID" '
         {parent[$1]=$2; rss[$1]=$3} END {for (pid in parent) {p=pid
@@ -427,6 +445,7 @@ process_log() {
 }
 
 SCRAPE_FAILS=0
+SAMPLE_ROWS=0
 sample_row() {
     local elapsed=$1
     # Sessions are held open by the engine; once it exits (or if it exits
@@ -472,6 +491,10 @@ sample_row() {
         "$code" \
         "$ms" \
         >>"$SAMPLES_CSV"
+    if ((METRICS_SNAPSHOT_EVERY > 0 && SAMPLE_ROWS % METRICS_SNAPSHOT_EVERY == 0)); then
+        prom_snapshot "$timestamp" "$elapsed" || cycle_log "metrics snapshot append failed"
+    fi
+    SAMPLE_ROWS=$((SAMPLE_ROWS + 1))
     local avail_kib
     avail_kib=$(df -Pk "$RUN_DIR" | awk 'NR==2 {print $4}')
     if ((avail_kib < 5 * 1024 * 1024)); then

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -400,54 +400,56 @@ class FlagshipLifecycleContracts(unittest.TestCase):
             finally:
                 terminate_group(process.pid, process)
 
+    def assert_failed_snapshot_append_rolls_back(self, runner, directory):
+        archive = directory / "metrics-snapshots.txt.gz"
+        body = directory / "metrics.prom"
+        body.write_text("bgp_peer_session_established 9\n")
+        fake_bin = directory / "bin"
+        fake_bin.mkdir()
+        # A gzip that emits a member header, then fails like a write error.
+        broken_gzip = fake_bin / "gzip"
+        broken_gzip.write_text(
+            "#!/usr/bin/env bash\n"
+            "cat >/dev/null\n"
+            "printf '\\x1f\\x8b\\x08\\x00\\x00\\x00\\x00\\x00\\x00\\x03partial'\n"
+            "exit 1\n"
+        )
+        broken_gzip.chmod(0o755)
+
+        def append(timestamp, elapsed, path=None):
+            environment = os.environ.copy()
+            if path:
+                environment["PATH"] = f"{path}:{environment['PATH']}"
+            return subprocess.run(
+                ["bash", "-c",
+                 'source "$1"; METRICS_SNAPSHOTS_GZ=$2; PROM_TMP=$3; prom_snapshot "$4" "$5"',
+                 "snapshot", str(HERE / runner), str(archive), str(body), timestamp, elapsed],
+                text=True, capture_output=True, check=False, env=environment,
+            )
+
+        def snapshots():
+            self.assertEqual(subprocess.run(["gzip", "-t", str(archive)], check=False).returncode, 0)
+            with gzip.open(archive, "rt", encoding="utf-8") as retained:
+                return retained.read().count("# snapshot ")
+
+        self.assertNotEqual(append("2026-01-01T00:00:00Z", "0", fake_bin).returncode, 0)
+        self.assertFalse(archive.exists())
+        self.assertEqual(append("2026-01-01T00:00:00Z", "0").returncode, 0)
+        self.assertEqual(append("2026-01-01T00:00:10Z", "10").returncode, 0)
+        intact = archive.read_bytes()
+        self.assertEqual(snapshots(), 2)
+
+        self.assertNotEqual(append("2026-01-01T00:00:20Z", "20", fake_bin).returncode, 0)
+        self.assertEqual(snapshots(), 2)
+        self.assertEqual(archive.read_bytes(), intact)
+
+        self.assertEqual(append("2026-01-01T00:00:30Z", "30").returncode, 0)
+        self.assertEqual(snapshots(), 3)
+
     def test_failed_snapshot_append_leaves_the_archive_readable(self):
         for runner in RUNNERS:
             with self.subTest(runner=runner), tempfile.TemporaryDirectory() as tmp:
-                directory = Path(tmp)
-                archive = directory / "metrics-snapshots.txt.gz"
-                body = directory / "metrics.prom"
-                body.write_text("bgp_peer_session_established 9\n")
-                fake_bin = directory / "bin"
-                fake_bin.mkdir()
-                # A gzip that emits a member header, then fails like a write error.
-                broken_gzip = fake_bin / "gzip"
-                broken_gzip.write_text(
-                    "#!/usr/bin/env bash\n"
-                    "cat >/dev/null\n"
-                    "printf '\\x1f\\x8b\\x08\\x00\\x00\\x00\\x00\\x00\\x00\\x03partial'\n"
-                    "exit 1\n"
-                )
-                broken_gzip.chmod(0o755)
-
-                def append(timestamp, elapsed, path=None):
-                    environment = os.environ.copy()
-                    if path:
-                        environment["PATH"] = f"{path}:{environment['PATH']}"
-                    return subprocess.run(
-                        ["bash", "-c",
-                         'source "$1"; METRICS_SNAPSHOTS_GZ=$2; PROM_TMP=$3; prom_snapshot "$4" "$5"',
-                         "snapshot", str(HERE / runner), str(archive), str(body), timestamp, elapsed],
-                        text=True, capture_output=True, check=False, env=environment,
-                    )
-
-                def snapshots():
-                    self.assertEqual(subprocess.run(["gzip", "-t", str(archive)], check=False).returncode, 0)
-                    with gzip.open(archive, "rt", encoding="utf-8") as retained:
-                        return retained.read().count("# snapshot ")
-
-                self.assertNotEqual(append("2026-01-01T00:00:00Z", "0", fake_bin).returncode, 0)
-                self.assertFalse(archive.exists())
-                self.assertEqual(append("2026-01-01T00:00:00Z", "0").returncode, 0)
-                self.assertEqual(append("2026-01-01T00:00:10Z", "10").returncode, 0)
-                intact = archive.read_bytes()
-                self.assertEqual(snapshots(), 2)
-
-                self.assertNotEqual(append("2026-01-01T00:00:20Z", "20", fake_bin).returncode, 0)
-                self.assertEqual(snapshots(), 2)
-                self.assertEqual(archive.read_bytes(), intact)
-
-                self.assertEqual(append("2026-01-01T00:00:30Z", "30").returncode, 0)
-                self.assertEqual(snapshots(), 3)
+                self.assert_failed_snapshot_append_rolls_back(runner, Path(tmp))
 
     def test_stale_identity_refuses_to_signal_an_unrelated_process(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -443,8 +443,8 @@ class FlagshipLifecycleContracts(unittest.TestCase):
                 self.assertEqual(snapshots(), 2)
 
                 self.assertNotEqual(append("2026-01-01T00:00:20Z", "20", fake_bin).returncode, 0)
-                self.assertEqual(archive.read_bytes(), intact)
                 self.assertEqual(snapshots(), 2)
+                self.assertEqual(archive.read_bytes(), intact)
 
                 self.assertEqual(append("2026-01-01T00:00:30Z", "30").returncode, 0)
                 self.assertEqual(snapshots(), 3)

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Subprocess contracts for flagship runner stop ownership."""
 
+import gzip
 import os
 import signal
 import socket
@@ -136,6 +137,7 @@ class FlagshipLifecycleContracts(unittest.TestCase):
             MANAGEMENT_LOAD_JSONL="$RUN_DIR/management-plane-load.jsonl"
             MANAGEMENT_LOAD_LOG="$RUN_DIR/management-plane-load.log"
             DOCTOR_BUNDLE="$RUN_DIR/doctor-bundle.tar.gz"
+            METRICS_SNAPSHOTS_GZ="$RUN_DIR/metrics-snapshots.txt.gz"
             PROM_TMP="$RUN_DIR/.metrics.prom"
             require_fd_headroom() { RUSTBGPD_NOFILE_SOFT_JSON=65536; }
             if declare -F start_management_load >/dev/null; then
@@ -264,6 +266,7 @@ class FlagshipLifecycleContracts(unittest.TestCase):
                     identity = run_dir / "runner.identity"
                     wait_for(identity)
                     wait_for_children(run_dir / "children", 3 if runner.startswith("run-soak-rs") else 2)
+                    wait_for(run_dir / "metrics-snapshots.txt.gz")
                     actual_pid = int(identity.read_text().split()[0])
                     self.assertNotEqual(outer.pid, actual_pid)
                     outer.terminate()
@@ -291,6 +294,10 @@ class FlagshipLifecycleContracts(unittest.TestCase):
                     if runner.startswith("run-soak-rs"):
                         self.assertIn("clean_sigterm", (run_dir / "management-plane-load.jsonl").read_text())
                     self.assertFalse((run_dir / "verdict.json").exists())
+                    with gzip.open(run_dir / "metrics-snapshots.txt.gz", "rt", encoding="utf-8") as retained:
+                        snapshot = retained.read()
+                    self.assertRegex(snapshot, r"\A# snapshot \d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ elapsed_sec=\d+\n")
+                    self.assertIn("\nbgp_peer_session_established 9\n", snapshot)
                     self.assertEqual(
                         (run_dir / "cleanup.complete").read_text().splitlines()[0],
                         "status=interrupted",

--- a/tests/soak/test_flagship_lifecycle.py
+++ b/tests/soak/test_flagship_lifecycle.py
@@ -400,6 +400,55 @@ class FlagshipLifecycleContracts(unittest.TestCase):
             finally:
                 terminate_group(process.pid, process)
 
+    def test_failed_snapshot_append_leaves_the_archive_readable(self):
+        for runner in RUNNERS:
+            with self.subTest(runner=runner), tempfile.TemporaryDirectory() as tmp:
+                directory = Path(tmp)
+                archive = directory / "metrics-snapshots.txt.gz"
+                body = directory / "metrics.prom"
+                body.write_text("bgp_peer_session_established 9\n")
+                fake_bin = directory / "bin"
+                fake_bin.mkdir()
+                # A gzip that emits a member header, then fails like a write error.
+                broken_gzip = fake_bin / "gzip"
+                broken_gzip.write_text(
+                    "#!/usr/bin/env bash\n"
+                    "cat >/dev/null\n"
+                    "printf '\\x1f\\x8b\\x08\\x00\\x00\\x00\\x00\\x00\\x00\\x03partial'\n"
+                    "exit 1\n"
+                )
+                broken_gzip.chmod(0o755)
+
+                def append(timestamp, elapsed, path=None):
+                    environment = os.environ.copy()
+                    if path:
+                        environment["PATH"] = f"{path}:{environment['PATH']}"
+                    return subprocess.run(
+                        ["bash", "-c",
+                         'source "$1"; METRICS_SNAPSHOTS_GZ=$2; PROM_TMP=$3; prom_snapshot "$4" "$5"',
+                         "snapshot", str(HERE / runner), str(archive), str(body), timestamp, elapsed],
+                        text=True, capture_output=True, check=False, env=environment,
+                    )
+
+                def snapshots():
+                    self.assertEqual(subprocess.run(["gzip", "-t", str(archive)], check=False).returncode, 0)
+                    with gzip.open(archive, "rt", encoding="utf-8") as retained:
+                        return retained.read().count("# snapshot ")
+
+                self.assertNotEqual(append("2026-01-01T00:00:00Z", "0", fake_bin).returncode, 0)
+                self.assertFalse(archive.exists())
+                self.assertEqual(append("2026-01-01T00:00:00Z", "0").returncode, 0)
+                self.assertEqual(append("2026-01-01T00:00:10Z", "10").returncode, 0)
+                intact = archive.read_bytes()
+                self.assertEqual(snapshots(), 2)
+
+                self.assertNotEqual(append("2026-01-01T00:00:20Z", "20", fake_bin).returncode, 0)
+                self.assertEqual(archive.read_bytes(), intact)
+                self.assertEqual(snapshots(), 2)
+
+                self.assertEqual(append("2026-01-01T00:00:30Z", "30").returncode, 0)
+                self.assertEqual(snapshots(), 3)
+
     def test_stale_identity_refuses_to_signal_an_unrelated_process(self):
         with tempfile.TemporaryDirectory() as tmp:
             run_dir = Path(tmp) / "run"


### PR DESCRIPTION
## Summary

Both flagship runners (`run-soak-rs-flagship.sh`, `run-soak-rr-flagship.sh`) scrape the full `/metrics` body every sample, extract ten scalars into `samples.csv`, and discard the body. Nothing else the daemon exposes survived to the archive, including the `bgp_rib_actor_work_duration_seconds{work_unit}` and `bgp_rib_readiness_query_wait_seconds{seam}` histograms that exist to diagnose readiness stalls during reloads.

Every `METRICS_SNAPSHOT_EVERY` samples (default `10`, `0` disables) the runner now appends the body it already fetched to `metrics-snapshots.txt.gz`, headed by a `# snapshot <UTC> elapsed_sec=<n>` line. Each append is one gzip member and `zcat`/`gzip.open` read the file as a single stream. A failed append is rolled back to the archive's prior length (a freshly created file is removed) so a partial member cannot corrupt later snapshots; a member interrupted by a hard crash is not recovered. No second fetch per sample; with the knob absent every other output is unchanged.

The RR runner is folded in because it has the identical `prom_scrape` → `prom_sum` → discard structure; the same helper and knob apply verbatim. The other `run-*-soak.sh` scripts are untouched.

## Sizing

One `/metrics` body from a live 1000-peer route-server daemon: **4,608,727 bytes raw, 62,654 lines, 212,486 bytes gzipped** (4.6%). Both histogram families were present (80 lines).

- 24 h at 30 s sampling = 2,880 samples. Retaining every sample would be 2,880 × 212 KiB ≈ 598 MB compressed (12.7 GB raw), six times the ~100 MB budget.
- ~100 MB / 212 KiB ≈ 480 snapshots, so N ≥ 6.
- `N = 10` → 288 snapshots × 212,486 B ≈ **61 MB compressed**, one snapshot every 5 minutes, about six per 30-minute reload interval so cumulative-histogram deltas bracket every reload.

Members are compressed independently, but each body is far larger than gzip's 32 KiB window, so this matches single-stream compression.

## Archive path

The analyzers open named files only (`run.json`, `samples.csv`, `cycles.log`, `rustbgpd.log`, the management JSONL) and skip unknown `cycles.log` bodies, so the new file and the `metrics snapshot append failed` note are inert to them. The runner header listings and `tests/soak/README.md` output lists name the artifact; archival is a whole-run-directory copy.

## Validation

- `bash -n` both runners: 0
- `shellcheck` both runners: same 8 pre-existing findings as `main` (SC2034 `SOAK_LOG` consumed by the sourced lifecycle file, SC1091 unfollowed sources); `shellcheck -x`: 0 findings
- `python3 -m unittest -v tests/soak/test_flagship_lifecycle.py`: 6 tests OK. The stop-ownership contract now also waits for the first snapshot and asserts the gzip decodes with the header line and a scraped family, for both runners. `test_failed_snapshot_append_leaves_the_archive_readable` builds two good members, forces an append to fail through a `gzip` stub that emits a member header then exits non-zero, asserts the bytes are unchanged and `gzip -t` still passes, then appends a third member and reads exactly three. It also covers the fresh-file case (no unreadable empty archive is left behind). Mutation check, both runners: with only the `truncate` line removed the test fails on the `gzip -t` assertion (`1 != 0`) after the mid-archive failed append; with the whole rollback removed it fails earlier, on the fresh-file check (an unreadable partial archive is left behind). Restored, the full file passes 6/6.
- `python3 -m unittest -v tests/soak/test_analyze_soak_rs_flagship.py`: 43 OK; `test_analyze_soak_rr_flagship.py`: 23 OK
- `just links`: 0; `scripts/check_public_tracker_ids.py`: 0
- `python3 scripts/check_developer_tooling.py --self-test` and `python3 scripts/check_developer_tooling.py` (the CI "developer tooling" step, ruff included): 0 and 0
- RS runner smoke on the final head (`SOAK_PEERS=12 SOAK_ROUTES_PER_PEER=50 SOAK_SECONDS=300 RELOAD_INTERVAL_SEC=60 TRIP_INTERVAL_SEC=120 TRIP_RESTART_SECONDS=20 WARMUP_SEC=30 SAMPLE_INTERVAL=10 METRICS_SNAPSHOT_EVERY=3`): runner exit 0, analyzer verdict `pass`, `cleanup.complete` reads `status=normal`. `metrics-snapshots.txt.gz` is 183,234 bytes, `gzip -t` exits 0, `zcat` yields 1,352,460 bytes / 17,096 lines with 13 `# snapshot` headers, which is ⌈38 `samples.csv` rows / 3⌉ = 13, spaced 30 s apart (`elapsed_sec` 0 … 360). Every snapshot carries both `bgp_rib_actor_work_duration_seconds` (48 lines) and `bgp_rib_readiness_query_wait_seconds` (32 lines); `cycles.log` records zero `metrics snapshot append failed` lines. Python's multi-member `gzip.open` counts the same 13. No `rustbgpd` or `reloadstall` process survived the run.
