### PR TITLE
fix(test): preserve nested cargo build fingerprints

### DIFF
--- a/tests/birdwatcher_adapter_smoke.rs
+++ b/tests/birdwatcher_adapter_smoke.rs
@@ -28,6 +28,9 @@
 //! announcer's noexport view with the gate name and the synthesized
 //! noexport-reason community).
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::os::unix::fs::PermissionsExt as _;
@@ -973,6 +976,98 @@ fn ixp_contract_gate_tracks_adapter_and_live_smoke_changes() {
 }
 
 #[test]
+fn nested_cargo_preserves_build_script_fingerprints() {
+    const TRACKED: [&str; 6] = [
+        "CARGO_MANIFEST_DIR",
+        "CARGO_PKG_NAME",
+        "CARGO_PKG_VERSION_MAJOR",
+        "CARGO_PKG_VERSION_MINOR",
+        "CARGO_PKG_VERSION_PATCH",
+        "CARGO_PKG_VERSION_PRE",
+    ];
+    assert!(
+        TRACKED.iter().any(|key| std::env::var_os(key).is_some()),
+        "run this regression through cargo test to supply parent package metadata"
+    );
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("Cargo.toml");
+    let target = temp.path().join("target");
+    std::fs::write(
+        &manifest,
+        "[package]\nname = \"cargo-environment-probe\"\nversion = \"0.0.0\"\n\
+         edition = \"2024\"\n[lib]\npath = \"lib.rs\"\n[workspace]\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("lib.rs"), "").unwrap();
+    std::fs::write(
+        temp.path().join("build.rs"),
+        format!(
+            r#"fn main() {{
+    for key in {TRACKED:?} {{ println!("cargo:rerun-if-env-changed={{key}}"); }}
+    println!("cargo:rerun-if-changed=build.rs");
+    assert_eq!(std::env::var("CARGO_PKG_NAME").unwrap(), "cargo-environment-probe");
+    let count = std::path::Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("executions");
+    let previous: u32 = std::fs::read_to_string(&count).unwrap_or_default().parse().unwrap_or(0);
+    std::fs::write(count, (previous + 1).to_string()).unwrap();
+}}
+"#
+        ),
+    )
+    .unwrap();
+    let run = |mut command: Command| {
+        let output = command
+            .args([
+                "build",
+                "--offline",
+                "--message-format=json",
+                "--manifest-path",
+            ])
+            .arg(&manifest)
+            .arg("--target-dir")
+            .arg(&target)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "fixture build failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let out_dir = String::from_utf8(output.stdout)
+            .unwrap()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .find(|message| message["reason"] == "build-script-executed")
+            .expect("Cargo reports the build script output directory")["out_dir"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        std::fs::read_to_string(Path::new(&out_dir).join("executions"))
+            .unwrap()
+            .parse::<u32>()
+            .unwrap()
+    };
+    // Model clean top-level Cargo independently of the helper under test.
+    let clean_control = || {
+        let mut command = cargo::command();
+        for key in TRACKED {
+            command.env_remove(key);
+        }
+        command
+    };
+    assert_eq!(run(clean_control()), 1);
+    assert_eq!(
+        run(cargo::command()),
+        1,
+        "nested Cargo must reuse the clean build-script fingerprint"
+    );
+    assert_eq!(
+        run(clean_control()),
+        1,
+        "returning to top-level Cargo must not rebuild the fixture"
+    );
+}
+
+#[test]
 fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_subset() {
     let temp = tempfile::tempdir().expect("create temp dir");
     std::fs::set_permissions(temp.path(), std::fs::Permissions::from_mode(0o700))
@@ -986,7 +1081,6 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         "pb_0001_as65020=127.0.0.1@master4\npb_0002_as65030=127.0.0.2@master4\n",
     )
     .expect("write initial aliases");
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
     let ars_context = temp.path().join("arouteserver-context.yml");
     let context =
@@ -995,7 +1089,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
             .replacen("192.0.2.11", "127.0.0.1", 1);
     std::fs::write(&ars_context, context).expect("write smoke renderer context");
     let ars_output = temp.path().join("arouteserver-render");
-    let rendered = Command::new(&cargo)
+    let rendered = cargo::command()
         .current_dir(workspace)
         .args(["run", "--quiet", "-p", "rs-config-render", "--"])
         .arg("--context")
@@ -1019,7 +1113,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     // the workspace build has usually compiled it already.
     let adapter_stderr = temp.path().join("adapter.stderr.log");
     let mut adapter = Proc {
-        child: Command::new(&cargo)
+        child: cargo::command()
             .args(["run", "--quiet", "-p", "birdwatcher-adapter", "--"])
             .arg("--grpc-addr")
             .arg(format!("unix://{}", grpc_socket.display()))
@@ -1836,7 +1930,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
     // Exercise the real branch so file mode cannot accidentally replace it.
     let direct_stderr = temp.path().join("direct-adapter.stderr.log");
     let mut direct_adapter = Proc {
-        child: Command::new(&cargo)
+        child: cargo::command()
             .args(["run", "--quiet", "-p", "birdwatcher-adapter", "--"])
             .arg("--grpc-addr")
             .arg(format!("unix://{}", grpc_socket.display()))
@@ -1872,7 +1966,7 @@ fn adapter_serves_birdwatcher_shaped_status_peer_accepted_filtered_and_noexport_
         get_json(direct_port, "/protocol/pb_direct_as65020", "direct adapter")["protocol"]["protocol"],
         "pb_direct_as65020"
     );
-    let invalid_direct = Command::new(&cargo)
+    let invalid_direct = cargo::command()
         .args(["run", "--quiet", "-p", "birdwatcher-adapter", "--"])
         .env("NO_COLOR", "1")
         .arg("--grpc-addr")

--- a/tests/commit_confirm_binary.rs
+++ b/tests/commit_confirm_binary.rs
@@ -17,6 +17,9 @@
 //! - any locator-free retired journal → boot refuses with N-1 recovery
 //!   guidance and leaves the evidence untouched.
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::fs::File;
 use std::os::unix::ffi::OsStrExt as _;
 use std::os::unix::fs::PermissionsExt as _;
@@ -100,8 +103,7 @@ fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
         let mut cmd = Command::new(path);
         cmd.arg("--addr").arg(grpc_addr).args(args).output()
     } else {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut cmd = Command::new(cargo);
+        let mut cmd = cargo::command();
         cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
             .arg("--addr")
             .arg(grpc_addr)

--- a/tests/evpn_dataplane_rr_only.rs
+++ b/tests/evpn_dataplane_rr_only.rs
@@ -17,6 +17,9 @@
 //! spawned: yes/no", which is queued under Phase 6's gRPC status
 //! work.
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::fs::File;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
@@ -120,8 +123,7 @@ fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
         let mut cmd = Command::new(path);
         cmd.arg("--addr").arg(grpc_addr).args(args).output()
     } else {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut cmd = Command::new(cargo);
+        let mut cmd = cargo::command();
         cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
             .arg("--addr")
             .arg(grpc_addr)

--- a/tests/evpn_instances_binary.rs
+++ b/tests/evpn_instances_binary.rs
@@ -1,3 +1,6 @@
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::fs::File;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
@@ -73,8 +76,7 @@ fn rbgp(grpc_addr: &str, args: &[&str]) -> Output {
         let mut cmd = Command::new(path);
         cmd.arg("--addr").arg(grpc_addr).args(args).output()
     } else {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut cmd = Command::new(cargo);
+        let mut cmd = cargo::command();
         cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
             .arg("--addr")
             .arg(grpc_addr)

--- a/tests/grpc_failure_exit_code.rs
+++ b/tests/grpc_failure_exit_code.rs
@@ -7,6 +7,9 @@
 //! and the peer manager; the Shutdown RPC proof pins the intentional exit-0 path
 //! beside them.
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::fs::PermissionsExt as _;
@@ -332,8 +335,7 @@ fn rbgp_command(grpc_addr: &str) -> Command {
         cmd.arg("--addr").arg(grpc_addr);
         cmd
     } else {
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut cmd = Command::new(cargo);
+        let mut cmd = cargo::command();
         cmd.args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
             .arg("--addr")
             .arg(grpc_addr);

--- a/tests/manrs_action1_example.rs
+++ b/tests/manrs_action1_example.rs
@@ -1,6 +1,9 @@
 //! The copyable MANRS Action 1 example stays daemon-valid and its embedded
 //! policy tests run through the real `rbgp policy check` command.
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -21,8 +24,7 @@ fn run_rbgp(args: &[&str]) -> Output {
             .expect("run rbgp");
     }
 
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    Command::new(cargo)
+    cargo::command()
         .args(["run", "--quiet", "-p", "rustbgpctl", "--bin", "rbgp", "--"])
         .args(args)
         .current_dir(repo_root())

--- a/tests/quickstart_dynamic_neighbor.rs
+++ b/tests/quickstart_dynamic_neighbor.rs
@@ -4,6 +4,9 @@
 //! runtime listeners, extracts the JSON and CLI commands from the guide
 //! itself, and proves runtime apply plus durable persistence.
 
+#[path = "support/cargo.rs"]
+mod cargo;
+
 use std::fs::File;
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
@@ -121,8 +124,7 @@ fn rbgp(grpc_addr: &str, cwd: &Path, args: &[&str]) -> Output {
                 .current_dir(cwd)
                 .output()
         } else {
-            let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-            let mut command = Command::new(cargo);
+            let mut command = cargo::command();
             command
                 .arg("run")
                 .arg("--quiet")

--- a/tests/support/cargo.rs
+++ b/tests/support/cargo.rs
@@ -1,0 +1,21 @@
+//! Cargo subprocesses started by integration tests.
+
+use std::process::Command;
+
+/// Keep caller build controls, but discard the enclosing test package's metadata.
+/// Build scripts track Cargo's incoming environment before Cargo supplies their
+/// own package values; inheriting these values needlessly changes fingerprints.
+pub fn command() -> Command {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut command = Command::new(cargo);
+    for (key, _) in std::env::vars_os() {
+        if key == "CARGO_MANIFEST_DIR"
+            || key
+                .to_str()
+                .is_some_and(|key| key.starts_with("CARGO_PKG_"))
+        {
+            command.env_remove(key);
+        }
+    }
+    command
+}


### PR DESCRIPTION
Integration tests launching Cargo inherited the enclosing test package's metadata. Ring tracked those incoming values, so nested builds and later top-level builds repeatedly invalidated its build-script fingerprint.

Route all ten nested Cargo calls through one shared test helper that removes inherited `CARGO_MANIFEST_DIR` and `CARGO_PKG_*` values. Cargo supplies each child's own package metadata; caller Cargo selection, target/configuration, compiler flags, jobserver controls, and existing CLI fallbacks are preserved.

Validation:

- `just gate` passed, including strict workspace Clippy, workspace tests, doctests, and rustdoc.
- All seven affected integration targets passed: 41 tests, with one existing ignored recurrence test.
- A dependency-free build-script regression checks clean → nested → clean reuse. Neutralizing only the cleanup line makes it fail at the expected second build-script execution.
- A controlled actual-ring comparison held package, features, and target constant. Unclean nested/top-level transitions each rebuilt ring and seven dependent artifacts (7.548 s / 7.645 s); the helper and following top-level invocation rebuilt none (0.154 s / 0.161 s), with identical clean fingerprint JSON. These are local command measurements; total CI savings remain unmeasured.
