### PR TITLE
fix(policy): admit peer-manager reads during rollback waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,16 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **Operator-visible:** `rbgp policy stats` and `rbgp neighbor` no longer fail
+  with `DEADLINE_EXCEEDED` when they arrive while a rejected reload is rolling
+  its export policies back. The peer manager awaited the rollback's batched
+  RIB restore with operator reads parked behind it for up to the two-minute
+  batch budget, so every status command issued right after a failed reload
+  could time out. Reads are now served while that restore is awaited, on the
+  same terms as during the forward transition; every session already runs its
+  restored chain again, so a read observes the generation being restored.
+  Mutations still wait for the rollback to finish, and its budget is unchanged.
+
+- **Operator-visible:** `rbgp policy stats` and `rbgp neighbor` no longer fail
   with `DEADLINE_EXCEEDED` when they arrive while a SIGHUP reload's batched
   export-policy transition is in progress. Both actors previously parked
   operator reads behind the whole RIB transition, so a read arriving more than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,15 +144,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Operator-visible:** `rbgp policy stats` and `rbgp neighbor` no longer fail
-  with `DEADLINE_EXCEEDED` when they arrive while a rejected reload is rolling
-  its export policies back. The peer manager awaited the rollback's batched
-  RIB restore with operator reads parked behind it for up to the two-minute
-  batch budget, so every status command issued right after a failed reload
-  could time out. Reads are now served while that restore is awaited, on the
-  same terms as during the forward transition; every session already runs its
-  restored chain again, so a read observes the generation being restored.
-  Mutations still wait for the rollback to finish, and its budget is unchanged.
+- **Operator-visible:** The peer manager now serves session snapshots,
+  import-policy statistics, and dataset status while a rejected reload awaits
+  enqueue or completion of its batched RIB restore. These reads report live
+  state, including sessions whose restoration failed; they do not promise a
+  common policy generation. This removes the peer-manager wait, but the RIB's
+  synchronous restore still fences its queries, so `rbgp neighbor` and
+  `rbgp policy stats --direction both` can still exhaust their deadlines.
+  Mutations and the rollback's two-minute batch budget are unchanged.
 
 - **Operator-visible:** `rbgp policy stats` and `rbgp neighbor` no longer fail
   with `DEADLINE_EXCEEDED` when they arrive while a SIGHUP reload's batched

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -40,6 +40,14 @@ cannot resume across it. Section 1's "only the readiness lane" wording and
 Section 5's "no general query is admitted" describe the design before this
 amendment. Rollback and standalone policy transactions are unchanged.
 
+**Amended:** 2026-09-12 — the rollback of a rejected cohort transition admits
+the same operator-read lane while the peer manager awaits its exact RIB
+compensation batch. Every cohort session already runs its prior chain again
+at that point, so a read observes the generation being restored; the
+ordinary command receiver stays unpolled and the two-minute batch-reply bound
+is unchanged. Standalone policy transactions and a reload's later
+compensating replay keep the full fence.
+
 ## Context
 
 A live policy reload can move hundreds of route-reflector or route-server

--- a/docs/adr/0105-grouped-export-policy-transition.md
+++ b/docs/adr/0105-grouped-export-policy-transition.md
@@ -41,12 +41,15 @@ Section 5's "no general query is admitted" describe the design before this
 amendment. Rollback and standalone policy transactions are unchanged.
 
 **Amended:** 2026-09-12 — the rollback of a rejected cohort transition admits
-the same operator-read lane while the peer manager awaits its exact RIB
-compensation batch. Every cohort session already runs its prior chain again
-at that point, so a read observes the generation being restored; the
-ordinary command receiver stays unpolled and the two-minute batch-reply bound
-is unchanged. Standalone policy transactions and a reload's later
-compensating replay keep the full fence.
+the same operator-read lane while the peer manager awaits enqueue or completion
+of its exact RIB compensation batch. Session restoration has been attempted,
+but an unsuccessful restore can leave a session on a different policy. Reads
+report live session state without a common generation pin. The RIB still
+executes the authoritative restore synchronously and fences general queries,
+so this admission alone does not guarantee completion of neighbor RPCs or
+export-policy statistics within their deadlines. The ordinary command receiver
+stays unpolled and the two-minute batch-reply bound is unchanged. Standalone
+policy transactions and a reload's later compensating replay keep the full fence.
 
 ## Context
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -618,13 +618,16 @@ pre-commit transition polls from the pre-commit state. Reads that arrive during
 the RIB's short commit batches wait for the commit, which remains the single
 switch point; a route listing started before the commit cannot be continued
 across it. When a reload's export-policy transition is rejected and rolled
-back, the same reads are served while the daemon awaits the batched RIB
-restore; every session already runs its prior chain again, so a read observes
-the generation being restored. Standalone policy transactions and a reload's
-later compensating replay keep the full fence. Readiness queries remain
-available at their existing transaction seams. A
-congested backend or a later transaction stage can still exhaust an operator
-read's deadline.
+back, the peer manager serves session snapshots, import-statistics collections,
+and dataset status while it awaits enqueue or completion of the batched RIB
+restore. These are live reads: a failed session restore can leave different
+sessions on different policies, and peer-manager and RIB reads do not share
+a generation pin. The RIB's synchronous restore still fences general queries,
+so `rbgp neighbor` and `rbgp policy stats --direction both` can still time out
+there. Standalone policy transactions and a reload's later compensating replay
+keep the full fence. Readiness queries remain available at their existing
+transaction seams. A congested backend or a later transaction stage can still
+exhaust an operator read's deadline.
 
 For a dataset content generation, every file must load successfully before
 publication. The daemon retains prior snapshots and loader errors, reserves

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -617,8 +617,12 @@ exactly as during prestaging), and the RIB answers general queries between its
 pre-commit transition polls from the pre-commit state. Reads that arrive during
 the RIB's short commit batches wait for the commit, which remains the single
 switch point; a route listing started before the commit cannot be continued
-across it. Rollback and standalone policy transactions keep the full fence.
-Readiness queries remain available at their existing transaction seams. A
+across it. When a reload's export-policy transition is rejected and rolled
+back, the same reads are served while the daemon awaits the batched RIB
+restore; every session already runs its prior chain again, so a read observes
+the generation being restored. Standalone policy transactions and a reload's
+later compensating replay keep the full fence. Readiness queries remain
+available at their existing transaction seams. A
 congested backend or a later transaction stage can still exhaust an operator
 read's deadline.
 

--- a/src/peer_manager/generation.rs
+++ b/src/peer_manager/generation.rs
@@ -30,9 +30,9 @@ use crate::config::{
 };
 use crate::policy_admin;
 
-use super::PeerManager;
 use super::lifecycle::PeerReshapeSnapshotOutcome;
 use super::policy::{DatasetDependent, DatasetRefreshFailure, PolicySnapshotFailureKind};
+use super::{OperatorReadAdmission, PeerManager};
 
 /// Counts of the per-peer actions one generation applied.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -275,7 +275,11 @@ impl PeerManager {
         // 1. Policy chains through the rollback-capable snapshot. No session
         //    identity is at stake yet, so a failure here costs nothing.
         match self
-            .apply_resolved_policy_snapshot_with_prestage_reads(resolved.policy_targets, true, true)
+            .apply_resolved_policy_snapshot_with_prestage_reads(
+                resolved.policy_targets,
+                true,
+                OperatorReadAdmission::Served,
+            )
             .await
         {
             Ok(priors) => applied.policy_priors = Some(priors),

--- a/src/peer_manager/lifecycle.rs
+++ b/src/peer_manager/lifecycle.rs
@@ -15,8 +15,8 @@ use tracing::{debug, error, info, warn};
 use crate::policy_admin::apply_config_event;
 
 use super::{
-    ManagedPeer, PEER_LIFECYCLE_COMMAND_TIMEOUT, PEER_POLICY_UPDATE_TIMEOUT, PeerManager,
-    PeerShutdownOutcome,
+    ManagedPeer, OperatorReadAdmission, PEER_LIFECYCLE_COMMAND_TIMEOUT, PEER_POLICY_UPDATE_TIMEOUT,
+    PeerManager, PeerShutdownOutcome,
 };
 
 pub(super) enum RuntimeCreatePeerFailureEffect {
@@ -284,6 +284,10 @@ impl PeerManager {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the restart fan-out keeps hold-down expiry, BFD withholding, and per-peer outcome bookkeeping together"
+    )]
     pub(super) async fn handle_due_max_prefix_restarts(&mut self) {
         let now = tokio::time::Instant::now();
         let mut due: Vec<(PeerKey, u64)> = self
@@ -353,7 +357,12 @@ impl PeerManager {
             .iter()
             .map(|(_, commands)| send_max_prefix_start_before(commands.clone(), attempt_deadline));
         let results = self
-            .await_with_readiness(futures::future::join_all(attempts))
+            .await_with_readiness(
+                futures::future::join_all(attempts),
+                OperatorReadAdmission::Fenced {
+                    reason: "bounded max-prefix restart fan-out outside any policy transaction",
+                },
+            )
             .await;
 
         for ((peer, _commands), result) in starts.into_iter().zip(results) {

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -953,9 +953,10 @@ impl PeerManager {
     /// registered RIB aggregate. During the transition every cohort session
     /// already runs its new chains, so a read observes the same mixed
     /// per-session generation the destination prestage admits; during the
-    /// rollback every session already runs its restored chain again, so a
-    /// read observes the prior generation, which is the generation being
-    /// restored.
+    /// rollback reads report live session state after restoration has been
+    /// attempted, including failed restores. Neither wait pins a common
+    /// generation across sessions or the RIB, whose authoritative restore
+    /// still fences its general-query lane.
     async fn await_with_readiness<F>(
         &mut self,
         future: F,

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -988,49 +988,6 @@ impl PeerManager {
         }
     }
 
-    /// Forward-path spelling of [`Self::await_with_readiness`] for the sites
-    /// that still carry the reload owner's decision as a flag.
-    async fn await_with_readiness_and_operator_reads<F>(
-        &mut self,
-        future: F,
-        allow_operator_reads: bool,
-    ) -> F::Output
-    where
-        F: Future,
-    {
-        self.await_with_readiness(future, Self::forward_admission(allow_operator_reads))
-            .await
-    }
-
-    const fn forward_admission(allow_operator_reads: bool) -> OperatorReadAdmission {
-        if allow_operator_reads {
-            OperatorReadAdmission::Served
-        } else {
-            OperatorReadAdmission::Fenced {
-                reason: "the transaction owner entered with operator reads fenced",
-            }
-        }
-    }
-
-    /// Forward-path spelling of [`Self::await_with_readiness_budget`] for the
-    /// sites that still carry the reload owner's decision as a flag.
-    async fn await_with_readiness_and_operator_budget<F>(
-        &mut self,
-        future: F,
-        budget: Duration,
-        allow_operator_reads: bool,
-    ) -> Option<F::Output>
-    where
-        F: Future,
-    {
-        self.await_with_readiness_budget(
-            future,
-            budget,
-            Self::forward_admission(allow_operator_reads),
-        )
-        .await
-    }
-
     /// Like [`Self::await_with_readiness`], but bound the step by a budget
     /// that accrues only while the step itself is being driven. Wall time
     /// spent servicing an interleaved readiness or operator query is not

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -135,6 +135,35 @@ const RIB_BATCH_REPLY_TIMEOUT: Duration = Duration::from_mins(2);
 /// masquerading as a missing session.
 const EXPLAIN_QUERY_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Whether an actor-owned wait admits the bounded operator-read lane
+/// (`rbgp neighbor`, `rbgp policy stats`, dataset status) while it is driven.
+/// The dedicated readiness lane is always admitted; the ordinary command
+/// receiver never is, so mutations stay strictly behind the owner. Operator
+/// reads carry deadlines of 100 ms to 2 s, so any wait that can outlast them
+/// must justify fencing them at the site: a fenced wait names what bounds it
+/// or what a served read would observe, the same way a lint allowance names
+/// its reason.
+#[derive(Clone, Copy, Debug)]
+enum OperatorReadAdmission {
+    /// Serve each operator read as it arrives; the wait resumes after the
+    /// read completes.
+    Served,
+    /// Leave operator reads queued behind the wait.
+    Fenced {
+        #[expect(
+            dead_code,
+            reason = "the reason documents the fence at its call site; it is not runtime state"
+        )]
+        reason: &'static str,
+    },
+}
+
+impl OperatorReadAdmission {
+    const fn admits(self) -> bool {
+        matches!(self, Self::Served)
+    }
+}
+
 /// Maximum number of session-side import-policy snapshots in flight per
 /// collector/RPC. The cap bounds each collector's memory/work while every
 /// query still shares the caller's single absolute deadline.
@@ -647,7 +676,7 @@ impl PeerManager {
             // Finish the admitted snapshot before a prestage ACK can let
             // the reload advance any session's installed policy.
             if let Some(task) = self.answer_operator_query(query).await {
-                let _ = self.await_with_readiness(task).await;
+                let _ = self.finish_admitted_operator_read(task).await;
             }
         } else {
             self.answer_normal_operator_query(query).await;
@@ -884,10 +913,12 @@ impl PeerManager {
         }
     }
 
-    /// Drive one owned transaction step while servicing at most one read-only
-    /// readiness query at a time. The transaction future is biased first, so a
-    /// probe flood cannot delay a completed apply/rollback step.
-    async fn await_with_readiness<F>(&mut self, future: F) -> F::Output
+    /// Finish one admitted operator read while servicing only the readiness
+    /// lane. This is the one wait that takes no admission: the read it
+    /// drives was itself admitted by an [`Self::await_with_readiness`] wait,
+    /// which admits the next read once this one completes, so reads stay in
+    /// order and the admitting wait never nests.
+    async fn finish_admitted_operator_read<F>(&mut self, future: F) -> F::Output
     where
         F: Future,
     {
@@ -909,19 +940,26 @@ impl PeerManager {
         }
     }
 
-    /// Like [`Self::await_with_readiness`], optionally admitting the bounded
-    /// operator-read lane as well. Only the forward reload owner passes
-    /// `true`, and only while it awaits the cohort's RIB transition: every
-    /// cohort session already runs its new chains at that point, so a read
-    /// admitted here observes the same mixed per-session generation the
-    /// destination prestage already admits, and the ordinary command
-    /// receiver stays unpolled so mutations remain strictly behind the
-    /// transaction. Each admitted read completes (through the readiness-only
-    /// helper, as during prestage) before the wait resumes.
-    async fn await_with_readiness_and_operator_reads<F>(
+    /// Drive one owned step while servicing at most one read-only readiness
+    /// query at a time and, when `admission` is [`OperatorReadAdmission::Served`],
+    /// the bounded operator-read lane as well. The step future is biased
+    /// first, so a probe flood cannot delay a completed apply/rollback step.
+    /// Each admitted operator read completes (through a fenced wait of its
+    /// own) before this wait resumes, and the ordinary command receiver is
+    /// never polled here, so mutations remain strictly behind the owner.
+    ///
+    /// A forward reload serves reads while it awaits the cohort's RIB
+    /// transition and while the same transaction's rollback awaits its
+    /// registered RIB aggregate. During the transition every cohort session
+    /// already runs its new chains, so a read observes the same mixed
+    /// per-session generation the destination prestage admits; during the
+    /// rollback every session already runs its restored chain again, so a
+    /// read observes the prior generation, which is the generation being
+    /// restored.
+    async fn await_with_readiness<F>(
         &mut self,
         future: F,
-        allow_operator_reads: bool,
+        admission: OperatorReadAdmission,
     ) -> F::Output
     where
         F: Future,
@@ -937,9 +975,12 @@ impl PeerManager {
                         None => self.readiness_rx = None,
                     }
                 }
-                query = Self::receive_operator_query(&mut self.operator_rx, &mut self.deferred_operator_queries), if allow_operator_reads => {
+                query = Self::receive_operator_query(&mut self.operator_rx, &mut self.deferred_operator_queries), if admission.admits() => {
                     match query {
-                        Some(query) => self.handle_operator_query(query, true).await,
+                        // Boxed so the read's handler is not part of every
+                        // fenced wait's state machine; it allocates only
+                        // when a read is actually admitted.
+                        Some(query) => Box::pin(self.handle_operator_query(query, true)).await,
                         None => self.operator_rx = None,
                     }
                 }
@@ -947,35 +988,62 @@ impl PeerManager {
         }
     }
 
-    /// Like [`Self::await_with_readiness`], but bound the transaction step by
-    /// a budget that accrues only while the step itself is being driven. Wall
-    /// time spent servicing an interleaved readiness query is not charged: a
-    /// `tokio::time::timeout` inside the step would keep counting during that
-    /// servicing, so a probe flood (or any long servicing burst) would be
-    /// deducted from a healthy session command's deadline — the mechanism
-    /// behind the cohort-setup starvation. Returns `None` when the accrued
-    /// budget elapses before the future completes.
-    async fn await_with_readiness_budget<F>(
+    /// Forward-path spelling of [`Self::await_with_readiness`] for the sites
+    /// that still carry the reload owner's decision as a flag.
+    async fn await_with_readiness_and_operator_reads<F>(
         &mut self,
         future: F,
-        budget: Duration,
-    ) -> Option<F::Output>
+        allow_operator_reads: bool,
+    ) -> F::Output
     where
         F: Future,
     {
-        self.await_with_readiness_and_operator_budget(future, budget, false)
+        self.await_with_readiness(future, Self::forward_admission(allow_operator_reads))
             .await
     }
 
-    /// Only a forward reload admits operator snapshots, during its initial
-    /// destination prestage here and while it awaits the cohort RIB
-    /// transition in [`Self::await_with_readiness_and_operator_reads`]. All
-    /// other transaction waits keep this lane fenced.
+    const fn forward_admission(allow_operator_reads: bool) -> OperatorReadAdmission {
+        if allow_operator_reads {
+            OperatorReadAdmission::Served
+        } else {
+            OperatorReadAdmission::Fenced {
+                reason: "the transaction owner entered with operator reads fenced",
+            }
+        }
+    }
+
+    /// Forward-path spelling of [`Self::await_with_readiness_budget`] for the
+    /// sites that still carry the reload owner's decision as a flag.
     async fn await_with_readiness_and_operator_budget<F>(
         &mut self,
         future: F,
         budget: Duration,
         allow_operator_reads: bool,
+    ) -> Option<F::Output>
+    where
+        F: Future,
+    {
+        self.await_with_readiness_budget(
+            future,
+            budget,
+            Self::forward_admission(allow_operator_reads),
+        )
+        .await
+    }
+
+    /// Like [`Self::await_with_readiness`], but bound the step by a budget
+    /// that accrues only while the step itself is being driven. Wall time
+    /// spent servicing an interleaved readiness or operator query is not
+    /// charged: a `tokio::time::timeout` inside the step would keep counting
+    /// during that servicing, so a probe flood (or any long servicing burst)
+    /// would be deducted from a healthy session command's deadline — the
+    /// mechanism behind the cohort-setup starvation. Returns `None` when the
+    /// accrued budget elapses before the future completes.
+    async fn await_with_readiness_budget<F>(
+        &mut self,
+        future: F,
+        budget: Duration,
+        admission: OperatorReadAdmission,
     ) -> Option<F::Output>
     where
         F: Future,
@@ -999,10 +1067,10 @@ impl PeerManager {
                         return None;
                     }
                 }
-                query = Self::receive_operator_query(&mut self.operator_rx, &mut self.deferred_operator_queries), if allow_operator_reads => {
+                query = Self::receive_operator_query(&mut self.operator_rx, &mut self.deferred_operator_queries), if admission.admits() => {
                     remaining = remaining.saturating_sub(attended.elapsed());
                     match query {
-                        Some(query) => self.handle_operator_query(query, true).await,
+                        Some(query) => Box::pin(self.handle_operator_query(query, true)).await,
                         None => self.operator_rx = None,
                     }
                     if remaining.is_zero() {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -348,9 +348,9 @@ struct PolicySnapshotContext {
     clean_state_window: CleanStateQueryWindow,
     /// Whether this transaction admits the bounded operator-read lane while
     /// it awaits a RIB aggregate. Decided once where the transaction starts,
-    /// so a rollback admits exactly what its forward apply admitted: reads
-    /// served while the registered rollback aggregate is awaited observe the
-    /// prior generation, which is the generation being restored.
+    /// so a rollback admits exactly what its forward apply admitted. Reads
+    /// report live state after session restoration was attempted; failed
+    /// restores can leave sessions on different policies.
     operator_reads: OperatorReadAdmission,
 }
 
@@ -2301,8 +2301,9 @@ impl PeerManager {
         });
 
         // Both waits below admit the operator-read lane on the transaction's
-        // terms: every session already runs its restored chain, so a read
-        // observes the generation being restored, and the rollback's own
+        // terms, reporting live state after session restoration was attempted.
+        // Some restores may have failed; admission does not imply a common
+        // generation or an available RIB query lane. The rollback's own
         // two-minute budget is unchanged.
         match tokio::time::timeout_at(
             deadline,

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -861,18 +861,23 @@ impl PeerManager {
         self.apply_resolved_policy_snapshot_with_prestage_reads(
             targets,
             require_clean_convergence,
-            false,
+            OperatorReadAdmission::Fenced {
+                reason: "standalone policy transactions and a reload's compensating replay keep their fence",
+            },
         )
         .await
     }
 
-    /// The forward reload owner may admit reads before the first policy effect.
-    /// Rollback and standalone policy operations use the fenced wrapper above.
+    /// The forward reload owner passes `Served`, admitting reads from its
+    /// first destination prestage on; standalone policy operations and a
+    /// reload's compensating replay use the fenced wrapper above. The
+    /// admission travels on the transaction context to every wait that
+    /// honours it, the rollback included.
     pub(super) async fn apply_resolved_policy_snapshot_with_prestage_reads(
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
         require_clean_convergence: bool,
-        allow_operator_reads: bool,
+        operator_reads: OperatorReadAdmission,
     ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
         let snapshot_started = Instant::now();
         let mut phases = PolicySnapshotPhaseTimings {
@@ -885,7 +890,7 @@ impl PeerManager {
                 targets,
                 require_clean_convergence,
                 &mut phases,
-                allow_operator_reads,
+                operator_reads,
             )
             .await;
         let total_us = elapsed_us(snapshot_started);
@@ -932,7 +937,7 @@ impl PeerManager {
         targets: Vec<ResolvedPeerPolicy>,
         require_clean_convergence: bool,
         phases: &mut PolicySnapshotPhaseTimings,
-        allow_operator_reads: bool,
+        operator_reads: OperatorReadAdmission,
     ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
         // ADR-0112: qualify RFC 8212 import-presence transitions before
         // anything below can touch a peer, so one incapable peer rejects the
@@ -945,7 +950,7 @@ impl PeerManager {
             forward: LazyRibBudget::default(),
             rollback: LazyRibBudget::default(),
             clean_state_window: CleanStateQueryWindow::default(),
-            operator_reads: PeerManager::forward_admission(allow_operator_reads),
+            operator_reads,
         };
         let preflight = self
             .preflight_rfc8212_import_transitions(&targets, &mut context.forward)
@@ -1025,7 +1030,6 @@ impl PeerManager {
                 &mut context,
                 require_clean_convergence,
                 phases,
-                allow_operator_reads,
             )
             .await
         else {
@@ -1462,7 +1466,6 @@ impl PeerManager {
         context: &mut PolicySnapshotContext,
         require_clean_convergence: bool,
         phase_timings: &mut PolicySnapshotPhaseTimings,
-        allow_operator_reads: bool,
     ) -> Option<Result<Vec<CapturedResolvedPolicy>, PolicySnapshotFailure>> {
         if targets.len() < 2 {
             return None;
@@ -1530,13 +1533,9 @@ impl PeerManager {
                 }
                 matches!(reply_rx.await, Ok(Ok(())))
             };
-            self.await_with_readiness_and_operator_budget(
-                round_trip,
-                RIB_REPLY_TIMEOUT,
-                allow_operator_reads,
-            )
-            .await
-            .unwrap_or(false)
+            self.await_with_readiness_budget(round_trip, RIB_REPLY_TIMEOUT, context.operator_reads)
+                .await
+                .unwrap_or(false)
         };
         info!(
             cohort_targets = targets.len(),
@@ -1830,7 +1829,7 @@ impl PeerManager {
         let cohort_result = match send_result {
             Err(_) => Err("RIB manager unavailable".to_string()),
             Ok(()) => {
-                self.await_export_policy_cohort_rib_reply(reply_rx, allow_operator_reads)
+                self.await_export_policy_cohort_rib_reply(reply_rx, context.operator_reads)
                     .await
             }
         };
@@ -1848,7 +1847,7 @@ impl PeerManager {
                 }
                 self.apply_export_policy_replacements_authoritatively(
                     &replacements,
-                    allow_operator_reads,
+                    context.operator_reads,
                 )
                 .await
             }
@@ -2038,12 +2037,9 @@ impl PeerManager {
     async fn await_export_policy_cohort_rib_reply(
         &mut self,
         reply_rx: oneshot::Receiver<Result<ExportPolicyCohortOutcome, String>>,
-        allow_operator_reads: bool,
+        operator_reads: OperatorReadAdmission,
     ) -> Result<ExportPolicyCohortOutcome, String> {
-        match self
-            .await_with_readiness_and_operator_reads(reply_rx, allow_operator_reads)
-            .await
-        {
+        match self.await_with_readiness(reply_rx, operator_reads).await {
             Err(_) => Err("RIB manager dropped cohort reply".to_string()),
             Ok(result) => result,
         }
@@ -2063,17 +2059,17 @@ impl PeerManager {
     async fn apply_export_policy_replacements_authoritatively(
         &mut self,
         replacements: &[PeerExportPolicyReplacement],
-        allow_operator_reads: bool,
+        operator_reads: OperatorReadAdmission,
     ) -> Result<(), String> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let rib_tx = self.rib_tx.clone();
         if self
-            .await_with_readiness_and_operator_reads(
+            .await_with_readiness(
                 rib_tx.send(RibUpdate::ReplacePeerExportPoliciesAuthoritatively {
                     replacements: replacements.to_vec(),
                     reply: reply_tx,
                 }),
-                allow_operator_reads,
+                operator_reads,
             )
             .await
             .is_err()
@@ -2082,7 +2078,7 @@ impl PeerManager {
         }
         let result = match tokio::time::timeout(
             super::RIB_BATCH_REPLY_TIMEOUT,
-            self.await_with_readiness_and_operator_reads(reply_rx, allow_operator_reads),
+            self.await_with_readiness(reply_rx, operator_reads),
         )
         .await
         {

--- a/src/peer_manager/policy.rs
+++ b/src/peer_manager/policy.rs
@@ -30,8 +30,8 @@ use crate::policy_admin::{
 };
 
 use super::{
-    CLEAN_STATE_QUERY_WINDOW, ManagedPeer, PEER_POLICY_UPDATE_TIMEOUT, PEER_QUERY_TIMEOUT,
-    PeerManager, RIB_REPLY_TIMEOUT, lifecycle::PeerReshapeSnapshotOutcome,
+    CLEAN_STATE_QUERY_WINDOW, ManagedPeer, OperatorReadAdmission, PEER_POLICY_UPDATE_TIMEOUT,
+    PEER_QUERY_TIMEOUT, PeerManager, RIB_REPLY_TIMEOUT, lifecycle::PeerReshapeSnapshotOutcome,
 };
 
 /// Peers applied between cohort-setup progress lines. Sized so a
@@ -335,8 +335,10 @@ impl LazyRibBudget {
     }
 }
 
-#[derive(Default)]
-struct PolicySnapshotRibBudget {
+/// Per-transaction state of one resolved policy snapshot: the RIB budgets its
+/// walks share, the clean-convergence retry window, and the operator-read
+/// admission its owner decided at entry.
+struct PolicySnapshotContext {
     /// Shared by every per-peer RIB command of the authoritative forward walk.
     forward: LazyRibBudget,
     /// Shared by every rollback partition's registered RIB aggregate. Anchored
@@ -344,6 +346,12 @@ struct PolicySnapshotRibBudget {
     /// the compensation's budget.
     rollback: LazyRibBudget,
     clean_state_window: CleanStateQueryWindow,
+    /// Whether this transaction admits the bounded operator-read lane while
+    /// it awaits a RIB aggregate. Decided once where the transaction starts,
+    /// so a rollback admits exactly what its forward apply admitted: reads
+    /// served while the registered rollback aggregate is awaited observe the
+    /// prior generation, which is the generation being restored.
+    operator_reads: OperatorReadAdmission,
 }
 
 struct PolicyRollbackPeerPlan {
@@ -540,10 +548,15 @@ impl PeerManager {
         };
         let commands = managed.handle.commands_sender();
         let state = self
-            .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                commands,
-                PEER_QUERY_TIMEOUT,
-            ))
+            .await_with_readiness(
+                rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                    commands,
+                    PEER_QUERY_TIMEOUT,
+                ),
+                OperatorReadAdmission::Fenced {
+                    reason: "100 ms state probe in the RFC 8212 preflight, before any peer is touched",
+                },
+            )
             .await;
         self.drain_readiness_queries().await;
 
@@ -669,9 +682,17 @@ impl PeerManager {
                 .await
                 .map_err(|_| failed("the RIB manager dropped the retained-stale reply"))
         };
-        tokio::time::timeout_at(deadline, self.await_with_readiness(round_trip))
-            .await
-            .map_err(|_| timed_out())?
+        tokio::time::timeout_at(
+            deadline,
+            self.await_with_readiness(
+                round_trip,
+                OperatorReadAdmission::Fenced {
+                    reason: "read-only RIB retained-stale proof on the primary lane, bounded by the walk budget",
+                },
+            ),
+        )
+        .await
+        .map_err(|_| timed_out())?
     }
 
     /// ADR-0112: qualify every target whose RFC 8212 import verdict would move,
@@ -920,9 +941,14 @@ impl PeerManager {
         // One forward RIB budget for the whole transaction: the presence
         // proofs below and the authoritative walk's per-peer applies both
         // queue on the RIB's primary lane, so they are bounded in total.
-        let mut rollback_rib_budget = PolicySnapshotRibBudget::default();
+        let mut context = PolicySnapshotContext {
+            forward: LazyRibBudget::default(),
+            rollback: LazyRibBudget::default(),
+            clean_state_window: CleanStateQueryWindow::default(),
+            operator_reads: PeerManager::forward_admission(allow_operator_reads),
+        };
         let preflight = self
-            .preflight_rfc8212_import_transitions(&targets, &mut rollback_rib_budget.forward)
+            .preflight_rfc8212_import_transitions(&targets, &mut context.forward)
             .await;
         phases.preflight_us = elapsed_us(preflight_started);
         preflight
@@ -939,7 +965,7 @@ impl PeerManager {
             let captured = self
                 .apply_resolved_policy_snapshot_authoritatively(
                     targets,
-                    &mut rollback_rib_budget,
+                    &mut context,
                     require_clean_convergence,
                 )
                 .await;
@@ -947,11 +973,7 @@ impl PeerManager {
             let captured = captured?;
             let convergence_started = Instant::now();
             let outcome = self
-                .complete_policy_snapshot(
-                    captured,
-                    &mut rollback_rib_budget,
-                    require_clean_convergence,
-                )
+                .complete_policy_snapshot(captured, &mut context, require_clean_convergence)
                 .await;
             phases.convergence_check_us = elapsed_us(convergence_started);
             return outcome;
@@ -971,7 +993,7 @@ impl PeerManager {
             let captured = self
                 .apply_resolved_policy_snapshot_authoritatively(
                     targets,
-                    &mut rollback_rib_budget,
+                    &mut context,
                     require_clean_convergence,
                 )
                 .await;
@@ -979,11 +1001,7 @@ impl PeerManager {
             let captured = captured?;
             let convergence_started = Instant::now();
             let outcome = self
-                .complete_policy_snapshot(
-                    captured,
-                    &mut rollback_rib_budget,
-                    require_clean_convergence,
-                )
+                .complete_policy_snapshot(captured, &mut context, require_clean_convergence)
                 .await;
             phases.convergence_check_us = elapsed_us(convergence_started);
             return outcome;
@@ -1004,7 +1022,7 @@ impl PeerManager {
         let Some(cohort_result) = self
             .try_apply_export_only_policy_cohort(
                 &cohort,
-                &mut rollback_rib_budget,
+                &mut context,
                 require_clean_convergence,
                 phases,
                 allow_operator_reads,
@@ -1021,7 +1039,7 @@ impl PeerManager {
             let captured = self
                 .apply_resolved_policy_snapshot_authoritatively(
                     targets,
-                    &mut rollback_rib_budget,
+                    &mut context,
                     require_clean_convergence,
                 )
                 .await;
@@ -1029,11 +1047,7 @@ impl PeerManager {
             let captured = captured?;
             let convergence_started = Instant::now();
             let outcome = self
-                .complete_policy_snapshot(
-                    captured,
-                    &mut rollback_rib_budget,
-                    require_clean_convergence,
-                )
+                .complete_policy_snapshot(captured, &mut context, require_clean_convergence)
                 .await;
             phases.convergence_check_us = elapsed_us(convergence_started);
             return outcome;
@@ -1049,7 +1063,7 @@ impl PeerManager {
         let authoritative_remainder = self
             .apply_resolved_policy_snapshot_authoritatively(
                 remainder,
-                &mut rollback_rib_budget,
+                &mut context,
                 require_clean_convergence,
             )
             .await;
@@ -1066,22 +1080,14 @@ impl PeerManager {
                 );
                 let convergence_started = Instant::now();
                 let outcome = self
-                    .complete_policy_snapshot(
-                        captured,
-                        &mut rollback_rib_budget,
-                        require_clean_convergence,
-                    )
+                    .complete_policy_snapshot(captured, &mut context, require_clean_convergence)
                     .await;
                 phases.convergence_check_us = elapsed_us(convergence_started);
                 outcome
             }
             Err(remainder_error) => {
                 let rollback = self
-                    .restore_resolved_policies(
-                        captured,
-                        &mut rollback_rib_budget,
-                        require_clean_convergence,
-                    )
+                    .restore_resolved_policies(captured, &mut context, require_clean_convergence)
                     .await;
                 let message = match &rollback {
                     Ok(()) => format!(
@@ -1114,7 +1120,7 @@ impl PeerManager {
     async fn complete_policy_snapshot(
         &mut self,
         captured: Vec<CapturedResolvedPolicy>,
-        rollback_rib_budget: &mut PolicySnapshotRibBudget,
+        context: &mut PolicySnapshotContext,
         require_clean_convergence: bool,
     ) -> Result<Vec<ResolvedPeerPolicy>, PolicySnapshotFailure> {
         let convergence_debt = require_clean_convergence
@@ -1127,7 +1133,7 @@ impl PeerManager {
             });
         if convergence_debt {
             return match self
-                .restore_resolved_policies(captured, rollback_rib_budget, require_clean_convergence)
+                .restore_resolved_policies(captured, context, require_clean_convergence)
                 .await
             {
                 Ok(()) => Err(PolicySnapshotFailure::compensated_code(
@@ -1219,10 +1225,15 @@ impl PeerManager {
                 .commands_sender();
 
             let outcome = self
-                .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                    commands,
-                    PEER_QUERY_TIMEOUT,
-                ))
+                .await_with_readiness(
+                    rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                        commands,
+                        PEER_QUERY_TIMEOUT,
+                    ),
+                    OperatorReadAdmission::Fenced {
+                        reason: "100 ms state probe during cohort selection, before any peer is touched",
+                    },
+                )
                 .await;
             self.drain_readiness_queries().await;
             match outcome {
@@ -1286,7 +1297,7 @@ impl PeerManager {
     async fn apply_resolved_policy_snapshot_authoritatively(
         &mut self,
         targets: Vec<ResolvedPeerPolicy>,
-        rollback_rib_budget: &mut PolicySnapshotRibBudget,
+        context: &mut PolicySnapshotContext,
         require_clean_convergence: bool,
     ) -> Result<Vec<CapturedResolvedPolicy>, PolicySnapshotFailure> {
         // Captured priors, in application order, for peers actually mutated.
@@ -1319,9 +1330,8 @@ impl PeerManager {
                     target.export_policy.clone(),
                     RefreshFailureHandling::Fatal,
                     None,
-                    require_clean_convergence
-                        .then_some(&mut rollback_rib_budget.clean_state_window),
-                    Some(&mut rollback_rib_budget.forward),
+                    require_clean_convergence.then_some(&mut context.clean_state_window),
+                    Some(&mut context.forward),
                 )
                 .await
             {
@@ -1332,11 +1342,7 @@ impl PeerManager {
                 applied[applied_idx].adj_rib_in_may_have_moved = apply_error.refresh_delivery_began;
                 let restored = std::mem::take(&mut applied);
                 return match self
-                    .restore_resolved_policies(
-                        restored,
-                        rollback_rib_budget,
-                        require_clean_convergence,
-                    )
+                    .restore_resolved_policies(restored, context, require_clean_convergence)
                     .await
                 {
                     Ok(()) => Err(PolicySnapshotFailure::compensated_code(
@@ -1376,7 +1382,13 @@ impl PeerManager {
         operation: &'static str,
     ) -> Result<(), rustbgpd_transport::PeerCommandError> {
         match self
-            .await_with_readiness_budget(round_trip, PEER_POLICY_UPDATE_TIMEOUT)
+            .await_with_readiness_budget(
+                round_trip,
+                PEER_POLICY_UPDATE_TIMEOUT,
+                OperatorReadAdmission::Fenced {
+                    reason: "500 ms session hot-apply; the per-session step completes before reads resume",
+                },
+            )
             .await
         {
             Some(result) => result,
@@ -1397,10 +1409,15 @@ impl PeerManager {
         window: &mut CleanStateQueryWindow,
     ) -> StateQueryOutcome {
         let first = self
-            .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                commands.clone(),
-                PEER_QUERY_TIMEOUT,
-            ))
+            .await_with_readiness(
+                rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                    commands.clone(),
+                    PEER_QUERY_TIMEOUT,
+                ),
+                OperatorReadAdmission::Fenced {
+                    reason: "100 ms clean-convergence state probe after session application",
+                },
+            )
             .await;
         self.drain_readiness_queries().await;
         if !matches!(first, StateQueryOutcome::TimedOut) {
@@ -1410,9 +1427,12 @@ impl PeerManager {
             return StateQueryOutcome::TimedOut;
         };
         let retried = self
-            .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                commands, remaining,
-            ))
+            .await_with_readiness(
+                rustbgpd_transport::PeerHandle::query_state_outcome_with(commands, remaining),
+                OperatorReadAdmission::Fenced {
+                    reason: "single bounded retry of the clean-convergence state probe",
+                },
+            )
             .await;
         self.drain_readiness_queries().await;
         retried
@@ -1439,7 +1459,7 @@ impl PeerManager {
     async fn try_apply_export_only_policy_cohort(
         &mut self,
         targets: &[&ResolvedPeerPolicy],
-        rollback_rib_budget: &mut PolicySnapshotRibBudget,
+        context: &mut PolicySnapshotContext,
         require_clean_convergence: bool,
         phase_timings: &mut PolicySnapshotPhaseTimings,
         allow_operator_reads: bool,
@@ -1585,11 +1605,7 @@ impl PeerManager {
                         managed.pending_refresh = true;
                     }
                     let prior_restore = self
-                        .restore_resolved_policies(
-                            captured,
-                            rollback_rib_budget,
-                            require_clean_convergence,
-                        )
+                        .restore_resolved_policies(captured, context, require_clean_convergence)
                         .await;
                     return Some(Err(match prior_restore {
                         Ok(()) => PolicySnapshotFailure::ambiguous_code(
@@ -1701,6 +1717,9 @@ impl PeerManager {
                                         refresh_commands,
                                         PEER_QUERY_TIMEOUT,
                                     ),
+                                    OperatorReadAdmission::Fenced {
+                                        reason: "100 ms state probe while unwinding a failed cohort export apply",
+                                    },
                                 )
                                 .await
                                 .is_some_and(|state| state.fsm_state == SessionState::Established);
@@ -1748,11 +1767,7 @@ impl PeerManager {
                     Ok(())
                 };
                 let prior_restore = self
-                    .restore_resolved_policies(
-                        captured,
-                        rollback_rib_budget,
-                        require_clean_convergence,
-                    )
+                    .restore_resolved_policies(captured, context, require_clean_convergence)
                     .await;
                 let prior_restore_code = prior_restore.as_ref().err().map(|error| error.code);
                 let prior_restore = prior_restore.map_err(|error| error.to_string());
@@ -1845,7 +1860,7 @@ impl PeerManager {
                 self.discard_prepared_export_destination(targets[0]).await;
             }
             let rollback = self
-                .restore_resolved_policies(captured, rollback_rib_budget, require_clean_convergence)
+                .restore_resolved_policies(captured, context, require_clean_convergence)
                 .await;
             return Some(Err(match rollback {
                 Ok(()) => PolicySnapshotFailure::compensated_code(
@@ -1888,16 +1903,18 @@ impl PeerManager {
                 .handle
                 .commands_sender();
             let state = if require_clean_convergence {
-                self.query_clean_session_state(
-                    commands,
-                    &mut rollback_rib_budget.clean_state_window,
-                )
-                .await
+                self.query_clean_session_state(commands, &mut context.clean_state_window)
+                    .await
             } else {
-                self.await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                    commands,
-                    PEER_QUERY_TIMEOUT,
-                ))
+                self.await_with_readiness(
+                    rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                        commands,
+                        PEER_QUERY_TIMEOUT,
+                    ),
+                    OperatorReadAdmission::Fenced {
+                        reason: "100 ms state probe before a deferred route refresh",
+                    },
+                )
                 .await
             };
             self.drain_readiness_queries().await;
@@ -1928,11 +1945,7 @@ impl PeerManager {
                     }
                     captured[index].adj_rib_in_may_have_moved = failure.delivery_began;
                     let rollback = self
-                        .restore_resolved_policies(
-                            captured,
-                            rollback_rib_budget,
-                            require_clean_convergence,
-                        )
+                        .restore_resolved_policies(captured, context, require_clean_convergence)
                         .await;
                     return Some(Err(match rollback {
                         Ok(()) => PolicySnapshotFailure::compensated_code(
@@ -1971,11 +1984,7 @@ impl PeerManager {
                     managed.pending_refresh = true;
                 }
                 let rollback = self
-                    .restore_resolved_policies(
-                        captured,
-                        rollback_rib_budget,
-                        require_clean_convergence,
-                    )
+                    .restore_resolved_policies(captured, context, require_clean_convergence)
                     .await;
                 return Some(Err(match rollback {
                     Ok(()) => PolicySnapshotFailure::compensated_code(
@@ -2144,9 +2153,17 @@ impl PeerManager {
                 .await
                 .map_err(|_| RibCommandError::internal("RIB manager dropped reply"))?
         };
-        tokio::time::timeout_at(deadline, self.await_with_readiness(round_trip))
-            .await
-            .map_err(|_| timed_out())?
+        tokio::time::timeout_at(
+            deadline,
+            self.await_with_readiness(
+                round_trip,
+                OperatorReadAdmission::Fenced {
+                    reason: "per-peer RIB export replacement of an authoritative walk, bounded by the walk budget",
+                },
+            ),
+        )
+        .await
+        .map_err(|_| timed_out())?
     }
 
     /// Apply a live-impact transaction that may include static neighbors and
@@ -2235,7 +2252,7 @@ impl PeerManager {
     async fn register_policy_rollback_rib(
         &mut self,
         plans: &[PolicyRollbackPeerPlan],
-        budget: &mut PolicySnapshotRibBudget,
+        context: &mut PolicySnapshotContext,
     ) -> Result<Option<RegisteredPolicyRollbackRib>, RuntimeConfigPolicyFailureCode> {
         // `plans` is newest-first because session compensation already ran in
         // reverse application order. The RIB command owns the reversal, so
@@ -2264,7 +2281,7 @@ impl PeerManager {
             return Err(RuntimeConfigPolicyFailureCode::RollbackBatchDuplicate);
         }
 
-        let deadline = budget.rollback.deadline();
+        let deadline = context.rollback.deadline();
         let rib_tx = self.rib_tx.clone();
         let (enqueued_tx, enqueued_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
@@ -2287,7 +2304,16 @@ impl PeerManager {
             }
         });
 
-        match tokio::time::timeout_at(deadline, self.await_with_readiness(enqueued_rx)).await {
+        // Both waits below admit the operator-read lane on the transaction's
+        // terms: every session already runs its restored chain, so a read
+        // observes the generation being restored, and the rollback's own
+        // two-minute budget is unchanged.
+        match tokio::time::timeout_at(
+            deadline,
+            self.await_with_readiness(enqueued_rx, context.operator_reads),
+        )
+        .await
+        {
             Ok(Ok(())) => Ok(Some(RegisteredPolicyRollbackRib { deadline, task })),
             Err(_) => {
                 // Dropping a JoinHandle detaches rather than cancels it. The
@@ -2296,7 +2322,10 @@ impl PeerManager {
                 drop(task);
                 Err(RuntimeConfigPolicyFailureCode::RollbackBatchTimeout)
             }
-            Ok(Err(_)) => match self.await_with_readiness(task).await {
+            Ok(Err(_)) => match self
+                .await_with_readiness(task, context.operator_reads)
+                .await
+            {
                 Ok(Err(code)) => Err(code),
                 Ok(Ok(_)) | Err(_) => Err(RuntimeConfigPolicyFailureCode::RollbackBatchReplyLost),
             },
@@ -2384,7 +2413,10 @@ impl PeerManager {
     /// before any Route Refresh, and all RIB sends/replies share one lazy
     /// absolute deadline across this top-level policy transaction. Timing out or
     /// dropping the caller detaches the exact registered aggregate so FIFO repair
-    /// can continue while conservative pending flags retain retry intent.
+    /// can continue while conservative pending flags retain retry intent. While
+    /// the aggregate is awaited, the operator-read lane is admitted on the
+    /// transaction's terms (`context.operator_reads`); the ordinary command
+    /// receiver stays unpolled, so mutations remain behind the rollback.
     #[expect(
         clippy::too_many_lines,
         reason = "exact rollback keeps session, RIB, refresh, bookkeeping, and pending-flag acknowledgements in one owner"
@@ -2392,7 +2424,7 @@ impl PeerManager {
     async fn restore_resolved_policies(
         &mut self,
         priors: Vec<CapturedResolvedPolicy>,
-        budget: &mut PolicySnapshotRibBudget,
+        context: &mut PolicySnapshotContext,
         require_exact_pending: bool,
     ) -> Result<(), PolicyRollbackFailure> {
         let pending_priors = priors
@@ -2459,7 +2491,7 @@ impl PeerManager {
             }
         }
 
-        let registered = match self.register_policy_rollback_rib(&plans, budget).await {
+        let registered = match self.register_policy_rollback_rib(&plans, context).await {
             Ok(registered) => registered,
             Err(code) => {
                 failure_code.get_or_insert(code);
@@ -2476,7 +2508,7 @@ impl PeerManager {
         if let Some(registered) = registered {
             match tokio::time::timeout_at(
                 registered.deadline,
-                self.await_with_readiness(registered.task),
+                self.await_with_readiness(registered.task, context.operator_reads),
             )
             .await
             {
@@ -2621,10 +2653,15 @@ impl PeerManager {
                 continue;
             };
             let state = self
-                .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                    commands,
-                    PEER_QUERY_TIMEOUT,
-                ))
+                .await_with_readiness(
+                    rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                        commands,
+                        PEER_QUERY_TIMEOUT,
+                    ),
+                    OperatorReadAdmission::Fenced {
+                        reason: "100 ms state probe in a validation-cache refresh fan-out",
+                    },
+                )
                 .await;
             self.drain_readiness_queries().await;
             match state {
@@ -2775,10 +2812,15 @@ impl PeerManager {
                 continue;
             };
             let state = self
-                .await_with_readiness(rustbgpd_transport::PeerHandle::query_state_outcome_with(
-                    commands,
-                    PEER_QUERY_TIMEOUT,
-                ))
+                .await_with_readiness(
+                    rustbgpd_transport::PeerHandle::query_state_outcome_with(
+                        commands,
+                        PEER_QUERY_TIMEOUT,
+                    ),
+                    OperatorReadAdmission::Fenced {
+                        reason: "100 ms state probe in a dataset refresh fan-out",
+                    },
+                )
                 .await;
             self.drain_readiness_queries().await;
             match state {
@@ -3024,7 +3066,13 @@ impl PeerManager {
         let (reply, response) = oneshot::channel();
         permit.send(RibUpdate::ReevaluatePeerExportPolicies { peers, reply });
         match self
-            .await_with_readiness_budget(response, RIB_REPLY_TIMEOUT)
+            .await_with_readiness_budget(
+                response,
+                RIB_REPLY_TIMEOUT,
+                OperatorReadAdmission::Fenced {
+                    reason: "one batched dataset export re-evaluation, bounded by RIB_REPLY_TIMEOUT",
+                },
+            )
             .await
         {
             Some(Ok(Ok(()))) => Ok(()),

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -909,3 +909,179 @@ async fn operator_reads_are_served_while_the_cohort_rib_reply_is_held() {
     drop(manager);
     rib.await.unwrap();
 }
+
+/// Stub RIB that rejects the cohort transition and then holds the rollback
+/// aggregate: signals `held` once `RestorePeerExportPoliciesAuthoritatively`
+/// arrives and answers ordered `Restored` receipts only after `release`.
+fn rib_rejecting_cohort_and_holding_rollback_reply(
+    mut rib_rx: mpsc::Receiver<RibUpdate>,
+    held: oneshot::Sender<()>,
+    release: oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut held = Some(held);
+        let mut release = Some(release);
+        while let Some(update) = rib_rx.recv().await {
+            match update {
+                RibUpdate::PrepareExportPolicyDestination { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                RibUpdate::ReplacePeerExportPolicies { reply, .. } => {
+                    let _ = reply.send(Err("test: cohort transition rejected".to_string()));
+                }
+                RibUpdate::RestorePeerExportPoliciesAuthoritatively {
+                    replacements,
+                    reply,
+                } => {
+                    if let Some(held) = held.take() {
+                        let _ = held.send(());
+                    }
+                    let release = release.take();
+                    tokio::spawn(async move {
+                        if let Some(release) = release {
+                            let _ = release.await;
+                        }
+                        // Receipts are in rollback execution order, the
+                        // reverse of the forward-ordered replacements.
+                        let receipts = replacements
+                            .iter()
+                            .rev()
+                            .map(|replacement| {
+                                rustbgpd_rib::PeerExportPolicyRestoreReceipt::Restored {
+                                    peer: replacement.peer,
+                                }
+                            })
+                            .collect();
+                        let _ = reply.send(Ok(receipts));
+                    });
+                }
+                _ => {}
+            }
+        }
+    })
+}
+
+/// Operator reads admitted while a rejected reload's rollback awaits its RIB
+/// aggregate: with the restore reply held here, a neighbor snapshot and the
+/// fleet import-stats collection both complete on the operator lane instead
+/// of waiting up to the two-minute batch budget. Every cohort session already
+/// runs its prior chain again, so a read observes the generation being
+/// restored. Awaiting the aggregate with the readiness-only helper parks both
+/// reads until the held reply is released and fails the bounded expectations.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the rejected transition, the held rollback aggregate, and the served reads share one fixture"
+)]
+#[tokio::test(start_paused = true)]
+async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
+    use super::super::policy::PolicySnapshotFailureKind;
+    use rustbgpd_api::peer_types::{PeerManagerOperatorQuery, ResolvedPeerPolicy};
+
+    let first = IpAddr::V4(Ipv4Addr::new(10, 39, 0, 1));
+    let second = IpAddr::V4(Ipv4Addr::new(10, 39, 0, 2));
+    let (rib_tx, rib_rx) = mpsc::channel::<RibUpdate>(8);
+    let (held_tx, held_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let rib = rib_rejecting_cohort_and_holding_rollback_reply(rib_rx, held_tx, release_rx);
+
+    let (_command_tx, command_rx) = mpsc::channel(16);
+    let (operator_tx, operator_rx) = mpsc::channel(4);
+    let mut manager = PeerManager::new(
+        command_rx,
+        65001,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        None,
+        BgpMetrics::new(),
+        rib_tx,
+        None,
+    )
+    .with_operator_queries(operator_rx);
+    let installs = Arc::new(AtomicUsize::new(0));
+    for peer in [first, second] {
+        insert_test_managed_peer(
+            &mut manager,
+            peer,
+            cohort_session_with_import_stats(peer, Arc::clone(&installs)),
+            false,
+        );
+    }
+    let next = deny_policy_chain();
+    let targets = [first, second]
+        .into_iter()
+        .map(|address| ResolvedPeerPolicy {
+            address,
+            interface: None,
+            import_policy: None,
+            export_policy: Some(next.clone()),
+        })
+        .collect::<Vec<_>>();
+    let reload = tokio::spawn(async move {
+        let result = manager
+            .apply_resolved_policy_snapshot_with_prestage_reads(targets, false, true)
+            .await;
+        (manager, result)
+    });
+
+    // The cohort transition was rejected; both sessions have been hot-applied
+    // forward and then restored, and the rollback aggregate is now held.
+    held_rx.await.unwrap();
+    assert_eq!(installs.load(Ordering::SeqCst), 4);
+    let (reply, response) = oneshot::channel();
+    operator_tx
+        .send(PeerManagerOperatorQuery::ListPeers { reply })
+        .await
+        .unwrap();
+    let infos = tokio::time::timeout(Duration::from_secs(1), response)
+        .await
+        .expect("a neighbor snapshot is answered while the rollback RIB reply is awaited")
+        .unwrap();
+    assert_eq!(infos.len(), 2);
+    let (reply, response) = oneshot::channel();
+    operator_tx
+        .send(PeerManagerOperatorQuery::QueryImportPolicyTermHits {
+            peer: None,
+            deadline: tokio::time::Instant::now() + Duration::from_secs(2),
+            reply,
+        })
+        .await
+        .unwrap();
+    let rows = tokio::time::timeout(Duration::from_secs(1), response)
+        .await
+        .expect("the import-stats collection is answered while the rollback RIB reply is awaited")
+        .unwrap();
+    assert!(
+        matches!(rows, SessionQueryOutcome::Reply(ref rows) if rows.len() == 2),
+        "{rows:?}"
+    );
+    assert!(
+        !reload.is_finished(),
+        "the transaction stays parked on the held rollback reply"
+    );
+
+    release_tx.send(()).unwrap();
+    let (mut manager, result) = reload.await.unwrap();
+    let failure = result.expect_err("the rejected cohort transition compensates");
+    assert_eq!(
+        failure.kind,
+        PolicySnapshotFailureKind::FullyCompensated,
+        "{}",
+        failure.message
+    );
+    for peer in [first, second] {
+        let restored = manager.peers.get(&key(peer)).unwrap();
+        assert_eq!(
+            (
+                restored.export_policy.as_ref(),
+                restored.pending_export_apply
+            ),
+            (None, false),
+            "{peer} export policy restored and rollback acknowledged"
+        );
+    }
+    for (_, managed) in manager.peers.drain() {
+        managed.handle.shutdown().await.unwrap().unwrap();
+    }
+    drop(manager);
+    rib.await.unwrap();
+}

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -855,7 +855,11 @@ async fn operator_reads_are_served_while_the_cohort_rib_reply_is_held() {
         .collect::<Vec<_>>();
     let reload = tokio::spawn(async move {
         let result = manager
-            .apply_resolved_policy_snapshot_with_prestage_reads(targets, false, true)
+            .apply_resolved_policy_snapshot_with_prestage_reads(
+                targets,
+                false,
+                OperatorReadAdmission::Served,
+            )
             .await;
         (manager, result)
     });
@@ -1018,7 +1022,11 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
         .collect::<Vec<_>>();
     let reload = tokio::spawn(async move {
         let result = manager
-            .apply_resolved_policy_snapshot_with_prestage_reads(targets, false, true)
+            .apply_resolved_policy_snapshot_with_prestage_reads(
+                targets,
+                false,
+                OperatorReadAdmission::Served,
+            )
             .await;
         (manager, result)
     });

--- a/src/peer_manager/tests/cohort_budgets.rs
+++ b/src/peer_manager/tests/cohort_budgets.rs
@@ -738,20 +738,37 @@ async fn forward_walk_rib_budget_stops_expired_retained_proofs() {
     );
 }
 
-/// Established session for the cohort read test: hot-applies export policy
-/// immediately, answers state queries as Established, and answers the
-/// import-stats query so the fleet collection can complete.
-fn cohort_session_with_import_stats(addr: IpAddr, installs: Arc<AtomicUsize>) -> PeerHandle {
+/// Session for cohort read tests. A rejected restore leaves its live state
+/// Idle with an error; other commands acknowledge immediately.
+fn cohort_session_with_import_stats(
+    addr: IpAddr,
+    installs: Arc<AtomicUsize>,
+    reject_restore: bool,
+) -> PeerHandle {
     let (session_tx, mut session_rx) = mpsc::channel::<PeerCommand>(16);
     let task = tokio::spawn(async move {
+        let mut restore_failed = false;
         while let Some(command) = session_rx.recv().await {
             match command {
-                PeerCommand::UpdateExportPolicy { reply, .. } => {
+                PeerCommand::UpdateExportPolicy { policy, reply } => {
                     installs.fetch_add(1, Ordering::SeqCst);
-                    let _ = reply.send(Ok(()));
+                    restore_failed = reject_restore && policy.is_none();
+                    let result = if restore_failed {
+                        Err(rustbgpd_transport::PeerCommandError::CommandFailed(
+                            "test: session restore rejected".to_string(),
+                        ))
+                    } else {
+                        Ok(())
+                    };
+                    let _ = reply.send(result);
                 }
                 PeerCommand::QueryState { reply } => {
-                    let _ = reply.send(policy_test_peer_state(addr, SessionState::Established));
+                    let mut state = policy_test_peer_state(addr, SessionState::Established);
+                    if restore_failed {
+                        state.fsm_state = SessionState::Idle;
+                        state.last_error = "test: session restore rejected".to_string();
+                    }
+                    let _ = reply.send(state);
                 }
                 PeerCommand::QueryImportPolicyTermHits { reply } => {
                     let _ = reply.send(Some(rustbgpd_transport::ImportPolicyTermHits {
@@ -839,7 +856,7 @@ async fn operator_reads_are_served_while_the_cohort_rib_reply_is_held() {
         insert_test_managed_peer(
             &mut manager,
             peer,
-            cohort_session_with_import_stats(peer, Arc::clone(&installs)),
+            cohort_session_with_import_stats(peer, Arc::clone(&installs), false),
             false,
         );
     }
@@ -966,18 +983,17 @@ fn rib_rejecting_cohort_and_holding_rollback_reply(
 }
 
 /// Operator reads admitted while a rejected reload's rollback awaits its RIB
-/// aggregate: with the restore reply held here, a neighbor snapshot and the
+/// aggregate: with the restore reply held here, a peer-manager snapshot and the
 /// fleet import-stats collection both complete on the operator lane instead
-/// of waiting up to the two-minute batch budget. Every cohort session already
-/// runs its prior chain again, so a read observes the generation being
-/// restored. Awaiting the aggregate with the readiness-only helper parks both
+/// of waiting up to the two-minute batch budget. A failed session restore is
+/// visible in its live snapshot; admission does not imply successful rollback
+/// or a common generation. Awaiting the aggregate with a fenced helper parks both
 /// reads until the held reply is released and fails the bounded expectations.
 #[expect(
     clippy::too_many_lines,
     reason = "the rejected transition, the held rollback aggregate, and the served reads share one fixture"
 )]
-#[tokio::test(start_paused = true)]
-async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
+async fn assert_operator_reads_during_rollback(reject_first_restore: bool) {
     use super::super::policy::PolicySnapshotFailureKind;
     use rustbgpd_api::peer_types::{PeerManagerOperatorQuery, ResolvedPeerPolicy};
 
@@ -1006,7 +1022,11 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
         insert_test_managed_peer(
             &mut manager,
             peer,
-            cohort_session_with_import_stats(peer, Arc::clone(&installs)),
+            cohort_session_with_import_stats(
+                peer,
+                Arc::clone(&installs),
+                reject_first_restore && peer == first,
+            ),
             false,
         );
     }
@@ -1031,9 +1051,12 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
         (manager, result)
     });
 
-    // The cohort transition was rejected; both sessions have been hot-applied
-    // forward and then restored, and the rollback aggregate is now held.
-    held_rx.await.unwrap();
+    // The cohort was rejected and both session restores were attempted. The
+    // successful restores' aggregate is held even if one session rejected.
+    tokio::time::timeout(Duration::from_secs(5), held_rx)
+        .await
+        .expect("the rollback reaches its RIB aggregate")
+        .unwrap();
     assert_eq!(installs.load(Ordering::SeqCst), 4);
     let (reply, response) = oneshot::channel();
     operator_tx
@@ -1045,6 +1068,24 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
         .expect("a neighbor snapshot is answered while the rollback RIB reply is awaited")
         .unwrap();
     assert_eq!(infos.len(), 2);
+    let first_info = infos.iter().find(|info| info.address == first).unwrap();
+    assert_eq!(
+        first_info.state,
+        if reject_first_restore {
+            SessionState::Idle
+        } else {
+            SessionState::Established
+        },
+        "the admitted snapshot reports the session's live state"
+    );
+    assert_eq!(
+        first_info.last_error,
+        if reject_first_restore {
+            "test: session restore rejected"
+        } else {
+            ""
+        }
+    );
     let (reply, response) = oneshot::channel();
     operator_tx
         .send(PeerManagerOperatorQuery::QueryImportPolicyTermHits {
@@ -1072,7 +1113,11 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
     let failure = result.expect_err("the rejected cohort transition compensates");
     assert_eq!(
         failure.kind,
-        PolicySnapshotFailureKind::FullyCompensated,
+        if reject_first_restore {
+            PolicySnapshotFailureKind::CompensationAmbiguous
+        } else {
+            PolicySnapshotFailureKind::FullyCompensated
+        },
         "{}",
         failure.message
     );
@@ -1083,8 +1128,12 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
                 restored.export_policy.as_ref(),
                 restored.pending_export_apply
             ),
-            (None, false),
-            "{peer} export policy restored and rollback acknowledged"
+            if reject_first_restore && peer == first {
+                (Some(&next), true)
+            } else {
+                (None, false)
+            },
+            "{peer} keeps the acknowledged policy and any outstanding restore intent"
         );
     }
     for (_, managed) in manager.peers.drain() {
@@ -1092,4 +1141,14 @@ async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
     }
     drop(manager);
     rib.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn operator_reads_are_served_while_the_rollback_rib_reply_is_held() {
+    assert_operator_reads_during_rollback(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn operator_reads_report_a_failed_session_restore_while_rollback_is_held() {
+    assert_operator_reads_during_rollback(true).await;
 }

--- a/src/peer_manager/tests/policy_stats.rs
+++ b/src/peer_manager/tests/policy_stats.rs
@@ -758,7 +758,11 @@ async fn prestage_import_snapshot_finishes_before_ready_ack_and_services_readine
         let (finished, mut finished_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
             let outcome = manager
-                .await_with_readiness_and_operator_budget(ack_rx, Duration::from_secs(10), true)
+                .await_with_readiness_budget(
+                    ack_rx,
+                    Duration::from_secs(10),
+                    OperatorReadAdmission::Served,
+                )
                 .await;
             let _ = finished.send(outcome);
             manager
@@ -1372,7 +1376,11 @@ async fn deferred_neighbor_read_survives_receiver_close_and_fences_prestage_ack(
         let (ack, ack_rx) = oneshot::channel();
         let worker = tokio::spawn(async move {
             let result = manager
-                .await_with_readiness_and_operator_budget(ack_rx, Duration::from_secs(1), true)
+                .await_with_readiness_budget(
+                    ack_rx,
+                    Duration::from_secs(1),
+                    OperatorReadAdmission::Served,
+                )
                 .await;
             assert!(matches!(result, Some(Ok(()))));
             manager

--- a/src/peer_manager/tests/reload_generation.rs
+++ b/src/peer_manager/tests/reload_generation.rs
@@ -1121,11 +1121,20 @@ async fn assert_generation_operator_read_boundaries(compensate: bool) {
             .unwrap();
         ping.await.unwrap();
         let queued_response = if compensate {
+            // The held message here is the destination prestage of the
+            // generation-level compensation: the policy phase committed, the
+            // later peer replacement failed, and the generation replays the
+            // captured priors through the forward snapshot path with operator
+            // reads fenced (`apply_resolved_policy_snapshot`). That prestage
+            // is bounded by `RIB_REPLY_TIMEOUT` and admits nothing. The
+            // in-transaction rollback aggregate (a rejected cohort's
+            // `RestorePeerExportPoliciesAuthoritatively`) is a different wait
+            // and does admit reads; `cohort_budgets` covers it.
             assert!(
                 tokio::time::timeout(Duration::from_millis(20), &mut response)
                     .await
                     .is_err(),
-                "operator reads must stay fenced during rollback"
+                "operator reads must stay fenced during the compensating replay's prestage"
             );
             Some(response)
         } else {

--- a/src/peer_manager/tests/wait_sites.rs
+++ b/src/peer_manager/tests/wait_sites.rs
@@ -1,7 +1,8 @@
 //! Operator-read admission at every peer-manager transaction wait.
 //!
-//! Every `await_with_readiness*` call site is one row of [`WAIT_SITES`]: what
-//! the site awaits, how a stub parks the transaction there, and whether a
+//! Every `await_with_readiness*` or `finish_admitted_operator_read` call site
+//! is one row of [`WAIT_SITES`]: what the site awaits, how a stub parks the
+//! transaction there, and whether a
 //! concurrent operator read (`ListPeers`, `QueryImportPolicyTermHits`) is
 //! served or deliberately fenced while it is parked. One driver runs every
 //! row. [`wait_site_table_covers_every_call_site`] fails when a call site is
@@ -18,9 +19,9 @@ use rustbgpd_api::runtime_config_settlement::RuntimeConfigPolicyFailureCode;
 use rustbgpd_rib::{ExportPolicyCohortOutcome, PeerExportPolicyRestoreReceipt};
 use rustbgpd_transport::ImportPolicyTermHits;
 
-/// Server-side deadline of every peer-manager read (`PEER_MANAGER_READ_TIMEOUT`
-/// in the API crate). A fenced site whose bound is below this never fails a
-/// reader on its own.
+/// Fresh caller budget used by this matrix (`PEER_MANAGER_READ_TIMEOUT` in
+/// the API crate). Prior queueing or other stages can consume that budget
+/// before a read encounters even a shorter individual fence.
 const READER_DEADLINE: Duration = Duration::from_secs(2);
 
 /// Reads issued while the site is parked. `Fenced` rows probe for `window`
@@ -216,12 +217,7 @@ const FORWARD_COHORT: Drive = Drive::ForwardCohort {
 const QUERY_PROBE_REASON: &str = "one session state probe bounded by PEER_QUERY_TIMEOUT (100 ms), \
      below the 2 s reader deadline; the readiness lane is drained after it";
 
-const ROLLBACK_REASON: &str = "rollback: sessions already run the restored chains while the RIB still \
-     evaluates the rejected ones; the readiness-only helper keeps operator reads fenced until the \
-     restore batch is acknowledged, bounded by the rollback budget (RIB_BATCH_REPLY_TIMEOUT, 2 min), \
-     which can outlast the 2 s reader deadline";
-
-/// One row per `await_with_readiness*` call site, in source order.
+/// One row per actor wait-helper call site, in source order.
 const WAIT_SITES: &[WaitSite] = &[
     WaitSite {
         site: "mod.rs::handle_operator_query",
@@ -235,8 +231,8 @@ const WAIT_SITES: &[WaitSite] = &[
         contract: Contract::Fenced {
             reason: "one admitted read completes before the next is polled: its collector must \
                      finish before a prestage ACK can advance a session's installed policy, and \
-                     it is bounded by that read's own deadline, so a queued read waits at most \
-                     one reader deadline",
+                     the collector uses the admitted read's absolute deadline; queued reads \
+                     can already have spent part of their own budget",
         },
         completion: Completion::ExportApplied,
     },
@@ -490,9 +486,8 @@ const WAIT_SITES: &[WaitSite] = &[
         },
         completion: Completion::ExportApplied,
     },
-    // Expected to flip to `Contract::Served` by the rollback-admission change
-    // that lets the rollback owner admit operator reads at both rollback waits
-    // (this row and `restore_resolved_policies` below).
+    // The rollback owner admits live peer-manager reads at both waits. The
+    // RIB's general-query lane is a separate contract, not exercised here.
     WaitSite {
         site: "policy.rs::register_policy_rollback_rib",
         awaits: "rollback RestorePeerExportPoliciesAuthoritatively enqueue acknowledgement",
@@ -505,9 +500,7 @@ const WAIT_SITES: &[WaitSite] = &[
         pre_read: false,
         additional_entry: None,
         window: HELD_FOREVER,
-        contract: Contract::Fenced {
-            reason: ROLLBACK_REASON,
-        },
+        contract: Contract::Served,
         completion: Completion::ExportRestored,
     },
     WaitSite {
@@ -529,7 +522,7 @@ const WAIT_SITES: &[WaitSite] = &[
         },
         completion: Completion::ExportRestored,
     },
-    // Expected to flip to `Contract::Served` together with the enqueue row.
+    // Deliberately served together with the rollback enqueue row above.
     WaitSite {
         site: "policy.rs::restore_resolved_policies",
         awaits: "rollback RestorePeerExportPoliciesAuthoritatively aggregate reply",
@@ -542,9 +535,7 @@ const WAIT_SITES: &[WaitSite] = &[
         pre_read: false,
         additional_entry: None,
         window: HELD_FOREVER,
-        contract: Contract::Fenced {
-            reason: ROLLBACK_REASON,
-        },
+        contract: Contract::Served,
         completion: Completion::ExportRestored,
     },
     WaitSite {
@@ -943,7 +934,11 @@ async fn drive(manager: &mut PeerManager, drive: Drive, peers: [IpAddr; 2]) -> R
         Drive::ForwardCohort { .. }
         | Drive::ForwardWalk { .. }
         | Drive::Rfc8212Transition { .. } => manager
-            .apply_resolved_policy_snapshot_with_prestage_reads(targets, clean, true)
+            .apply_resolved_policy_snapshot_with_prestage_reads(
+                targets,
+                clean,
+                OperatorReadAdmission::Served,
+            )
             .await
             .map(drop)
             .map_err(|failure| failure.message),
@@ -1280,11 +1275,10 @@ async fn every_wait_site_honours_its_operator_read_contract() {
 /// Call sites of the wait helpers per enclosing function, excluding the
 /// helper definitions themselves.
 fn wait_call_sites(file: &'static str, source: &str) -> BTreeMap<String, usize> {
-    const HELPERS: [&str; 4] = [
+    const HELPERS: [&str; 3] = [
         "await_with_readiness",
-        "await_with_readiness_and_operator_reads",
         "await_with_readiness_budget",
-        "await_with_readiness_and_operator_budget",
+        "finish_admitted_operator_read",
     ];
     let mut sites = BTreeMap::new();
     let mut current = "<none>";
@@ -1304,7 +1298,8 @@ fn wait_call_sites(file: &'static str, source: &str) -> BTreeMap<String, usize> 
                 .next()
                 .expect("split yields at least one piece");
         }
-        let calls = trimmed.matches(".await_with_readiness").count();
+        let calls = trimmed.matches(".await_with_readiness").count()
+            + trimmed.matches(".finish_admitted_operator_read").count();
         if calls > 0 && !HELPERS.contains(&current) {
             *sites.entry(format!("{file}::{current}")).or_default() += calls;
         }
@@ -1312,7 +1307,7 @@ fn wait_call_sites(file: &'static str, source: &str) -> BTreeMap<String, usize> 
     sites
 }
 
-/// A new `await_with_readiness*` call site must get a row in `WAIT_SITES`
+/// A new actor wait-helper call site must get a row in `WAIT_SITES`
 /// stating whether operator reads are served or fenced there, and why. Rows
 /// that re-exercise a covered site through another entry point
 /// (`additional_entry`) are not counted, so each site is keyed once.
@@ -1335,7 +1330,7 @@ fn wait_site_table_covers_every_call_site() {
     }
     assert_eq!(
         sources, table,
-        "every await_with_readiness* call site needs exactly one WAIT_SITES row keyed by \
+        "every actor wait-helper call site needs exactly one WAIT_SITES row keyed by \
          file::enclosing_fn (left: call sites in the source, right: table rows); add a row \
          stating whether operator reads are served or fenced at the new site, and why"
     );


### PR DESCRIPTION
## Problem and delivered scope

A rejected SIGHUP reload parks the peer manager while its batched RIB restore is enqueued and acknowledged, for up to the two-minute rollback budget. This change admits the existing bounded operator-read lane at those waits: session snapshots, import-policy statistics, and dataset status can complete while the peer manager still owns the rollback.

**This is a partial correction, not a complete rollback RPC availability fix.** The RIB still executes `RestorePeerExportPoliciesAuthoritatively` synchronously and fences its general-query lane. Neighbor RPCs need a RIB snapshot after their peer-manager snapshot; `policy stats --direction both` requests export statistics from the RIB before import statistics from sessions. Either RPC can still exhaust its deadline during a long RIB restore. A forced-rejection run under the 1000-peer management-load cell and a safe RIB-side read solution remain outstanding.

## Behavior and consistency

The forward reload owner carries `OperatorReadAdmission::Served` into its rollback. Ordinary commands remain queued, each admitted read completes before the peer-manager wait resumes, and the rollback's two-minute absolute budget is unchanged. Standalone policy transactions and a reload's later compensating replay retain their fences.

Reads report live state after session restoration has been attempted. A failed restore can leave sessions on different policies; peer-manager and RIB replies do not share a generation pin. Admission does not imply successful compensation. The regression explicitly checks a rejected session restore while another peer's RIB restoration is still awaited.

`OperatorReadAdmission::{Served, Fenced { reason }}` replaces the boolean admission chain. `PolicySnapshotContext` carries the decision alongside the existing RIB budgets and clean-state retry window. Each actor-owned wait states admission; fenced sites retain a local reason. `finish_admitted_operator_read` admits readiness only while completing an already admitted read, avoiding nested operator admission. The operator handler is boxed only when a read is admitted to avoid increasing every fenced future's size.

## Regressions and matrix integration

- A rejected cohort's rollback reply is held; a peer-manager `ListPeers` snapshot and fleet import-statistics collection each finish within one second of virtual time while the transaction remains parked. Releasing the reply completes compensation and clears acknowledged peers' export debt. The original regression failed on the unfixed tree with the bounded snapshot expectation timing out.
- The same fixture rejects one session restore. The admitted snapshot reports that session's live `Idle` state and error, then the transaction reports `CompensationAmbiguous`; the failed peer retains its installed policy and pending export-apply intent while the successfully restored peer clears its debt.
- The matrix introduced by #2458 deliberately changes the rollback enqueue and aggregate rows from fenced to served. Its full-channel enqueue case exercises admission before the RIB accepts the restore. The failed-send task remains unreachable as a parked wait; standalone and compensating-replay entries remain fenced.
- The completeness guard includes the renamed `finish_admitted_operator_read`, preserving coverage of the admitted collector's completion fence. The matrix's forward owner entry uses the explicit admission value.

These are peer-manager regressions with a stub RIB. They do not establish end-to-end RPC availability during the RIB's synchronous restore.

## Remaining wait-site audit

Concurrent operator callers have 100 ms, 500 ms, and 2 s deadlines. A serial collection of individually short fenced waits can exceed the fleet deadline. "Per context" means served for the forward SIGHUP owner and its in-transaction rollback, fenced for standalone policy transactions and the later compensating replay.

| Site in `policy.rs` unless noted | Wait and bound | Admission |
| --- | --- | --- |
| `qualify_rfc8212_import_transition` | Per-peer state probe, 100 ms; serial preflight can exceed 2 s | Fenced |
| `query_peer_retained_stale` | Primary-lane RIB proof, shared 2 min walk budget or 5 s inline | Fenced |
| Cohort selection | Per-peer state probe, 100 ms; serial fleet walk can exceed 2 s | Fenced |
| `hot_apply_session_policy` | Session apply, 500 ms attention budget per peer | Fenced |
| `query_clean_session_state` | 100 ms probe plus one retry within a shared 2 s window | Fenced |
| Cohort destination prestage | RIB preparation, 5 s attention budget | Per context |
| Post-reassert cohort export failure probe | One 100 ms state probe | Fenced |
| Deferred refresh state probe | 100 ms per changed member; serial walk can exceed 2 s | Fenced |
| `await_export_policy_cohort_rib_reply` | No local reply deadline; RIB owns its 60 s pre-commit budget | Per context |
| `apply_export_policy_replacements_authoritatively` | Send, then reply with a 2 min bound | Per context |
| `replace_peer_export_policy_in_rib` | Per-peer replacement, shared 2 min walk budget or 5 s inline | Fenced |
| `register_policy_rollback_rib` | Enqueue acknowledgement under the shared 2 min rollback budget | **Per context, changed here** |
| `register_policy_rollback_rib` failed-send task | Task already returned when its acknowledgement closes | Cannot park |
| `restore_resolved_policies` | Registered aggregate under the same 2 min rollback budget | **Per context, changed here** |
| Validation-cache refresh fan-out | 100 ms state probe per dependent | Fenced |
| Dataset refresh fan-out | 100 ms state probe per dependent | Fenced |
| `reevaluate_dataset_exports` | RIB batch, 5 s attention budget | Fenced |
| `lifecycle.rs::handle_due_max_prefix_restarts` | One shared absolute 500 ms deadline for all Start sends; does not scale with member count | Fenced |
| `mod.rs::handle_operator_query` | An already admitted collector's own deadline | Readiness only |

Serial walks, primary-lane RIB waits, and the two non-owner transaction entries remain separate work. Adding arbitrary live-query drains inside authoritative restore would expose intermediate policy and membership mutations; this PR does not do that.

## Validation

After integrating #2458, #2459, and #2462, head `f9140679b` passed all 449 focused peer-manager tests, including both rollback fixtures and the matrix. Normal commit and push hooks passed formatting, strict workspace Clippy, workspace library tests, and rustdoc. Local documentation links, public-content checks, the site-manifest check, lint-reason validation, and diff whitespace checks also passed.

The original runtime head passed `just gate`. The integration follow-up changes tests and documentation; the broader combined-main gate remains part of merge follow-through.
