### PR TITLE
docs(soak): clarify readiness acceptance and release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,12 +89,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The route-server flagship soak analyzer now fails its `/readyz` gate on
-  three consecutive breached samples rather than on a single one, matching
-  the readiness-probe `failureThreshold` default that health-probe consumers
-  apply. The verdict reports the total breach count, the longest consecutive
+  three consecutive breached samples rather than on a single one. This follows
+  Kubernetes's default failure count; the soak's 30-second interval and 250 ms
+  response limit remain separate choices from Kubernetes's 10-second and
+  one-second defaults. It tolerates isolated breaches while rejecting missing
+  observations. The verdict reports the total breach count, the longest consecutive
   run, and the first 20 offending samples, separating a non-200 status
-  (including a failed request) from a late 200. Missing observations fail
-  closed, so dropped metric scrapes cannot silently alter breach streaks.
+  (including a failed request) from a late 200. See the
+  [readiness acceptance policy](docs/soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes).
 
 - The container healthcheck now uses `rbgp health --liveness`: it checks gRPC
   responsiveness rather than core-actor readiness. Override it with

--- a/bench/scale/route-server-1000/README.md
+++ b/bench/scale/route-server-1000/README.md
@@ -20,12 +20,17 @@ GiB `MemAvailable`. Lock contention exits 75.
 
 Runtime gates are also fixed: cold convergence within 60 seconds, overall
 completion within 600 seconds, daemon-tree RSS at most 2 GiB sampled each
-second, and `/readyz` sampled every 100 ms with every response HTTP 200 in at
-most 250 ms. Selected update-group and actor-poll metrics are scraped every
-250 ms. The run is accepted only with four exact delivery rows, all sessions
+second, and `/readyz` probed with a 100 ms delay between requests, with every
+response HTTP 200 in at most 250 ms. Selected update-group and actor-poll
+metrics are scraped every 250 ms. The run is accepted only with four exact delivery rows, all sessions
 up, no decode errors, one 1,000-member update group, no fallback peers, and at
 least four `finalize` polls. An advertised-route explanation additionally
 proves an actual prefix passes export policy through a non-null update group.
+
+This fixed-shape receipt deliberately rejects any readiness breach. Its
+per-sample gate is stricter than the flagship RS soak's consecutive-failure
+policy; see [readiness acceptance](../../../docs/soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes).
+Neither harness changes the daemon's shared 200 ms core-actor deadline.
 
 Run only on a quiet performance host, from the immutable commit to measure:
 

--- a/docs/project/release-checklist.md
+++ b/docs/project/release-checklist.md
@@ -103,6 +103,33 @@ convention in `CONTRIBUTING.md`:
       either refresh the affected cells or disclose the newer release beside
       the dated historical result.
 
+## Flagship operating proof
+
+For v0.70, qualify the selected release candidate with the full 24-hour
+route-server management-load soak. Use the
+[runner procedure](../../tests/soak/README.md) and its
+[precommitted gates](../soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes).
+
+- [ ] Integrate the accepted runtime and harness changes, verify applicable
+      main checks, and exercise reloads and peer trips in a short shakedown
+      before committing to the 24-hour run. A smoke is not endurance proof.
+- [ ] Pin and retain the candidate source identity, executable hashes,
+      workload, sampling interval, analyzer revision, and gate thresholds.
+      Later runtime or dependency changes require candidate qualification
+      again; an older daemon's passing receipt does not transfer automatically.
+- [ ] Require a completed 24-hour run and every applicable gate to pass.
+      Isolated readiness breaches stay in the report but do not automatically
+      block release under the agreed consecutive-failure policy. Missing
+      observations still fail, and management correctness remains zero-failure.
+- [ ] Review readiness status/latency counts and any retained timing metrics
+      with their documented limits. A passing gate is not evidence that every
+      latency spike's cause was fixed; unresolved investigation can remain
+      tracked without imposing an undocumented zero-breach gate after the run.
+- [ ] Archive the original evidence and verdict with the
+      [receipt template](../soaks/soak-receipt-template.md). Record reanalysis
+      separately. Finish release dates and the applicable package/artifact
+      checks below only after qualification; a passing soak does not replace them.
+
 ## Narrow v1 RS/RR compatibility gate
 
 The project remains public alpha outside the explicit

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -115,6 +115,13 @@ The next product milestone is operational trust for the route-server / route-
 reflector beachhead, not another breadth sprint. Work in this section outranks
 new AFI/SAFI and EVPN dataplane expansion.
 
+For v0.70, the [release checklist](release-checklist.md#flagship-operating-proof)
+requires a qualifying 24-hour management-load soak on the selected candidate.
+Earlier archived soaks do not automatically qualify later runtime changes.
+The [current route-server readiness policy](../soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes)
+uses consecutive failures and rejects missing observations; isolated breaches
+remain visible without automatically blocking a release whose agreed gates pass.
+
 - **Maintain the narrow v1 role contract.** The shipped machine-checked
   inventory (#862; LAN-355) pins only the configuration and API used by
   IPv4/IPv6 route servers and route reflectors, `.rpol`, RPKI/ASPA, Roles/OTC,

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -11,6 +11,16 @@ resolved.
 
 ## Open issues
 
+- **Reloads can produce transient readiness failures.** The current core probe
+  can return `/readyz` 503 during a policy reload, and observed HTTP latency can
+  exceed its shared 200 ms actor deadline. Timing instrumentation supports
+  investigation but does not establish that the underlying delay is fixed.
+  The [operator probe contract](operations.md#http-probes) distinguishes
+  instantaneous responses from consumer hysteresis. The
+  [route-server soak policy](../soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes)
+  permits isolated breaches while retaining them as evidence; they do not
+  automatically block release when all agreed acceptance gates pass.
+
 - **Fleet policy stats can time out during reload.** The daemon's
   `GetPolicyStats` RPC shares one absolute 2 s deadline across peer validation,
   export counters, import counters, and dataset reads. Fleet calls such as
@@ -20,15 +30,15 @@ resolved.
   investigation.
   See the [policy stats contract](api.md#policyservice).
 
-- **700-member dual-stack reload acceptance remains open.** The
-  [post-change filtering run](../perf/ixp-dualstack-policy-noops-2026-09.md#700-member-follow-through)
-  completed all four reloads but failed the health and warning checks. Its
-  passing 200-member cell and the older IPv4-only receipts do not establish
-  the full dual-stack operating shape. The
-  [earlier stopped campaign](../perf/ixp-dualstack-2026-09-08.md) retains its
-  separate incomplete-reload and health failures.
-
 ## Resolved
+
+- **700-member dual-stack reload acceptance completed (resolved).** All 13
+  cells in the [final campaign](../perf/ixp-dualstack-final-campaign-2026-09.md)
+  passed supplemental gate v3, including two complete 700-member campaigns
+  across both family mixes and policy shapes. Five cells retain their original
+  gate v2 failures for classified cleanup TCP-refusal warnings; the receipt
+  preserves those results and the earlier failed runs. This scoped acceptance
+  does not replace the separate qualifying 24-hour management-load soak.
 
 - **Add-Path export explain covers exact candidates (resolved).** For
   negotiated IPv4/IPv6 unicast Add-Path send, `ExplainAdvertisedRoute` and

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -1148,6 +1148,22 @@ configured peers, zero Established peers, or zero routes can still be ready.
 Event-history, EVPN, FIB, and peer-count health are surfaced through their own
 metrics and status commands rather than as v1 readiness gates.
 
+Each `/readyz` response reports the current probe result; the endpoint has no
+internal failure-count hysteresis. The shared 200 ms core-actor deadline is
+not a bound on total HTTP wall-clock time: runtime scheduling and response
+delivery can take longer, and a successful probe observed after the deadline
+is rejected.
+
+Consumers choose their own failure policy. Kubernetes defaults to three failed
+probes, a 10-second interval, and a one-second timeout; an HTTP 503 still fails
+that probe even when it arrives within one second. The flagship RS soak instead
+requires HTTP 200 within 250 ms and fails on three consecutive breaches at its
+default 30-second sampling interval. Missing observations fail its gate.
+Isolated breaches remain visible findings but do not automatically block a
+release when all agreed acceptance gates pass. See the
+[readiness acceptance and Kubernetes comparison](../soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes)
+for the precise observation rules and the separate RR gate.
+
 ### The `peer` label
 
 Every `peer`-labeled series — session, RIB, policy, max-prefix, BFD, BMP —

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -35,6 +35,14 @@ In particular:
 For operational boundaries and non-goals, see
 [`LIMITATIONS.md`](limitations.md).
 
+## Readiness and operating evidence
+
+Operational readiness and soak acceptance are separate from compatibility.
+The [`/readyz` contract](operations.md#http-probes) describes the current core
+probe; the [route-server soak policy](../soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes)
+defines consecutive-failure and evidence requirements. Passing that scenario
+does not promise zero transient readiness failures or widen the stable inventory.
+
 ## Authorization is a different classification
 
 The [gRPC method inventory](grpc-method-inventory.md) assigns every method an

--- a/docs/soaks/soak-acceptance-gates.md
+++ b/docs/soaks/soak-acceptance-gates.md
@@ -299,6 +299,58 @@ never as silent green.
 | Minimum sample count | ≥ 0.9 × (`SOAK_SECONDS` ÷ `SAMPLE_INTERVAL`) | CSV row count | One row per interval; scrape failures skip the row (and ≥ 5 consecutive failures abort). |
 | No abort record | zero `ABORT:` lines | `cycles.log` | The runner writes one before any fail-closed exit (daemon death, blind sampler, evidence deadline, disk floor, watchdog). |
 
+#### Readiness acceptance and Kubernetes probes
+
+The daemon's [`/readyz` endpoint](../reference/operations.md#http-probes)
+reports the result of the current core probe. Its shared 200 ms deadline covers
+the peer-manager and RIB checks; it is not a promise that every HTTP request
+finishes within 200 ms. Scheduling delays and HTTP delivery also affect the
+latency observed by the sampler. The endpoint applies no consecutive-failure
+filter of its own.
+
+The route-server flagship soak applies hysteresis: it requires repeated failed
+observations before failing the readiness gate. This follows Kubernetes's
+default failure-count policy, with different sampling and latency settings:
+
+| Setting | Kubernetes readiness-probe default | Route-server flagship soak |
+|---|---|---|
+| Consecutive failures to fail the check | 3 | 3 |
+| Probe interval | 10 seconds | 30 seconds by default; actual interval recorded in `run.json` |
+| Response limit | 1 second | HTTP 200 within 250 ms |
+
+Kubernetes defaults and HTTP success semantics are documented in its
+[probe reference](https://kubernetes.io/docs/concepts/workloads/pods/probes/#configuration-fields).
+The soak has a stricter per-response latency limit, but samples less often:
+three failures at its default interval span at least 60 seconds. It therefore
+permits longer outages than the default 10-second cadence. These are sampled
+observations, not proof of continuous failure between probes. A 503 fails an
+individual Kubernetes HTTP probe even when it arrives within one second;
+three consecutive failures are what fail its overall readiness check. A
+30-second archive cannot establish what intervening 10-second probes would
+have observed.
+
+Missing evidence is not a healthy sample. Logged scrape failures or gaps of
+at least two sample intervals, including planned window edges, fail the soak
+readiness gate. A gap resets the breach streak. The verdict preserves complete
+breach counts and the longest streak, with detailed lists capped at 20.
+This acceptance policy tolerates isolated breaches and rejects missing
+observations; it is neither uniformly stricter nor uniformly looser than the
+previous zero-breach gate.
+
+An isolated breach remains visible and can guide latency investigation, but
+does not automatically block a release when all agreed soak gates pass.
+Samples during reloads and trips are still counted; there is no reload-window
+exemption. A passing readiness gate does not excuse failed management, session,
+reload, memory, or evidence gates. Preserve earlier verdicts under their
+original analyzer and record any reanalysis separately.
+
+The [RIB timing histograms](../reference/operations.md#routing)
+support investigation; component durations do not bound full probe latency,
+and admitted-query wait is not the entire HTTP response time. A passing soak
+does not by itself demonstrate that the source of every latency spike was fixed.
+The [fixed-shape route-server receipt](../../bench/scale/route-server-1000/README.md)
+and scenario 11 below retain their own, different readiness gates.
+
 ### 11. Route-reflector flagship (reflection correctness under churn) — `run-soak-rr-flagship.sh` (`analyze-soak-rr-flagship.py`)
 
 The documented RR flagship shape on a bare-host daemon: 1000 real iBGP

--- a/docs/soaks/soak-receipt-template.md
+++ b/docs/soaks/soak-receipt-template.md
@@ -17,6 +17,9 @@ verdict: **FAIL** | **ABORTED**>
 image's SHA>)
 **Scenario config hash:** `<sha256 of run.json>` (pins duration,
 cadence, pool sizes, topology, and container names as executed)
+**Executable identities:** <daemon, CLI, and harness SHA-256 hashes>
+**Analyzer and gate revision:** <source SHA, including any separately recorded
+reanalysis revision; preserve the original verdict>
 **Date:** <start UTC> → <end UTC> (<actual duration>)
 
 ## Verdict
@@ -57,6 +60,16 @@ not be measured is a FAIL with the reason stated.
 
 <N> / <M> gates pass. Analyzer verdict: `<pass|fail>`
 (`verdict.json` / `report.json` archived below).
+
+For the route-server flagship, report readiness status failures, latency
+failures, longest consecutive streak, scrape failures and observation gaps,
+alongside the actual sample interval and both limits. Isolated breaches may
+coexist with a PASS under the
+[precommitted policy](soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes).
+Keep their diagnostic detail; do not reinterpret a passing run as zero breaches.
+Identify any separately retained timing-series evidence and its measurement
+limits. A revised analyzer's result is reanalysis, not a replacement original
+receipt or qualification of a different candidate.
 
 ## Abort record
 

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -131,12 +131,11 @@ async fn handle_connection(
         },
         "/livez" => text_response("200 OK", "ok\n"),
         "/readyz" => {
-            // Hard bound on the response, not just the probe's internal
-            // waits: a runtime stall can hold the probe past the deadline
-            // and then complete it — on unpark the queued reply is polled
-            // before the expired timer, so without the elapsed guard a
-            // late success would be certified as a (contract-violating)
-            // late 200.
+            // Reject a successful probe observed after the shared deadline.
+            // After a runtime stall, a queued reply can be polled before the
+            // expired timer; the elapsed guard prevents certifying that late
+            // success. Scheduling and response delivery can still delay the
+            // HTTP response beyond the deadline.
             let started = std::time::Instant::now();
             match tokio::time::timeout(CORE_READINESS_DEADLINE, readiness_probe.check()).await {
                 Ok(Ok(())) if started.elapsed() <= CORE_READINESS_DEADLINE => {

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1066,6 +1066,23 @@ precommitted gates are scenario 10 in
 directory under `/tmp` is required by the gRPC UDS `sun_path` cap; the
 scenario is regenerated fresh per run and copied into the run dir.
 
+The RS readiness gate requires HTTP 200 within 250 ms and fails on three
+consecutive breaches, with a default 30-second sampling interval. Missing
+observations also fail the gate. Isolated breaches remain reported findings,
+but do not automatically block a release when all agreed acceptance gates pass.
+This is soak acceptance hysteresis; `/readyz` itself reports each current
+probe result using its unchanged shared 200 ms core-actor deadline. See
+[readiness acceptance and Kubernetes probes](../../docs/soaks/soak-acceptance-gates.md#readiness-acceptance-and-kubernetes-probes)
+for the observation rules and the different Kubernetes defaults and RR gate.
+
+For readiness diagnosis, retain timestamped Prometheus series or snapshots
+from the measured daemon through existing monitoring. `samples.csv` does not
+include the RIB actor-work or readiness-wait histograms, and
+`management-plane-load.jsonl` records probe timings and response hashes, not
+Prometheus payloads. The runner overwrites `.metrics.prom` as scrape scratch;
+it is not a complete history. Those files alone cannot establish the histogram
+correlation described in the [operations guide](../../docs/reference/operations.md).
+
 ---
 
 # Route-reflector flagship soak (reflection correctness under churn)


### PR DESCRIPTION
Document the distinction between instantaneous core readiness and the route-server soak's consecutive-failure policy. The canonical comparison explains Kubernetes defaults, the different sampling and response limits, missing-observation rejection, and the separate benchmark and route-reflector gates.

Link that policy from operations, stability, known issues, the roadmap, release preparation and soak instructions. Receipt guidance records candidate/analyzer identity and visible isolated breaches; metric diagnosis requires separately retained timestamped data. Correct the stale dual-stack acceptance entry and the source comment that implied a hard HTTP response-time bound.

Validation: documentation links, public-content/privacy checker, site manifest, release-checklist paths, metric consumers, formatting and strict Clippy passed. The Rust edit changes only a comment; no runtime or acceptance behavior changes.
