### PR TITLE
fix(policy): serve operator reads during the cohort rib transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,20 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Operator-visible:** `rbgp policy stats` and `rbgp neighbor` no longer fail
+  with `DEADLINE_EXCEEDED` when they arrive while a SIGHUP reload's batched
+  export-policy transition is in progress. Both actors previously parked
+  operator reads behind the whole RIB transition, so a read arriving more than
+  about 0.8 s before the commit exhausted its two-second budget at 1000 peers.
+  The peer manager now keeps serving session snapshots and import-statistics
+  collections while it awaits the batched RIB reply, on the same terms as
+  during destination prestaging, and the RIB answers general queries from the
+  pre-commit state between its pre-commit transition polls. Reads that arrive
+  during the short commit batches still wait for the commit, which remains the
+  single switch point; a paged route listing started before the commit cannot
+  be continued across it. Budgets, the reload's atomic commit, and rollback
+  fencing are unchanged.
+
 - **Operator-visible:** a configuration reload could be rejected with no runtime
   effect when one peer's session-state query was slow during heavy RIB load.
   The slow peer was excluded from the batched export-policy cohort and fell to

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2099,9 +2099,13 @@ impl RibManager {
     fn advance_route_pages_for_update(&mut self, update: &RibUpdate) {
         match update {
             // `ReplacePeerExportPolicies` stages a multi-iteration clean
-            // transition whose `Finalize` flips group memberships and export
-            // overlays; general queries stay fenced out until it is terminal,
-            // so advancing here at acceptance covers the whole transaction.
+            // transition whose `CommitMembers` flips group memberships and
+            // export overlays. Advancing here at acceptance invalidates every
+            // continuation from before the transaction; the terminal commit
+            // advances again (`finish_clean_policy_transition_commit`) so a
+            // page started between pre-commit polls, where general queries
+            // are served from the pre-commit state, cannot continue across
+            // the switch.
             RibUpdate::ReplacePeerExportPolicy { .. }
             | RibUpdate::ReplacePeerExportPolicies { .. }
             | RibUpdate::ReplacePeerExportPoliciesAuthoritatively { .. }
@@ -2135,6 +2139,32 @@ impl RibManager {
     /// queries until that transition is terminal.
     fn drain_general_queries_if_unfenced(&mut self) {
         if self.pending_clean_policy_transition.is_none() {
+            self.drain_queries(QUERY_BUDGET_PER_CHUNK);
+        }
+    }
+
+    /// Serve one bounded general-query budget between two polls of an owned
+    /// clean policy transition. Every pre-commit poll leaves committed
+    /// membership, installed policy, counters, and wire state untouched, so
+    /// the primary state at this seam is exactly the pre-commit generation
+    /// and a read answered here is what the same read would have returned
+    /// just before the transition was accepted. The query lane carries only
+    /// reads by construction (mutations arrive on the primary channel, which
+    /// stays fenced), so nothing served here can invalidate the parked
+    /// phase. The commit phase keeps the fence: membership and counters
+    /// move per batch there, and its terminal poll advances the advertised
+    /// page generation before any read can observe the new state.
+    fn drain_general_queries_between_transition_polls(&mut self) {
+        let pre_commit = self
+            .pending_clean_policy_transition
+            .as_ref()
+            .is_some_and(|pending| {
+                !matches!(
+                    pending.poll_kind(),
+                    distribution::CleanPolicyTransitionPollKind::Commit
+                )
+            });
+        if pre_commit {
             self.drain_queries(QUERY_BUDGET_PER_CHUNK);
         }
     }
@@ -4052,10 +4082,12 @@ impl RibManager {
                 .set_rib_ingest_channel_depth(i64::try_from(self.rx.len()).unwrap_or(i64::MAX));
 
             if let Some(mut pending) = self.pending_clean_policy_transition.take() {
-                // Only the type-narrow readiness lane may interleave here.
-                // General queries, primary updates, route chunks, timers, and
-                // resync work remain queued until terminal commit or the
-                // fail-closed fallback handoff.
+                // The type-narrow readiness lane interleaves at every poll,
+                // and a bounded general-query budget between pre-commit
+                // polls (see `drain_general_queries_between_transition_polls`).
+                // Primary updates, route chunks, timers, and resync work
+                // remain queued until terminal commit or the fail-closed
+                // fallback handoff.
                 let member_count = pending.member_count();
                 Self::warn_if_policy_transition_slow(&mut pending, member_count);
                 self.drain_readiness_queries(Some(pending.elapsed()));
@@ -4121,6 +4153,7 @@ impl RibManager {
                     let _ = reply.send(result);
                 }
                 self.drain_readiness_queries(policy_transition_elapsed);
+                self.drain_general_queries_between_transition_polls();
                 tokio::task::yield_now().await;
                 continue;
             }

--- a/crates/rib/src/manager/tests/paged_query.rs
+++ b/crates/rib/src/manager/tests/paged_query.rs
@@ -2243,10 +2243,12 @@ fn accepted_refresh_work_advances_each_route_page_version_once() {
 }
 
 /// A shared clean export-policy transition commits its group-membership and
-/// export-overlay flips in `Finalize`, which does not always reach the
-/// distribution-pass fence (no dirty or forced peers). General queries stay
-/// queued while the transition owns the actor, so fencing at command
-/// acceptance covers the whole transaction, including the fallback handoff.
+/// export-overlay flips in `CommitMembers`, which does not always reach the
+/// distribution-pass fence (no dirty or forced peers). Fencing at command
+/// acceptance invalidates every continuation from before the transaction,
+/// including on the fallback handoff; the terminal commit advances again
+/// because general queries are served between the pre-commit polls (see the
+/// update-group transition seam tests).
 #[test]
 fn accepting_a_shared_policy_transition_invalidates_advertised_continuations() {
     let (_tx, rx) = mpsc::channel(8);

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -2685,10 +2685,14 @@ async fn clean_policy_transition_existing_destination_shares_every_members_count
     handle.await.unwrap();
 }
 
+/// Dedicated readiness beats a saturated general-query lane while a
+/// transition is owned, general queries are served from the pre-commit
+/// state in bounded per-poll slices rather than parked behind the whole
+/// transition, and the terminal commit releases everything.
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 #[expect(
     clippy::too_many_lines,
-    reason = "the scheduler regression pins dedicated readiness, general-query isolation, and terminal release in one transaction"
+    reason = "the scheduler regression pins dedicated readiness, bounded general-query service, and terminal release in one transaction"
 )]
 async fn clean_policy_transition_isolates_readiness_from_general_query_flood() {
     const ROUTE_COUNT: usize = 32;
@@ -2819,12 +2823,35 @@ async fn clean_policy_transition_isolates_readiness_from_general_query_flood() {
         1.0,
         "transition remains owned while readiness overtakes the query flood",
     );
-    for reply in &mut general_replies {
-        assert!(matches!(
-            reply.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
-        ));
-    }
+    // The flood is served from the pre-commit state in bounded slices — at
+    // most one `QUERY_BUDGET_PER_CHUNK` budget per transition poll — so it
+    // can neither delay readiness nor be drained ahead of it. Every answer
+    // is the pre-commit table (identical for a count query).
+    let polls: u64 = histogram_sample_counts_by_label(
+        &metrics,
+        "bgp_rib_policy_transition_actor_poll_duration_seconds",
+        "poll_kind",
+    )
+    .values()
+    .sum();
+    let mut answered = 0_usize;
+    general_replies = general_replies
+        .into_iter()
+        .filter_map(|mut reply| match reply.try_recv() {
+            Ok(count) => {
+                assert_eq!(count, ROUTE_COUNT);
+                answered += 1;
+                None
+            }
+            Err(oneshot::error::TryRecvError::Empty) => Some(reply),
+            Err(oneshot::error::TryRecvError::Closed) => panic!("general query dropped"),
+        })
+        .collect();
+    assert!(
+        answered <= usize::try_from(polls).unwrap() * super::super::QUERY_BUDGET_PER_CHUNK,
+        "general queries are served in one bounded budget per transition poll \
+         (answered {answered} across {polls} polls)"
+    );
     assert!(
         receivers
             .iter_mut()
@@ -2866,12 +2893,6 @@ async fn clean_policy_transition_isolates_readiness_from_general_query_flood() {
         0.0,
         "commit clears transition ownership",
     );
-    for reply in &mut general_replies {
-        assert!(matches!(
-            reply.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
-        ));
-    }
 
     let (recovered_reply, recovered_response) = oneshot::channel();
     readiness_tx
@@ -3148,7 +3169,8 @@ async fn accepted_policy_transition_does_not_drain_prequeued_general_queries() {
 
     // This is the exact fairness seam used after a primary-channel receive.
     // The accepted transition must suppress it even though the query was
-    // already queued before ownership began.
+    // already queued before ownership began; the transition's own
+    // between-poll seam serves it from the pre-commit state instead.
     manager.drain_general_queries_if_unfenced();
     assert!(matches!(
         query_response.try_recv(),
@@ -5017,6 +5039,123 @@ async fn commit_flush_batches_are_bounded_and_drain_monotonically() {
         response.try_recv().unwrap(),
         Ok(crate::update::ExportPolicyCohortOutcome::Committed)
     );
+}
+
+/// One advertised page for `peer` through the general query lane, driven
+/// at the exact seam under test; `None` when the seam left it queued.
+fn advertised_page_at_transition_seam(
+    manager: &mut RibManager,
+    query_tx: &mpsc::Sender<RibUpdate>,
+    peer: IpAddr,
+    between_polls: bool,
+) -> Option<crate::update::RoutePage> {
+    let (reply, mut response) = oneshot::channel();
+    query_tx
+        .try_send(RibUpdate::QueryRoutesPage {
+            scope: RouteQueryScope::Advertised { peer },
+            filter: None,
+            after: None,
+            expected_version: None,
+            page_size: 16,
+            reply,
+        })
+        .unwrap();
+    if between_polls {
+        manager.drain_general_queries_between_transition_polls();
+    } else {
+        manager.drain_general_queries_if_unfenced();
+    }
+    response.try_recv().ok().map(|page| page.unwrap())
+}
+
+/// General queries arriving while the RIB owns a clean transition are
+/// answered between its pre-commit polls from the pre-commit state (an
+/// operator sees exactly what the read returned before the transition was
+/// accepted), stay queued through the commit batches, and see the switched
+/// state under a fresh advertised page generation once the transition is
+/// terminal. Removing the between-poll drain parks the first read behind
+/// the whole transition; serving during commit answers the second read from
+/// half-moved memberships; dropping the commit-time page advance lets the
+/// pre-commit continuation resume over the new state.
+#[tokio::test]
+async fn general_queries_served_between_precommit_polls_and_fenced_during_commit() {
+    const MEMBER_COUNT: usize = 2 * super::super::COMMIT_MEMBERS_PER_POLL + 1;
+    const ROUTE_COUNT: usize = 2;
+    const OLD_COMMUNITY: u32 = 0xFDE8_2101;
+    const NEXT_COMMUNITY: u32 = 0xFDE8_2108;
+    let (query_tx, query_rx) = mpsc::channel(8);
+    let (mut manager, peers, _receivers) =
+        direct_clean_transition_manager(MEMBER_COUNT, ROUTE_COUNT, None);
+    manager.query_rx = query_rx;
+    let member = peers[MEMBER_COUNT - 1];
+    let source = manager.grouped_member_of(member).expect("grouped");
+    let next_policy = community_chain(NEXT_COMMUNITY);
+    let mut response = start_clean_transition(&mut manager, &peers, &next_policy);
+    let accepted_version = manager.route_page_advertised_version;
+
+    // Park after the first bounded pre-commit poll: nothing committed has
+    // moved, and the read must be answered right here.
+    let (kind, outcome) = step_parked_transition(&mut manager);
+    assert_eq!((kind, outcome), ("bounded", "continue"));
+    let page = advertised_page_at_transition_seam(&mut manager, &query_tx, member, true)
+        .expect("a general query is answered between pre-commit transition polls");
+    assert_eq!(page.routes.len(), ROUTE_COUNT);
+    assert!(
+        page.routes
+            .iter()
+            .all(|route| route.communities().contains(&OLD_COMMUNITY)),
+        "the pre-commit answer carries the installed (old) export policy"
+    );
+    assert_eq!(Some(page.version), accepted_version);
+    assert_eq!(manager.grouped_member_of(member), Some(source));
+    assert!(manager.pending_clean_policy_transition.is_some());
+
+    // Drive to the first parked commit batch: the last member is still in
+    // the source group while earlier members have moved, so the read must
+    // stay queued rather than observe the half-switched fleet.
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(outcome, "continue", "{kind} poll must park mid-transition");
+        if kind == "commit" {
+            break;
+        }
+    }
+    assert_ne!(manager.grouped_member_of(peers[0]), Some(source));
+    assert_eq!(manager.grouped_member_of(member), Some(source));
+    assert!(
+        advertised_page_at_transition_seam(&mut manager, &query_tx, member, true).is_none(),
+        "general queries stay fenced while commit batches move memberships"
+    );
+    assert_eq!(manager.route_page_advertised_version, accepted_version);
+
+    // Terminal commit: the queued read is released by the ordinary
+    // post-update drain, answers from the new generation, and the page
+    // version has moved so the pre-commit continuation cannot resume.
+    loop {
+        let (kind, outcome) = step_parked_transition(&mut manager);
+        assert_eq!(kind, "commit");
+        if outcome == "committed" {
+            break;
+        }
+    }
+    assert_eq!(
+        response.try_recv().unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    assert_ne!(
+        manager.route_page_advertised_version, accepted_version,
+        "the terminal commit advances the advertised page generation"
+    );
+    manager.drain_general_queries_if_unfenced();
+    let page = advertised_page_at_transition_seam(&mut manager, &query_tx, member, false)
+        .expect("general queries resume after the terminal commit");
+    assert!(
+        page.routes
+            .iter()
+            .all(|route| route.communities().contains(&NEXT_COMMUNITY)),
+        "the post-commit answer carries the committed (new) export policy"
+    );
+    assert_eq!(Some(page.version), manager.route_page_advertised_version);
 }
 
 /// With wall-clock budget in hand, the probe-and-prepare phase strides the

--- a/crates/rib/src/manager/update_groups/policy_transition.rs
+++ b/crates/rib/src/manager/update_groups/policy_transition.rs
@@ -503,9 +503,14 @@ impl RibManager {
     /// Publish cohort-wide gauges once after the synchronous membership commit.
     /// Refreshing them per member is both unobservable (queries cannot
     /// interleave in the commit section) and quadratic for large cohorts.
+    /// The advertised page generation advances here as well: general queries
+    /// are served from the pre-commit state between the earlier polls, so a
+    /// continuation started there must not resume over the switched
+    /// memberships.
     pub(in crate::manager) fn finish_clean_policy_transition_commit(&mut self) {
         self.refresh_update_group_gauges();
         self.refresh_group_residue_gauge();
+        self.advance_advertised_pages();
     }
 
     /// Build the shared old→new inventory for one batched authoritative

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -23,6 +23,23 @@ rather than committing.
 RIB compensation is one rollback-only exact batch with ordered receipts and
 the normal two-minute batch-reply bound.
 
+**Amended:** 2026-09-11 — operator reads are served during the cohort RIB
+transition instead of waiting for its commit. The forward reload owner
+admits its bounded operator-read lane (session snapshots, import-statistics
+collections, dataset status) while it awaits the batched RIB reply, on the
+same terms as the destination prestage: every cohort session already runs
+its new chains, so a read observes the same mixed per-session generation
+prestage admits, and the ordinary command receiver stays unpolled. The RIB
+run loop serves one bounded general-query budget between pre-commit
+transition polls from the primary state, which no pre-commit phase changes,
+so such a read returns exactly the pre-commit generation; the query lane
+carries only reads, mutations stay queued on the primary channel, and the
+`CommitMembers` batches keep the full fence. The terminal commit advances
+the advertised page generation so a route listing started before the commit
+cannot resume across it. Section 1's "only the readiness lane" wording and
+Section 5's "no general query is admitted" describe the design before this
+amendment. Rollback and standalone policy transactions are unchanged.
+
 ## Context
 
 A live policy reload can move hundreds of route-reflector or route-server

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -608,10 +608,19 @@ The existing request deadlines still apply under sustained read load.
 During a forward generation's export-destination prestaging, neighbor inventory
 and policy-statistics reads can inspect the installed generation while the RIB
 prepares the candidate destination. These reads retain their existing deadlines.
-Once session policy application starts, operator reads wait for settlement;
-rollback and standalone policy transactions keep the same fence. Readiness
-queries remain available at their existing transaction seams. A congested backend
-or a later transaction stage can still exhaust an operator read's deadline.
+Once session policy application starts, operator reads wait for that
+per-session step to finish; while the daemon then awaits the batched RIB
+transition for the cohort, they are served again: the peer manager answers
+session snapshots and import-statistics collections (each cohort session
+already runs its new chains, so a per-session row may show either generation,
+exactly as during prestaging), and the RIB answers general queries between its
+pre-commit transition polls from the pre-commit state. Reads that arrive during
+the RIB's short commit batches wait for the commit, which remains the single
+switch point; a route listing started before the commit cannot be continued
+across it. Rollback and standalone policy transactions keep the full fence.
+Readiness queries remain available at their existing transaction seams. A
+congested backend or a later transaction stage can still exhaust an operator
+read's deadline.
 
 For a dataset content generation, every file must load successfully before
 publication. The daemon retains prior snapshots and loader errors, reserves
@@ -1302,7 +1311,7 @@ exactly under the floods these drops account for.
 | `bgp_rib_outbound_registration_failover_total{peer}` | Outbound registrations handed to another live session for the same address after the active session's `PeerDown`/GR-down (the symmetric collision interleaving: the loser's `PeerUp` replaced the winner's registration before the loser went down). The exact nonzero, unambiguous survivor enters `awaiting_refresh`, is re-registered, receives the staged initial table without EoR, and is asked for an inbound ROUTE-REFRESH; matching post-failback BoRR/EoRR completes convergence |
 | `bgp_rib_dirty_resync_total{outcome}` | Dirty-peer resync timer fires, by `cleared` / `still_dirty` |
 | `bgp_rib_ingest_channel_depth` | RIB manager ingest queue depth, sampled once per manager loop iteration; pegged at capacity means producers are parked on backpressure |
-| `bgp_rib_policy_transition_in_progress` | Whether the RIB actor owns an atomic export-policy transition (`1` = in progress). General RIB queries and mutations remain fenced while the dedicated core-readiness lane remains responsive |
+| `bgp_rib_policy_transition_in_progress` | Whether the RIB actor owns an atomic export-policy transition (`1` = in progress). Mutations remain fenced until the transition is terminal; general RIB queries are served from the pre-commit state between the pre-commit polls and wait only through the commit batches, while the dedicated core-readiness lane remains responsive throughout |
 | `bgp_rib_policy_transition_last_duration_milliseconds` | Monotonic elapsed duration of the most recently completed atomic export-policy transition; retained across idle periods for post-event diagnosis |
 | `bgp_rib_policy_transition_actor_poll_duration_seconds{poll_kind}` | Duration of each real RIB actor transition poll. Bounded `poll_kind` values are `bounded` (chunked phase work), `prefix_snapshot` (the two complete O(table) snapshot polls), `finalize` (atomic membership/emission commit plus the global dirty/forced retry opportunity), and `commit` (bounded `CommitMembers` batches — at most eight members flushed per poll) |
 | `bgp_rib_policy_transition_total{outcome}` | Terminal actor-owned policy transitions. `committed` means the atomic cohort transition committed; `fallback_handoff` means uncommitted cleanup succeeded and authoritative per-peer apply is required; `fallback_cleanup_error` means that cleanup failed. Empty, rejected, missing, in-progress, abandoned, continued, pre-ownership, and synthetic actor-exit paths do not increment it |

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -909,6 +909,44 @@ impl PeerManager {
         }
     }
 
+    /// Like [`Self::await_with_readiness`], optionally admitting the bounded
+    /// operator-read lane as well. Only the forward reload owner passes
+    /// `true`, and only while it awaits the cohort's RIB transition: every
+    /// cohort session already runs its new chains at that point, so a read
+    /// admitted here observes the same mixed per-session generation the
+    /// destination prestage already admits, and the ordinary command
+    /// receiver stays unpolled so mutations remain strictly behind the
+    /// transaction. Each admitted read completes (through the readiness-only
+    /// helper, as during prestage) before the wait resumes.
+    async fn await_with_readiness_and_operator_reads<F>(
+        &mut self,
+        future: F,
+        allow_operator_reads: bool,
+    ) -> F::Output
+    where
+        F: Future,
+    {
+        tokio::pin!(future);
+        loop {
+            tokio::select! {
+                biased;
+                result = &mut future => return result,
+                query = Self::receive_readiness_query(&mut self.readiness_rx) => {
+                    match query {
+                        Some(query) => self.handle_readiness_query(query).await,
+                        None => self.readiness_rx = None,
+                    }
+                }
+                query = Self::receive_operator_query(&mut self.operator_rx, &mut self.deferred_operator_queries), if allow_operator_reads => {
+                    match query {
+                        Some(query) => self.handle_operator_query(query, true).await,
+                        None => self.operator_rx = None,
+                    }
+                }
+            }
+        }
+    }
+
     /// Like [`Self::await_with_readiness`], but bound the transaction step by
     /// a budget that accrues only while the step itself is being driven. Wall
     /// time spent servicing an interleaved readiness query is not charged: a
@@ -929,8 +967,10 @@ impl PeerManager {
             .await
     }
 
-    /// Only a forward reload's initial destination prestage may admit operator
-    /// snapshots. All other transaction waits keep this lane fenced.
+    /// Only a forward reload admits operator snapshots, during its initial
+    /// destination prestage here and while it awaits the cohort RIB
+    /// transition in [`Self::await_with_readiness_and_operator_reads`]. All
+    /// other transaction waits keep this lane fenced.
     async fn await_with_readiness_and_operator_budget<F>(
         &mut self,
         future: F,

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -1814,7 +1814,10 @@ impl PeerManager {
             .await;
         let cohort_result = match send_result {
             Err(_) => Err("RIB manager unavailable".to_string()),
-            Ok(()) => self.await_export_policy_cohort_rib_reply(reply_rx).await,
+            Ok(()) => {
+                self.await_export_policy_cohort_rib_reply(reply_rx, allow_operator_reads)
+                    .await
+            }
         };
         let rib_result = match cohort_result {
             Ok(ExportPolicyCohortOutcome::Committed) => Ok(()),
@@ -1828,8 +1831,11 @@ impl PeerManager {
                 if prestaged {
                     self.discard_prepared_export_destination(targets[0]).await;
                 }
-                self.apply_export_policy_replacements_authoritatively(&replacements)
-                    .await
+                self.apply_export_policy_replacements_authoritatively(
+                    &replacements,
+                    allow_operator_reads,
+                )
+                .await
             }
             Err(error) => Err(error),
         };
@@ -2010,17 +2016,25 @@ impl PeerManager {
             .await;
     }
 
-    /// Await the cohort RIB reply while admitting only the dedicated
-    /// read-only readiness lane. The ordinary command receiver stays owned by
-    /// the run loop and is not polled, so mutations remain strictly behind the
-    /// transaction. Dropping the transaction caller does not cancel a
-    /// partially applied policy: this actor still drives commit or rollback to
-    /// completion before returning to the normal lane.
+    /// Await the cohort RIB reply while admitting the dedicated read-only
+    /// readiness lane and, for the forward reload owner, the bounded
+    /// operator-read lane: the cohort sessions already run their new chains,
+    /// so an operator read here sees the same mixed generation prestage
+    /// admits, and the RIB answers its side from the pre-commit state. The
+    /// ordinary command receiver stays owned by the run loop and is not
+    /// polled, so mutations remain strictly behind the transaction. Dropping
+    /// the transaction caller does not cancel a partially applied policy:
+    /// this actor still drives commit or rollback to completion before
+    /// returning to the normal lane.
     async fn await_export_policy_cohort_rib_reply(
         &mut self,
         reply_rx: oneshot::Receiver<Result<ExportPolicyCohortOutcome, String>>,
+        allow_operator_reads: bool,
     ) -> Result<ExportPolicyCohortOutcome, String> {
-        match self.await_with_readiness(reply_rx).await {
+        match self
+            .await_with_readiness_and_operator_reads(reply_rx, allow_operator_reads)
+            .await
+        {
             Err(_) => Err("RIB manager dropped cohort reply".to_string()),
             Ok(result) => result,
         }
@@ -2035,20 +2049,23 @@ impl PeerManager {
     /// — instead of one full-table resync per member. Peers no longer
     /// registered in the RIB are skipped inside the batch (a reconnect
     /// installs the desired policy), matching the prior per-peer loop. The
-    /// dedicated readiness lane is admitted throughout the send/reply.
+    /// dedicated readiness lane is admitted throughout the send/reply, plus
+    /// the operator-read lane on the same terms as the clean transition.
     async fn apply_export_policy_replacements_authoritatively(
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
+        allow_operator_reads: bool,
     ) -> Result<(), String> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let rib_tx = self.rib_tx.clone();
         if self
-            .await_with_readiness(rib_tx.send(
-                RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
+            .await_with_readiness_and_operator_reads(
+                rib_tx.send(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
                     replacements: replacements.to_vec(),
                     reply: reply_tx,
-                },
-            ))
+                }),
+                allow_operator_reads,
+            )
             .await
             .is_err()
         {
@@ -2056,7 +2073,7 @@ impl PeerManager {
         }
         let result = match tokio::time::timeout(
             super::RIB_BATCH_REPLY_TIMEOUT,
-            self.await_with_readiness(reply_rx),
+            self.await_with_readiness_and_operator_reads(reply_rx, allow_operator_reads),
         )
         .await
         {

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -737,3 +737,175 @@ async fn forward_walk_rib_budget_stops_expired_retained_proofs() {
         "the expired third proof must not be admitted"
     );
 }
+
+/// Established session for the cohort read test: hot-applies export policy
+/// immediately, answers state queries as Established, and answers the
+/// import-stats query so the fleet collection can complete.
+fn cohort_session_with_import_stats(addr: IpAddr, installs: Arc<AtomicUsize>) -> PeerHandle {
+    let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
+    let task = tokio::spawn(async move {
+        while let Some(command) = session_rx.recv().await {
+            match command {
+                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                    installs.fetch_add(1, Ordering::SeqCst);
+                    let _ = reply.send(Ok(()));
+                }
+                PeerCommand::QueryState { reply } => {
+                    let _ = reply.send(policy_test_peer_state(addr, SessionState::Established));
+                }
+                PeerCommand::QueryImportPolicyTermHits { reply } => {
+                    let _ = reply.send(Some(rustbgpd_transport::ImportPolicyTermHits {
+                        generation: 1,
+                        evals: 0,
+                        eval_errors: 0,
+                        last_error: None,
+                        terms: Vec::new(),
+                    }));
+                }
+                PeerCommand::Shutdown => break,
+                _ => {}
+            }
+        }
+        Ok(())
+    });
+    PeerHandle::from_parts(session_tx, task)
+}
+
+/// Stub RIB that holds the cohort reply: signals `held` once the batched
+/// replacement arrives and answers `Committed` only after `release` fires.
+fn rib_holding_cohort_reply(
+    mut rib_rx: mpsc::Receiver<RibUpdate>,
+    held: oneshot::Sender<()>,
+    release: oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut held = Some(held);
+        let mut release = Some(release);
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::PrepareExportPolicyDestination { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    if let Some(held) = held.take() {
+                        let _ = held.send(());
+                    }
+                    let release = release.take();
+                    tokio::spawn(async move {
+                        if let Some(release) = release {
+                            let _ = release.await;
+                        }
+                        let _ = reply.send(Ok(rustbgpd_rib::ExportPolicyCohortOutcome::Committed));
+                    });
+                }
+                _ => {}
+            }
+        }
+    })
+}
+
+/// Operator reads admitted while the forward reload awaits the cohort RIB
+/// reply: with the RIB still owning the transition (its reply held here),
+/// a neighbor snapshot and the fleet import-stats collection both complete
+/// on the operator lane instead of waiting behind the transition. Awaiting
+/// the reply with the readiness-only helper parks both reads until the
+/// held reply is released and fails the bounded expectations below.
+#[tokio::test(start_paused = true)]
+async fn operator_reads_are_served_while_the_cohort_rib_reply_is_held() {
+    use rustbgpd_api::peer_types::{PeerManagerOperatorQuery, ResolvedPeerPolicy};
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 38, 0, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 38, 0, 2));
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let (held_tx, held_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let rib = rib_holding_cohort_reply(rib_rx, held_tx, release_rx);
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let (operator_tx, operator_rx) = mpsc::channel(4);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_operator_queries(operator_rx);
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            cohort_session_with_import_stats(peer, Arc::clone(&installs)),
+            false,
+        );
+    }
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+    let reload = tokio::spawn(async move {
+        let result = manager
+            .apply_resolved_policy_snapshot_with_prestage_reads(targets, false, true)
+            .await;
+        (manager, result)
+    });
+
+    // The RIB owns the transition: every cohort session already runs the
+    // new chain and the reply is held until released below.
+    held_rx.await.unwrap();
+    assert_eq!(installs.load(Ordering::SeqCst), 2);
+    let (reply, response) = oneshot::channel();
+    operator_tx
+        .send(PeerManagerOperatorQuery::ListPeers { reply })
+        .await
+        .unwrap();
+    let infos = tokio::time::timeout(Duration::from_secs(1), response)
+        .await
+        .expect("a neighbor snapshot is answered while the cohort RIB reply is awaited")
+        .unwrap();
+    assert_eq!(infos.len(), 2);
+    let (reply, response) = oneshot::channel();
+    operator_tx
+        .send(PeerManagerOperatorQuery::QueryImportPolicyTermHits {
+            peer: None,
+            deadline: tokio::time::Instant::now() + Duration::from_secs(2),
+            reply,
+        })
+        .await
+        .unwrap();
+    let rows = tokio::time::timeout(Duration::from_secs(1), response)
+        .await
+        .expect("the import-stats collection is answered while the cohort RIB reply is awaited")
+        .unwrap();
+    assert!(
+        matches!(rows, SessionQueryOutcome::Reply(ref rows) if rows.len() == 2),
+        "{rows:?}"
+    );
+    assert!(
+        !reload.is_finished(),
+        "the transaction stays parked on the held reply"
+    );
+
+    release_tx.send(()).unwrap();
+    let (mut manager, result) = reload.await.unwrap();
+    result.expect("the cohort commits once the held reply is released");
+    assert_eq!(
+        manager.peers.get(&key(first)).unwrap().export_policy,
+        Some(next)
+    );
+    for (_, managed) in manager.peers.drain() {
+        managed.handle.shutdown().await.unwrap().unwrap();
+    }
+    drop(manager);
+    rib.await.unwrap();
+}

--- a/src/peer_manager/tests/reload_generation.rs
+++ b/src/peer_manager/tests/reload_generation.rs
@@ -1120,18 +1120,32 @@ async fn assert_generation_operator_read_boundaries(compensate: bool) {
             .await
             .unwrap();
         ping.await.unwrap();
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), &mut response)
+        let queued_response = if compensate {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(20), &mut response)
+                    .await
+                    .is_err(),
+                "operator reads must stay fenced during rollback"
+            );
+            Some(response)
+        } else {
+            // The forward owner keeps admitting operator reads while the
+            // cohort RIB reply is held: the sessions already run their new
+            // chains, so the snapshot observes the same mixed generation
+            // prestage admits rather than waiting for the commit.
+            let infos = tokio::time::timeout(Duration::from_secs(1), &mut response)
                 .await
-                .is_err(),
-            "operator reads must stay fenced after session application and during rollback"
-        );
+                .expect("operator reads are served while the cohort RIB reply is held")
+                .unwrap();
+            assert_eq!(infos.len(), 3);
+            None
+        };
         assert!(matches!(
             mutation_response.try_recv(),
             Err(oneshot::error::TryRecvError::Empty)
         ));
         rib_tx.send(held).await.unwrap();
-        (response, mutation_response)
+        (queued_response, mutation_response)
     };
     let (outcome, (operator_response, mutation_response)) =
         tokio::time::timeout(Duration::from_secs(5), async {
@@ -1154,7 +1168,9 @@ async fn assert_generation_operator_read_boundaries(compensate: bool) {
     }
     let manager = tokio::spawn(harness.mgr.run());
     tokio::time::timeout(Duration::from_secs(1), async {
-        assert_eq!(operator_response.await.unwrap().len(), 3);
+        if let Some(operator_response) = operator_response {
+            assert_eq!(operator_response.await.unwrap().len(), 3);
+        }
         let _ = mutation_response.await.unwrap();
         command_tx.send(PeerManagerCommand::Shutdown).await.unwrap();
         manager.await.unwrap();
@@ -1168,7 +1184,7 @@ async fn assert_generation_operator_read_boundaries(compensate: bool) {
 }
 
 #[tokio::test(start_paused = true)]
-async fn forward_generation_services_operator_reads_only_during_prestage() {
+async fn forward_generation_services_operator_reads_through_the_cohort_transition() {
     assert_generation_operator_read_boundaries(false).await;
 }
 


### PR DESCRIPTION
## What changed

A SIGHUP reload's batched export-policy transition parked operator reads in both actors until its commit. The peer manager awaited the cohort RIB reply with only the readiness lane admitted (`await_export_policy_cohort_rib_reply`), and the RIB served no general query while `pending_clean_policy_transition` was owned. At 1000 peers the transition runs about 0.7–2 s, so `rbgp policy stats --direction both` and `rbgp neighbor` arriving more than about 0.8 s before the commit exhausted their shared two-second budget with `DEADLINE_EXCEEDED`.

- **Peer manager** (`src/peer_manager/mod.rs`, `src/peer_manager/policy.rs`): `await_with_readiness_and_operator_reads` is the readiness-only wait plus the existing bounded operator-read lane; the forward reload owner (`allow_operator_reads`, the same flag prestage already uses) passes it through `await_export_policy_cohort_rib_reply` and the authoritative-batch fallback. Each admitted read completes through the existing `handle_operator_query(.., during_prestage = true)` path before the wait resumes; the ordinary command receiver stays unpolled, so mutations remain strictly behind the transaction. Rollback and standalone policy transactions are unchanged (fenced).
- **RIB** (`crates/rib/src/manager/mod.rs`, `crates/rib/src/manager/update_groups/policy_transition.rs`): `drain_general_queries_between_transition_polls` serves one `QUERY_BUDGET_PER_CHUNK` budget between transition polls while the parked phase is pre-commit (`poll_kind() != Commit`). No pre-commit phase changes committed membership, policy, counters, or wire state, so the answer is exactly the pre-commit generation. The `CommitMembers` batches keep the fence (membership and counters move per batch), and the terminal commit now advances the advertised page generation so a paged listing started before the commit cannot resume across it. The query lane carries only reads (every mutation sender in the daemon and API uses the primary channel), so nothing served here can invalidate the parked phase.

Budgets, the atomic commit, and rollback fencing are unchanged. No metrics were added.

## Why

Per-run phase attribution (both failing soak runs) placed the wait in the cohort RIB transition: latency ≈ time remaining until commit + a post-commit tail, so any read arriving more than ~0.8 s before commit failed. Prestage reads were already admitted and already observed a mixed per-session generation, so the transition wait was not a stricter consistency window than prestage — only the actor was blocked.

## Evidence

Local reproduction: the unchanged flagship runner (`tests/soak/run-soak-rs-flagship.sh`, 1000 peers × 400 routes, 12 reloads at 40 s, one max-prefix trip, daemon and engine pinned to two cores, the management driver's 5 s cadence unchanged) plus a probe driver that fires `rbgp policy stats --direction both` and `rbgp neighbor` at prestage-end +0.00/+0.15/+0.30/+0.60 s, i.e. inside the transition. Arrival is measured against the reload's own `reload generation phase timing` record (commit). Same box, same pinning, idle otherwise, baseline and fixed back to back.

| arrival vs commit | baseline (main) | fixed |
| --- | --- | --- |
| −0.82 … −0.35 s (72 probes) | 2,008–3,541 ms, **72/72 failed** | 16–101 ms, 0/72 failed |
| −0.22 … −0.00 s (24 probes) | 2,837–3,295 ms, 10/24 failed | 2,746–3,091 ms, 8/24 failed |
| runner's own 5 s cadence (242 ops) | 5 failures | 0 failures |

Reload timing is unchanged: `cohort_rib_transition_us` 602–820 ms baseline vs 648–818 ms fixed; `total_us` 1.20–1.46 s vs 1.22–1.60 s; 12/12 committed, no fallback, no rejection in either run.

The second row is the post-commit tail, not this fix's seam: those reads arrive during the fenced commit batches and are then answered while the RIB drains the primary backlog queued behind the transition and the 1000 sessions write the shared flush on two cores. Their audit records show both stages slow after the commit (export 0.66–2.23 s, import 0.67–1.34 s). It is the same tail the soak attribution called "~1.2 s after commit" on the eight-vCPU host; it is left named for a follow-up.

## Tests

- `crates/rib/src/manager/tests/update_groups.rs::general_queries_served_between_precommit_polls_and_fenced_during_commit` — an advertised page queued on the query lane is answered between pre-commit polls with the old policy and the acceptance-time page version, stays queued through a parked commit batch, and after the terminal commit is answered with the new policy under a new page version. Mutation-checked: a no-op between-poll drain fails the first assertion; dropping the commit-time page advance fails the version assertion.
- `src/peer_manager/tests/cohort_budgets.rs::operator_reads_are_served_while_the_cohort_rib_reply_is_held` — a stub RIB holds the cohort reply; `ListPeers` and the fleet `QueryImportPolicyTermHits` collection both complete within one second on the operator lane while the transaction stays parked. Fails on main (`Elapsed`).
- `crates/rib/src/manager/tests/update_groups.rs::clean_policy_transition_isolates_readiness_from_general_query_flood` — asserted the RIB fence (every flooded general query stays parked while the transition is owned); it now asserts the replacement contract: readiness still overtakes the saturated lane, and general queries are answered from the pre-commit state in at most one `QUERY_BUDGET_PER_CHUNK` budget per transition poll. The acceptance-time page-version test keeps its assertion with the commit-time advance documented.
- `src/peer_manager/tests/reload_generation.rs` — the existing boundary test codified the old fence; its forward arm now expects the snapshot to be served while the replacement is held (renamed `forward_generation_services_operator_reads_through_the_cohort_transition`), and the rollback arm still asserts the fence. The forward arm fails on main.

## Compatibility

Operator-visible: `rbgp policy stats` and `rbgp neighbor` answer during a reload's export-policy transition instead of failing their deadline; a per-session row may show either generation during that window (as during prestaging already), and a paged route listing started before the commit is invalidated at the commit. CHANGELOG entry under Unreleased/Fixed; `docs/reference/operations.md` and ADR-0105 (dated amendment) updated.

## Gates (local, this branch)

- `cargo fmt --all -- --check`: rc=0
- `just gate-rib`: rc=0
- `just gate`: rc=0 (third run; first run failed on the flood test revised above, second on an unrelated `authz_runtime` parallel-subscriber flake that passes alone — both logs retained)
