### PR TITLE
feat(rib): log post-commit first general query timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   committed export-policy transition that an operator read follows within
   ten seconds: the terminal commit poll's duration, the general queries and
   primary updates queued at commit, the wall-clock wait from the end of that
-  poll to the first general query served, the route-chunk, primary-update,
-  and dirty-resync work the actor ran in that span, and the unattributed
-  remainder (time the actor task was parked or not scheduled). It attributes
-  the operator-read tail across a reload commit; actor scheduling is
-  unchanged.
+  poll to the first general query dispatched, elapsed wall time inside
+  route-chunk, primary-update, and dirty-resync work in that span, and the
+  unattributed remainder (including other actor work, idle time, and
+  scheduling delays). This describes the RIB side before query execution,
+  not end-to-end operator latency; actor scheduling is unchanged.
 
 - Added `bgp_rib_actor_work_duration_seconds{work_unit}` and
   `bgp_rib_readiness_query_wait_seconds{seam}`. The first times route-chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The RIB logs one `post-commit first general query timing` record per
+  committed export-policy transition that an operator read follows within
+  ten seconds: the terminal commit poll's duration, the general queries and
+  primary updates queued at commit, the wall-clock wait from the end of that
+  poll to the first general query served, the route-chunk, primary-update,
+  and dirty-resync work the actor ran in that span, and the unattributed
+  remainder (time the actor task was parked or not scheduled). It attributes
+  the operator-read tail across a reload commit; actor scheduling is
+  unchanged.
+
 - Added `bgp_rib_actor_work_duration_seconds{work_unit}` and
   `bgp_rib_readiness_query_wait_seconds{seam}`. The first times route-chunk
   construction and processing, coalesced outbound distribution, and subsequent

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -2204,11 +2204,19 @@ impl RibManager {
             let Ok(query) = self.query_rx.try_recv() else {
                 break;
             };
-            if let Some(trace) = self.post_commit_query_trace.take() {
-                trace.emit();
-            }
-            self.handle_update(query);
+            self.serve_general_query(query);
         }
+    }
+
+    /// Serve one item received from the general query lane. Every delivery
+    /// path (the bounded drains and both event-loop select arms) goes
+    /// through here so the post-commit query trace is consumed by the
+    /// first general query actually served, whichever path serves it.
+    fn serve_general_query(&mut self, query: RibUpdate) {
+        if let Some(trace) = self.post_commit_query_trace.take() {
+            trace.emit();
+        }
+        self.handle_update(query);
     }
 
     /// Run one actor work unit, accounting its duration to the post-commit
@@ -4440,7 +4448,7 @@ impl RibManager {
                     }
                     query = self.query_rx.recv(), if query_rx_open => {
                         match query {
-                            Some(q) => self.handle_update(q),
+                            Some(q) => self.serve_general_query(q),
                             None => query_rx_open = false,
                         }
                     }
@@ -4526,7 +4534,7 @@ impl RibManager {
                     }
                     query = self.query_rx.recv(), if query_rx_open => {
                         match query {
-                            Some(q) => self.handle_update(q),
+                            Some(q) => self.serve_general_query(q),
                             None => query_rx_open = false,
                         }
                     }

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -827,9 +827,9 @@ pub struct RibManager {
     /// interleave; general queries, primary mutations, and timers remain
     /// ordered behind the final commit or fail-closed fallback handoff.
     pending_clean_policy_transition: Option<distribution::PendingCleanPolicyTransition>,
-    /// Attribution of the first general query served after a committed
+    /// Attribution of the first general query dispatched after a committed
     /// transition; armed by the terminal commit poll, finished by the next
-    /// general-query drain.
+    /// general-query dispatch on any delivery path.
     post_commit_query_trace: Option<PostCommitQueryTrace>,
     /// In-progress unfenced staging of a prospective clean-transition
     /// destination group (`RibUpdate::PrepareExportPolicyDestination`).
@@ -948,13 +948,13 @@ const SLOW_POLICY_TRANSITION: std::time::Duration = std::time::Duration::from_se
 pub(in crate::manager) const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration =
     std::time::Duration::from_secs(30);
 
-/// A general query served later than this after a committed transition is
-/// unrelated to the commit; the trace is dropped instead of reporting the
-/// idle gap as a wait.
+/// Limit the observation window after a committed transition. Queries
+/// arriving after it do not emit a record; the interval alone cannot
+/// establish whether a query was delayed by the commit.
 const POST_COMMIT_QUERY_TRACE_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Actor work units accounted between a transition's terminal commit poll and
-/// the first general query served afterwards.
+/// the first general query dispatched afterwards.
 #[derive(Clone, Copy)]
 enum PostCommitWork {
     RouteChunk,
@@ -963,14 +963,16 @@ enum PostCommitWork {
 }
 
 /// What the actor ran between a committed clean policy transition's terminal
-/// poll and the first general query it served afterwards. One
+/// poll and the first general query it dispatches afterwards. One
 /// `post-commit first general query timing` record per committed transition
 /// that a general query follows within [`POST_COMMIT_QUERY_TRACE_WINDOW`]:
 /// `first_query_wait_us` is wall-clock from the end of the terminal poll,
-/// `busy_us` the actor work run in that span, and `unattributed_us` the
-/// remainder — time the actor task was parked or not scheduled. With
-/// `queued_general_queries > 0` the query was already waiting at commit, so
-/// the whole wait is the operator-visible post-commit tail.
+/// `busy_us` the elapsed wall time inside the three instrumented work
+/// classes, and `unattributed_us` the remainder, including uninstrumented
+/// actor work, idle time, and scheduling delays outside those classes.
+/// Dispatch is measured before the query handler runs, not at reply
+/// completion. With `queued_general_queries > 0`, a query was already
+/// waiting at commit; otherwise the interval also includes arrival delay.
 struct PostCommitQueryTrace {
     since: std::time::Instant,
     member_count: usize,
@@ -2211,7 +2213,7 @@ impl RibManager {
     /// Serve one item received from the general query lane. Every delivery
     /// path (the bounded drains and both event-loop select arms) goes
     /// through here so the post-commit query trace is consumed by the
-    /// first general query actually served, whichever path serves it.
+    /// first general query dispatched, whichever path delivers it.
     fn serve_general_query(&mut self, query: RibUpdate) {
         if let Some(trace) = self.post_commit_query_trace.take() {
             trace.emit();

--- a/crates/rib/src/manager/mod.rs
+++ b/crates/rib/src/manager/mod.rs
@@ -827,6 +827,10 @@ pub struct RibManager {
     /// interleave; general queries, primary mutations, and timers remain
     /// ordered behind the final commit or fail-closed fallback handoff.
     pending_clean_policy_transition: Option<distribution::PendingCleanPolicyTransition>,
+    /// Attribution of the first general query served after a committed
+    /// transition; armed by the terminal commit poll, finished by the next
+    /// general-query drain.
+    post_commit_query_trace: Option<PostCommitQueryTrace>,
     /// In-progress unfenced staging of a prospective clean-transition
     /// destination group (`RibUpdate::PrepareExportPolicyDestination`).
     /// Advanced one budgeted slice at a time only when no ordinary
@@ -943,6 +947,75 @@ const SLOW_POLICY_TRANSITION: std::time::Duration = std::time::Duration::from_se
 /// once ownership is far beyond any legitimate transition receipt.
 pub(in crate::manager) const MAX_HEALTHY_POLICY_TRANSITION_AGE: std::time::Duration =
     std::time::Duration::from_secs(30);
+
+/// A general query served later than this after a committed transition is
+/// unrelated to the commit; the trace is dropped instead of reporting the
+/// idle gap as a wait.
+const POST_COMMIT_QUERY_TRACE_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Actor work units accounted between a transition's terminal commit poll and
+/// the first general query served afterwards.
+#[derive(Clone, Copy)]
+enum PostCommitWork {
+    RouteChunk,
+    PrimaryUpdate,
+    ResyncTick,
+}
+
+/// What the actor ran between a committed clean policy transition's terminal
+/// poll and the first general query it served afterwards. One
+/// `post-commit first general query timing` record per committed transition
+/// that a general query follows within [`POST_COMMIT_QUERY_TRACE_WINDOW`]:
+/// `first_query_wait_us` is wall-clock from the end of the terminal poll,
+/// `busy_us` the actor work run in that span, and `unattributed_us` the
+/// remainder — time the actor task was parked or not scheduled. With
+/// `queued_general_queries > 0` the query was already waiting at commit, so
+/// the whole wait is the operator-visible post-commit tail.
+struct PostCommitQueryTrace {
+    since: std::time::Instant,
+    member_count: usize,
+    terminal_poll: std::time::Duration,
+    queued_general_queries: usize,
+    ingest_backlog: usize,
+    busy: std::time::Duration,
+    route_chunks: u32,
+    primary_updates: u32,
+    resync_ticks: u32,
+}
+
+impl PostCommitQueryTrace {
+    fn record(&mut self, unit: PostCommitWork, elapsed: std::time::Duration) {
+        self.busy += elapsed;
+        let counter = match unit {
+            PostCommitWork::RouteChunk => &mut self.route_chunks,
+            PostCommitWork::PrimaryUpdate => &mut self.primary_updates,
+            PostCommitWork::ResyncTick => &mut self.resync_ticks,
+        };
+        *counter = counter.saturating_add(1);
+    }
+
+    fn emit(self) {
+        let wait = self.since.elapsed();
+        if wait > POST_COMMIT_QUERY_TRACE_WINDOW {
+            return;
+        }
+        let micros =
+            |duration: std::time::Duration| u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        info!(
+            member_count = self.member_count,
+            terminal_poll_us = micros(self.terminal_poll),
+            queued_general_queries = self.queued_general_queries,
+            ingest_backlog_at_commit = self.ingest_backlog,
+            first_query_wait_us = micros(wait),
+            busy_us = micros(self.busy),
+            unattributed_us = micros(wait.saturating_sub(self.busy)),
+            route_chunks = self.route_chunks,
+            primary_updates = self.primary_updates,
+            resync_ticks = self.resync_ticks,
+            "post-commit first general query timing"
+        );
+    }
+}
 
 struct ReplacementReadiness {
     #[cfg(feature = "bench-internals")]
@@ -1667,6 +1740,7 @@ impl RibManager {
             replacement_readiness_receipts: Vec::new(),
             pending_route_batches: VecDeque::new(),
             pending_clean_policy_transition: None,
+            post_commit_query_trace: None,
             pending_destination_prestage: None,
             prepared_destination: None,
             pending_exact_export_withdrawals: HashSet::new(),
@@ -2130,8 +2204,39 @@ impl RibManager {
             let Ok(query) = self.query_rx.try_recv() else {
                 break;
             };
+            if let Some(trace) = self.post_commit_query_trace.take() {
+                trace.emit();
+            }
             self.handle_update(query);
         }
+    }
+
+    /// Run one actor work unit, accounting its duration to the post-commit
+    /// query trace while one is armed.
+    fn traced<T>(&mut self, unit: PostCommitWork, work: impl FnOnce(&mut Self) -> T) -> T {
+        if self.post_commit_query_trace.is_none() {
+            return work(self);
+        }
+        let started = std::time::Instant::now();
+        let out = work(self);
+        if let Some(trace) = self.post_commit_query_trace.as_mut() {
+            trace.record(unit, started.elapsed());
+        }
+        out
+    }
+
+    /// [`Self::process_next_route_chunk`] under the post-commit query trace:
+    /// only a processed chunk counts, not the empty-queue probe.
+    fn traced_route_chunk(&mut self) -> bool {
+        if self.post_commit_query_trace.is_none() {
+            return self.process_next_route_chunk();
+        }
+        let started = std::time::Instant::now();
+        let processed = self.process_next_route_chunk();
+        if processed && let Some(trace) = self.post_commit_query_trace.as_mut() {
+            trace.record(PostCommitWork::RouteChunk, started.elapsed());
+        }
+        processed
     }
 
     /// Preserve the policy-transition ownership fence when a primary update
@@ -2419,19 +2524,21 @@ impl RibManager {
         // Route batches are actor-deferred for fairness. During a timer race,
         // however, preserve channel order: an EoR or timeout must not release
         // selection before route payloads accepted ahead of it are applied.
-        while self.process_next_route_chunk() {
+        while self.traced_route_chunk() {
             drained = true;
         }
         while let Ok(update) = self.rx.try_recv() {
             drained = true;
-            self.handle_update(update);
+            self.traced(PostCommitWork::PrimaryUpdate, |manager| {
+                manager.handle_update(update);
+            });
             if self.pending_clean_policy_transition.is_some() {
                 // The accepted cohort command now owns FIFO. Leave every
                 // later primary update queued until its atomic finalize or
                 // fail-closed fallback handoff completes.
                 break;
             }
-            while self.process_next_route_chunk() {
+            while self.traced_route_chunk() {
                 drained = true;
             }
         }
@@ -4082,6 +4189,9 @@ impl RibManager {
                 .set_rib_ingest_channel_depth(i64::try_from(self.rx.len()).unwrap_or(i64::MAX));
 
             if let Some(mut pending) = self.pending_clean_policy_transition.take() {
+                // A newly owned transition supersedes any trace still armed
+                // from the previous commit.
+                self.post_commit_query_trace = None;
                 // The type-narrow readiness lane interleaves at every poll,
                 // and a bounded general-query budget between pre-commit
                 // polls (see `drain_general_queries_between_transition_polls`).
@@ -4120,6 +4230,17 @@ impl RibManager {
                         if let Some(reply) = reply {
                             terminal_reply = Some((reply, Ok(crate::update::ExportPolicyCohortOutcome::Committed)));
                         }
+                        manager.post_commit_query_trace = Some(PostCommitQueryTrace {
+                            since: std::time::Instant::now(),
+                            member_count,
+                            terminal_poll: started.elapsed(),
+                            queued_general_queries: manager.query_rx.len(),
+                            ingest_backlog: manager.rx.len(),
+                            busy: std::time::Duration::ZERO,
+                            route_chunks: 0,
+                            primary_updates: 0,
+                            resync_ticks: 0,
+                        });
                         None
                     }
                     distribution::CleanPolicyTransitionAdvance::Fallback(mut failed) => {
@@ -4213,7 +4334,8 @@ impl RibManager {
                     count = self.dirty_peers.len(),
                     "resync timer fired for dirty peers"
                 );
-                let backlog = self.resync_dirty_peers_bounded();
+                let backlog =
+                    self.traced(PostCommitWork::ResyncTick, Self::resync_dirty_peers_bounded);
                 if self.resync_tick_pending() {
                     self.metrics.record_rib_dirty_resync("still_dirty");
                     let interval = if backlog {
@@ -4304,7 +4426,7 @@ impl RibManager {
                 continue;
             }
 
-            if self.process_next_route_chunk() {
+            if self.traced_route_chunk() {
                 self.drain_readiness_queries(None);
                 self.drain_queries(QUERY_BUDGET_PER_CHUNK);
                 tokio::task::yield_now().await;
@@ -4326,7 +4448,9 @@ impl RibManager {
                         match update {
                             Some(update) => {
                                 self.maybe_stall_test_ingest(&update).await;
-                                self.handle_update(update);
+                                self.traced(PostCommitWork::PrimaryUpdate, |manager| {
+                                    manager.handle_update(update);
+                                });
                                 self.drain_general_queries_if_unfenced();
                             }
                             None => break,
@@ -4337,7 +4461,8 @@ impl RibManager {
                             count = self.dirty_peers.len(),
                             "resync timer fired for dirty peers"
                         );
-                        let backlog = self.resync_dirty_peers_bounded();
+                        let backlog = self
+                            .traced(PostCommitWork::ResyncTick, Self::resync_dirty_peers_bounded);
 
                         // Reset for next tick if work remains, otherwise disarm.
                         if self.resync_tick_pending() {
@@ -4409,7 +4534,9 @@ impl RibManager {
                         match update {
                             Some(update) => {
                                 self.maybe_stall_test_ingest(&update).await;
-                                self.handle_update(update);
+                                self.traced(PostCommitWork::PrimaryUpdate, |manager| {
+                                    manager.handle_update(update);
+                                });
                                 self.drain_general_queries_if_unfenced();
                             }
                             None => break,

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -5234,6 +5234,204 @@ async fn post_commit_query_trace_accounts_work_until_first_general_query() {
     assert!(manager.post_commit_query_trace.is_none());
 }
 
+/// A committed transition arms the post-commit query trace and the first
+/// general query served afterwards consumes it, whichever event-loop path
+/// delivers that query. With the actor idle after the commit (no primary
+/// backlog) the delivering path is the query-lane select arm; a trace
+/// consumed only by the bounded drains survives that query, so the record
+/// is missing here and a later drain would report the whole idle gap as
+/// the wait.
+#[tokio::test(flavor = "current_thread")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one running-actor scenario carries the log capture, the committed transition, and both query paths"
+)]
+async fn post_commit_query_trace_is_consumed_by_idle_select_arm_query() {
+    use std::collections::BTreeMap;
+    use std::sync::Arc as StdArc;
+
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    #[derive(Default)]
+    struct Fields(BTreeMap<String, String>);
+    impl Visit for Fields {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+    struct Capture(StdArc<Mutex<Vec<Fields>>>);
+    impl Subscriber for Capture {
+        fn enabled(&self, _: &Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+        fn record(&self, _: &Id, _: &Record<'_>) {}
+        fn record_follows_from(&self, _: &Id, _: &Id) {}
+        fn event(&self, event: &Event<'_>) {
+            let mut fields = Fields::default();
+            event.record(&mut fields);
+            self.0.lock().unwrap().push(fields);
+        }
+        fn enter(&self, _: &Id) {}
+        fn exit(&self, _: &Id) {}
+    }
+    const RECORD: &str = "post-commit first general query timing";
+    let captured = StdArc::new(Mutex::new(Vec::new()));
+    let records = |captured: &Mutex<Vec<Fields>>| -> Vec<BTreeMap<String, String>> {
+        captured
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|fields| fields.0.get("message").is_some_and(|m| m.contains(RECORD)))
+            .map(|fields| fields.0.clone())
+            .collect()
+    };
+    // The run loop is spawned on this current-thread runtime, so the
+    // thread's default subscriber sees the actor's records.
+    let _subscriber = tracing::subscriber::set_default(Capture(StdArc::clone(&captured)));
+
+    let (tx, rx) = mpsc::channel(32);
+    let (query_tx, query_rx) = mpsc::channel(8);
+    let manager = RibManager::new(rx, query_rx, None, None, BgpMetrics::new());
+    let handle = tokio::spawn(manager.run());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let reuses = Arc::new(AtomicUsize::new(0));
+    let old_policy = community_chain(0xFDE8_2201);
+    let next_policy = community_chain(0xFDE8_2202);
+    let peers = [
+        IpAddr::V4(Ipv4Addr::new(10, 27, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 27, 0, 2)),
+    ];
+    let mut receivers = Vec::new();
+    for (index, peer) in peers.iter().copied().enumerate() {
+        let mut spec = PeerUpSpec::ibgp(peer);
+        spec.route_reflector_client = true;
+        spec.export_policy = Some(old_policy.clone());
+        receivers.push(
+            peer_up_with_cohort_encoder(
+                &tx,
+                spec,
+                Arc::new(CohortExactEncoder {
+                    owner: u64::try_from(index + 1).unwrap(),
+                    profile: 31,
+                    max_len: 4_096,
+                    generation: AtomicUsize::new(0),
+                    advance_generation: false,
+                    probes: Arc::clone(&probes),
+                    reuses: Arc::clone(&reuses),
+                }),
+            )
+            .await,
+        );
+    }
+    let source = Ipv4Addr::new(192, 0, 2, 16);
+    let routes_received = |prefix: Ipv4Prefix| RibUpdate::RoutesReceived {
+        session_id: 0,
+        peer: IpAddr::V4(source),
+        announced: vec![crate::test_support::make_route(prefix, source)],
+        withdrawn: vec![],
+        flowspec_announced: vec![],
+        flowspec_withdrawn: vec![],
+        evpn_announced: vec![],
+        evpn_withdrawn: vec![],
+    };
+    tx.send(routes_received(Ipv4Prefix::new(
+        Ipv4Addr::new(203, 0, 118, 0),
+        24,
+    )))
+    .await
+    .unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+
+    let (reply, response) = oneshot::channel();
+    tx.send(RibUpdate::ReplacePeerExportPolicies {
+        replacements: peers
+            .iter()
+            .map(|&peer| crate::update::PeerExportPolicyReplacement {
+                peer,
+                export_policy: Some(next_policy.clone()),
+            })
+            .collect(),
+        reply,
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        response.await.unwrap(),
+        Ok(crate::update::ExportPolicyCohortOutcome::Committed)
+    );
+    let committed_at = std::time::Instant::now();
+    for receiver in &mut receivers {
+        let update = receiver.recv().await.unwrap();
+        assert!(update.announce[0].attributes.iter().any(|attribute| {
+            matches!(attribute, PathAttribute::Communities(values) if values.contains(&0xFDE8_2202))
+        }));
+    }
+    assert!(
+        records(&captured).is_empty(),
+        "nothing is emitted before a query"
+    );
+
+    // Idle actor, then one general query delivered by the select arm.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let idle_gap = committed_at.elapsed();
+    let (reply, count) = oneshot::channel();
+    query_tx
+        .send(RibUpdate::QueryLocRibCount { reply })
+        .await
+        .unwrap();
+    assert_eq!(count.await.unwrap(), 1);
+    let first = records(&captured);
+    assert_eq!(
+        first.len(),
+        1,
+        "exactly one post-commit record after the first general query, \
+         served from the idle select arm: {first:?}"
+    );
+    let wait_us: u64 = first[0]["first_query_wait_us"].parse().unwrap();
+    let observed_us = u64::try_from(committed_at.elapsed().as_micros()).unwrap();
+    assert!(
+        wait_us >= u64::try_from(idle_gap.as_micros()).unwrap() && wait_us <= observed_us + 100_000,
+        "first_query_wait_us={wait_us} must match the observed idle gap \
+         ({idle_gap:?} .. {observed_us} us)"
+    );
+    assert_eq!(first[0]["queued_general_queries"], "0");
+
+    // A later primary update and its bounded drain find no trace to emit.
+    let (reply, count) = oneshot::channel();
+    query_tx
+        .try_send(RibUpdate::QueryLocRibCount { reply })
+        .unwrap();
+    tx.try_send(routes_received(Ipv4Prefix::new(
+        Ipv4Addr::new(203, 0, 119, 0),
+        24,
+    )))
+    .unwrap();
+    let _ = count.await.unwrap();
+    for receiver in &mut receivers {
+        assert_eq!(receiver.recv().await.unwrap().announce.len(), 1);
+    }
+    assert_eq!(
+        records(&captured).len(),
+        1,
+        "the trace is consumed once; a later drain emits nothing"
+    );
+
+    drop(tx);
+    drop(query_tx);
+    handle.await.unwrap();
+}
+
 /// With wall-clock budget in hand, the probe-and-prepare phase strides the
 /// whole cohort in a handful of polls instead of one route-slice per poll —
 /// the fenced pre-commit window must not scale with table x member count

--- a/crates/rib/src/manager/tests/update_groups.rs
+++ b/crates/rib/src/manager/tests/update_groups.rs
@@ -5158,6 +5158,82 @@ async fn general_queries_served_between_precommit_polls_and_fenced_during_commit
     assert_eq!(Some(page.version), manager.route_page_advertised_version);
 }
 
+/// The post-commit query trace counts the actor work run between the
+/// terminal commit poll and the next general query, and that query's drain
+/// consumes it: one attribution record per commit, and untraced drains
+/// leave nothing armed.
+#[tokio::test]
+async fn post_commit_query_trace_accounts_work_until_first_general_query() {
+    use super::super::{PostCommitQueryTrace, PostCommitWork};
+    const ROUTE_COUNT: usize = 2;
+    let (query_tx, query_rx) = mpsc::channel(8);
+    let (mut manager, _peers, _receivers) = direct_clean_transition_manager(2, ROUTE_COUNT, None);
+    manager.query_rx = query_rx;
+    assert!(!manager.traced_route_chunk());
+    assert!(manager.post_commit_query_trace.is_none());
+
+    manager.post_commit_query_trace = Some(PostCommitQueryTrace {
+        since: std::time::Instant::now(),
+        member_count: 2,
+        terminal_poll: std::time::Duration::from_millis(1),
+        queued_general_queries: 0,
+        ingest_backlog: 0,
+        busy: std::time::Duration::ZERO,
+        route_chunks: 0,
+        primary_updates: 0,
+        resync_ticks: 0,
+    });
+    let announced = vec![crate::test_support::make_route(
+        Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24),
+        Ipv4Addr::new(192, 0, 2, 42),
+    )];
+    manager.traced(PostCommitWork::PrimaryUpdate, |manager| {
+        manager.handle_update(RibUpdate::RoutesReceived {
+            session_id: 0,
+            peer: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 42)),
+            announced,
+            withdrawn: vec![],
+            flowspec_announced: vec![],
+            flowspec_withdrawn: vec![],
+            evpn_announced: vec![],
+            evpn_withdrawn: vec![],
+        });
+    });
+    while manager.traced_route_chunk() {}
+    let trace = manager
+        .post_commit_query_trace
+        .as_ref()
+        .expect("trace stays armed until a query");
+    assert_eq!(trace.primary_updates, 1);
+    assert_eq!(
+        trace.route_chunks, 1,
+        "only the processed chunk counts, not the empty-queue probe"
+    );
+    assert!(trace.busy > std::time::Duration::ZERO);
+
+    let (reply, mut response) = oneshot::channel();
+    query_tx
+        .try_send(RibUpdate::QueryExportPolicyTermHits { peer: None, reply })
+        .unwrap();
+    manager.drain_general_queries_if_unfenced();
+    assert!(
+        response.try_recv().is_ok(),
+        "the query is served by the drain that consumes the trace"
+    );
+    assert!(
+        manager.post_commit_query_trace.is_none(),
+        "the first general query consumes the trace"
+    );
+
+    let (reply, mut response) = oneshot::channel();
+    query_tx
+        .try_send(RibUpdate::QueryExportPolicyTermHits { peer: None, reply })
+        .unwrap();
+    manager.drain_general_queries_if_unfenced();
+    assert!(response.try_recv().is_ok());
+    assert!(manager.post_commit_query_trace.is_none());
+}
+
 /// With wall-clock budget in hand, the probe-and-prepare phase strides the
 /// whole cohort in a handful of polls instead of one route-slice per poll —
 /// the fenced pre-commit window must not scale with table x member count


### PR DESCRIPTION
## Summary

Attribution of the residual operator-read tail across a reload's export-policy commit, with the RIB-side stage record that produced it and a correction to that record.

- The attribution conclusion rests on external probe latency plus per-core CPU sampling and stands: in the reported two-core cell the load engine shared the daemon's cores and the daemon's runtime workers were starved; with the engine on other cores every probe is inside the budget on the same binary and the same daemon pinning.
- The `post-commit first general query timing` record as first pushed was consumed only by the bounded query drains; a general query delivered by either event-loop select arm (the common path once the primary backlog has drained and the actor is idle) left the trace armed, and a later drain then reported the whole idle gap as the wait. Corrected here: every query-lane delivery path serves through one helper that consumes the trace.
- No actor scheduling change. The fix candidates in the RIB actor loop (a general-query budget before the post-commit primary backlog, or a narrower commit-phase fence) are not applied because the measurement shows the RIB actor is not what holds the read.

## Observed defect

After the forward-path change that serves operator reads between pre-commit transition polls, `rbgp policy stats --direction both` and `rbgp neighbor` arriving 0.00–0.22 s before the commit of a 1000-member transition still took 2.7–3.1 s in a local 1000-peer × 400-route cell with the daemon and the load engine pinned together on two cores, against a 2 s budget. The same probes 0.35–0.82 s before commit took 16–101 ms.

## Attribution

Cell: 1000 peers × 400 routes, steady churn, SIGHUP reloads every 40 s, six reloads, probes fired at fixed offsets from prestage end (`policy stats --direction both` and `neighbor`, each with the 2 s budget), latency anchored on the RIB's own `RIB export-policy transition completed` record, pinned-core busy time sampled at 100 ms, daemon per-thread CPU from `/proc`. Same instrumented binary in both runs; only the engine's CPU affinity differs.

### Run A — daemon and engine on the same two cores (the reported cell)

| arrival relative to commit | probes | latency | over 2 s budget |
| --- | --- | --- | --- |
| −0.22 … 0.00 s | 12 | 19 – 2982 ms | 10 of 12 |
| −0.90 … −0.30 s | 22 | 19 – 3259 ms | 4 of 22 (all four in the one reload with a remainder per-peer apply) |
| +0.00 … +0.50 s | 8 | 2179 – 3503 ms | 8 of 8 |

The two pinned cores were at 100 % for the whole post-commit window while the daemon's two runtime workers received 0.9–1.5 CPU-seconds of the 6 available; the co-pinned engine, reading and parsing the 1000-session re-advertisement, took the rest. The original RIB record showed 31–37 primary updates queued at commit, a 1.5–2.7 s interval to the recorded dispatch, and 0–240 ms inside its instrumented work classes. That record had the idle-path defect described below and cannot establish a descheduling interval; the CPU-sharing attribution rests on external latency and per-core/per-thread CPU sampling.

### Run B — same daemon pinning, engine on four other cores

| arrival relative to commit | probes | latency | over 2 s budget |
| --- | --- | --- | --- |
| −0.22 … 0.00 s | 16 | 16 – 640 ms | 0 of 16 |
| −0.90 … −0.30 s | 16 | 22 – 101 ms | 0 of 16 |
| +0.00 … +0.50 s | 14 | 257 – 1862 ms | 0 of 14 |

The remaining post-commit tail is in the session collection, not the RIB: reads arriving +0.06…+0.16 s after commit took 1.65–1.86 s with the export stage (RIB) at 3–76 ms and the import stage (one query to each of the 1000 session tasks, which are streaming the shared re-advertisement) at 1.6–1.8 s. The daemon's own two workers ran at 80–100 % for about 1.5–2 s after each commit.

### Conclusion

- The 2.7–3.1 s two-core figure was produced by the load engine sharing the daemon's two cores.
- In the measured split-core cell, the RIB export stage was short compared with the session collection. These observations do not establish a general upper bound on RIB dispatch or end-to-end read latency; no actor-loop scheduling change is justified by this attribution alone.
- What remains on a daemon with its cores to itself is the import stage of `policy stats` (and the peer-manager operator read for `neighbor`) waiting on session tasks busy writing the re-advertisement — a runtime-sharing property of the flush, outside the RIB actor; it stayed inside the budget here and matches the ~1.1–1.2 s tail measured on the eight-vCPU soak host.

## The record and its correction

One `post-commit first general query timing` record per committed transition that a general query follows within ten seconds: the terminal commit poll's duration, the general queries and primary updates queued at commit, the interval from the end of that poll to first general-query dispatch, elapsed wall time inside route-chunk / primary-update / dirty-resync work (`busy_us`), and the remainder (`unattributed_us`). Dispatch is recorded before the handler executes, so this does not measure reply completion or end-to-end operator latency.

`busy_us` includes any descheduling inside those instrumented work calls. `unattributed_us` includes uninstrumented actor work (such as readiness handling, timer sweeps, destination prestaging and initial registrations), idle time, and scheduling delays outside those calls. Neither field is CPU time. When no general query was queued at commit, the dispatch interval also includes time before the first query arrives; the ten-second observation window does not establish causality. A newer owned transition supersedes an unconsumed record.

As first pushed the trace was taken only inside `drain_queries`. Query-lane delivery paths and their status after the correction:

| delivery path | site | before | after |
| --- | --- | --- | --- |
| bounded drains (`drain_queries`: post-chunk, prestage, registration, post-update, between pre-commit polls) | `RibManager::drain_queries` | consumed the trace | wired via helper `serve_general_query` |
| timer-armed event loop, `query = self.query_rx.recv()` arm | `RibManager::run`, first `tokio::select!` | served without consuming | wired via helper `serve_general_query` |
| timer-free event loop, `query = self.query_rx.recv()` arm | `RibManager::run`, second `tokio::select!` | served without consuming | wired via helper `serve_general_query` |

No other site receives from the query lane (`bench_support` only reads its depth). The Run A/B numbers above that come from the record were produced by the first version and can overstate the wait where the first post-commit query took a select arm; the attribution does not depend on them. The regression `post_commit_query_trace_is_consumed_by_idle_select_arm_query` commits a transition through the running actor, lets it go idle, sends one general query through the normal loop, and asserts exactly one record whose `first_query_wait_us` matches the observed idle gap, then that a later primary update and its bounded drain emit nothing. Against the tree before the helper it fails at the first assertion:

```
assertion `left == right` failed: exactly one post-commit record after the first general query, served from the idle select arm: []
  left: 0
 right: 1
```

### Record versus probe (fixed head, Run B shape: daemon on two cores, engine elsewhere, six reloads)

Same cell as Run B, binaries rebuilt with the corrected record. The probe column is the earliest-completing driven probe of that reload whose completion is after the commit; its latency is measured around the `rbgp` process (start-up, gRPC, the RIB stage, the peer-manager stage, reply rendering). Where the daemon's own `GetPolicyStats` stage audit exists for that reload, its export stage (the RIB stage) is given as the direct comparison.

| reload | record `first_query_wait_us` | queued at commit | first post-commit probe | external probe latency | delta (probe − record) | audit export (RIB) / import stage for that reload's `policy stats` probes |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 13 ms | 1 | `neighbor`, arrival −0.14 s | 348 ms | +335 ms | 4 / 364 ms, 2 / 150 ms, 5 / 70 ms |
| 2 | 26 ms | 1 | `neighbor`, arrival −0.15 s | 377 ms | +351 ms | 5 / 107 ms, 126 / 147 ms |
| 3 | 233 ms | 0 | `neighbor`, arrival −0.08 s | 383 ms | +150 ms | 9 / 65 ms, 10 / 69 ms |
| 4 | 9 ms | 1 | `neighbor`, arrival −0.14 s | 402 ms | +393 ms | 19 / 202 ms, 19 / 209 ms, 355 / 137 ms |
| 5 | 134 ms | 0 | `policy stats`, arrival −0.13 s | 426 ms | +292 ms | 97 / 139 ms, 96 / 138 ms, 108 / 30 ms |
| 6 | 204 ms | 0 | `neighbor`, arrival −0.04 s | 361 ms | +157 ms | 2 / 125 ms, 146 / 155 ms, 146 / 163 ms |

The record and the external probes have different endpoints. The record starts after the terminal commit poll and ends before the first general-query handler runs. A probe can start before commit, includes process and RPC overhead, and joins RIB and peer-manager work; the earliest-completing probe also need not contain the first query dispatched. These aggregate rows therefore cannot be added or subtracted to reconstruct one request. The daemon's policy-stats audit independently records 125–364 ms import stages in this run. It supports a session-collection contribution, without treating the RIB trace's unattributed remainder as a CPU-starvation measurement.

Every probe in the `−0.22 … 0.00 s` band of this run: n=24, 15–518 ms, 0 of 24 over the 2 s budget; `+0.00 … +0.50 s`: n=12, 227–312 ms, 0 of 12.

## Not done here

- No actor-loop change: the `−0.22…0.00 s` row is inside the budget in the measured cell once the daemon has its own cores. The record measures dispatch only; no general latency bound follows from it.
- The session-collection tail (import stage during the 1000-session re-advertisement) is measured but not changed; it lives in the peer manager and transport, not in this crate.

## Validation

Runtime and tests at 0ba34e1bb (the record, delivery-path correction, and regression; subsequent review corrections change comments and documentation only):

- `cargo fmt --all -- --check`: rc=0
- `cargo test -p rustbgpd-rib`: rc=0 (1333 passed; both trace tests included)
- `just gate-rib`: rc=0
- `just gate`: rc=0

The regression fails on the tree before the correction with the assertion text quoted above and passes after it.

