### PR TITLE
test(api): make the audit-level assertion independent of callsite interest timing

### DIFF
--- a/crates/api/src/authz_runtime/tests.rs
+++ b/crates/api/src/authz_runtime/tests.rs
@@ -1061,6 +1061,10 @@ async fn liveness_rpc_authenticates_and_respects_read_listener_cap() {
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one pinned level per audit case plus the in-scope callsite warm-up"
+)]
 fn only_successful_read_audits_are_debug_and_all_are_counted() {
     use tracing::{Event, Level, Metadata, Subscriber, span};
     struct Levels(Arc<Mutex<Vec<Level>>>);
@@ -1150,10 +1154,19 @@ fn only_successful_read_audits_are_debug_and_all_are_counted() {
             );
         }
     };
-    // Initialize callsites before installing the scoped subscriber; another
-    // parallel test may otherwise register one under its default dispatcher.
-    record(&BgpMetrics::new());
-    tracing::subscriber::with_default(Levels(levels.clone()), || record(&metrics));
+    tracing::subscriber::with_default(Levels(levels.clone()), || {
+        // Registering this dispatcher raises the process max level from OFF,
+        // so sibling tests start registering these callsites right now, and
+        // whichever thread registers one first caches its interest
+        // process-wide; a thread with no subscriber caches `Interest::never()`,
+        // which drops the event on the macro fast path. Warm the callsites,
+        // then re-register everything against this subscriber; a callsite
+        // registers once, so the measured calls cannot lose that race.
+        record(&BgpMetrics::new());
+        tracing::callsite::rebuild_interest_cache();
+        levels.lock().unwrap().clear();
+        record(&metrics);
+    });
     assert_eq!(*levels.lock().unwrap(), cases.map(|(_, _, level)| level));
     assert_eq!(
         gather_text(&metrics)


### PR DESCRIPTION
## Failure

`authz_runtime::tests::only_successful_read_audits_are_debug_and_all_are_counted` fails intermittently inside the parallel `rustbgpd-api --lib` suite while passing reliably alone:

```
assertion `left == right` failed
  left:  [Debug, Info, Info, Info, Info, Info, Info]
  right: [Debug, Info, Info, Info, Info, Info, Info, Warn]
```

A second shape was also observed while reproducing (`left: [Debug, Warn]`): the six INFO events were the ones dropped that time.

## Mechanism (verified against tracing 0.1.44 / tracing-core 0.1.36)

- `tracing-core` initialises the process max level to `OFF`; the event macros check `LevelFilter::current()` before touching the callsite. In this test binary nothing registers a dispatcher before this test, so the old warm-up call outside `with_default` registered no callsite at all.
- `with_default` calls `Dispatch::new`, which registers the dispatcher, rebuilds the interest cache and raises the max level to `TRACE`. From that instant every thread in the process starts registering the callsites it hits.
- A callsite registers once. With a single registered dispatcher, `DefaultCallsite::register` computes the interest via `Rebuilder::JustOne`, i.e. from the *registering* thread's default dispatcher. A sibling test thread has no subscriber, so it caches `Interest::never()` for the callsite process-wide, and the macro's cached-interest fast path then drops the event before any subscriber is consulted.
- The test thread hits the DEBUG and INFO callsites first and the WARN callsite last, so the WARN callsite is the one most often lost to a sibling; which callsite is lost depends only on which one a sibling registers first.

A deterministic reproduction (a throwaway thread emitting the operator-only audit inside the scope before the test thread does) drops the WARN event every time and is repaired by `rebuild_interest_cache()` inside the scope.

## Fix

Move the warm-up inside the scoped subscriber, then call `tracing::callsite::rebuild_interest_cache()` and clear the captured levels before the measured calls. All three audit callsites are registered by the time the rebuild runs, the rebuild re-evaluates them against the scoped subscriber, and a callsite cannot register again, so the measured calls can no longer lose the race. This is the pattern the rib and config tests already use.

## Loops

- Before (`cargo test -p rustbgpd-api --lib`): 0 failures in 15 runs at the default thread count; 2 failures in 15 runs at `--test-threads=64` (both the assertion above).
- After: 0 failures in 30 runs (15 at `--test-threads=64`, 15 at the default thread count).

## Other scoped-subscriber test sites

- `crates/rib/src/manager/tests/orf.rs`, `crates/rib/src/manager/tests/rpki.rs`, `src/config/tests/rpol.rs`: already warm inside the scope and call `rebuild_interest_cache()` before the measured call; unchanged.
- `src/reload.rs`, `src/peer_manager/tests/reload_generation.rs`: `set_default` followed by `rebuild_interest_cache()`, no warm-up. The rebuild repairs any callsite a sibling already registered; the residual window is a sibling registering one of the measured callsites for the first time between the rebuild and the measured call. No failure observed; unchanged.
- `crates/rib/src/manager/update_groups/tests.rs` (`extend_inventory` degradation event): `rebuild_interest_cache()` inside the scope, no warm-up; same narrow residual as above. No failure observed; unchanged.
- `crates/rib/src/manager/tests/update_groups.rs` (abandoned authoritative export-policy batch): neither warm-up nor rebuild, but the skip callsite is reached only when the reply is already closed at dispatch, which no sibling drives without a subscriber. No failure observed; unchanged.

## Gates

HEAD `246134b7190089e0ba8feb3aea52c6d89c41fec0`

- `cargo fmt --all -- --check`: rc=0
- `cargo test -p rustbgpd-api --lib`: rc=0 (781 passed)
- `cargo clippy -p rustbgpd-api --all-targets --locked -- -D warnings`: rc=0
- `scripts/check-clippy-reasons.py`: rc=0 (the test gains a `too_many_lines` expectation with a reason; the in-scope warm-up pushed it two code lines over the limit)
