### PR TITLE
fix(transport): yield while draining shared update groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Shared update-group consumers yield at their bounded chunk checkpoints even
+  when the encoder has already completed, allowing other tasks to enqueue
+  session-state and import-counter reads during the drain. Encoder election,
+  command ordering, and writer failure handling are unchanged.
+
 - The route-server flagship soak drains its management probes before releasing
   the engine's final session shutdown. The analyzer checks this ordering against
   the daemon log, preventing natural teardown from being counted as a stable

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -615,6 +615,9 @@ impl PeerSession {
                 // drain without ever waiting for another encoder notification.
                 if index % 64 == 0 {
                     self.poll_shared_group_command();
+                    // Let read producers run even when the stream is complete.
+                    // Only consumers yield; the encoder keeps its election guard.
+                    tokio::task::yield_now().await;
                 }
                 if !self.wants_shared_chunk(update, &chunk) {
                     continue;

--- a/crates/transport/src/session/tests/shared_group_encode.rs
+++ b/crates/transport/src/session/tests/shared_group_encode.rs
@@ -396,6 +396,76 @@ async fn shared_group_encoder_and_buffered_consumer_service_queued_reads() {
 }
 
 #[tokio::test]
+async fn shared_group_buffered_consumer_yields_for_new_reads() {
+    use std::future::{Future, poll_fn};
+    use std::task::Poll;
+
+    let (mut member, _wire) = shared_group_member(65001).await;
+    let (commands, receiver) = mpsc::channel(8);
+    member.commands = receiver;
+    member.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Permit,
+    }])));
+    let generation = member.import_policy_generation;
+    let announce: Vec<_> = (0..129_u32)
+        .map(|index| {
+            make_sourced_route(
+                Ipv4Addr::new(10, 44, 0, 1),
+                Ipv4Prefix::new(Ipv4Addr::from(0x0A40_0000 + index * 256), 24),
+                64_601,
+            )
+        })
+        .collect();
+    let (typed, update, chunks) = shared_query_update(&member, &announce);
+    assert_eq!(chunks.len(), 129, "fixture spans three checkpoints");
+    typed.test_publish(chunks);
+    typed.test_finish(super::shared_group::StreamTerminal::Complete);
+    {
+        let consumer = member.handle_outbound_route_update(update);
+        tokio::pin!(consumer);
+        assert!(
+            poll_fn(|cx| Poll::Ready(consumer.as_mut().poll(cx)))
+                .await
+                .is_pending(),
+            "completed shared stream must yield before draining every chunk"
+        );
+
+        // These reads do not exist until the consumer has handed back control.
+        // Await admission in another task without resuming the consumer, so the
+        // proof does not depend on Tokio's choice of which task to poll next.
+        let (mut state, mut counters) = tokio::spawn(async move {
+            let (reply, state) = oneshot::channel();
+            commands
+                .try_send(PeerCommand::QueryState { reply })
+                .unwrap();
+            let (reply, counters) = oneshot::channel();
+            commands
+                .try_send(PeerCommand::QueryImportPolicyTermHits { reply })
+                .unwrap();
+            (state, counters)
+        })
+        .await
+        .unwrap();
+        consumer.await;
+
+        // No outer actor loop runs: both replies must come from shared work.
+        let state = state.try_recv().expect("state answered inside shared work");
+        assert!(state.updates_sent > 0 && state.updates_sent < 129);
+        let counters = counters
+            .try_recv()
+            .expect("stats answered inside shared work")
+            .expect("installed import chain");
+        assert_eq!(counters.generation, generation);
+        assert_eq!(counters.evals, 0);
+    }
+    assert_eq!(member.updates_sent, 129);
+    let writer = member.writer_join.take().unwrap();
+    writer.abort();
+    let _ = writer.await;
+}
+
+#[tokio::test]
 async fn shared_transition_payload_excludes_only_the_target_source() {
     let (mut session, _rib_rx) = make_test_session_with_rib(65001, 65002);
     let (client, mut server) = connected_stream_pair().await;


### PR DESCRIPTION
A consumer of an already completed shared update-group stream could enqueue its entire output in one executor poll. Its command checkpoints serviced reads already queued, but gave other tasks no opportunity to enqueue new reads. Yield at the existing 64-chunk consumer checkpoints, including the initial checkpoint, so read producers can run during the drain. The encoder remains synchronous, and the existing mutation FIFO and writer failure handling are preserved.

The deterministic regression starts with 129 published chunks and a completed stream, requires the consumer to suspend, then runs a separate task that admits state and import-counter reads. Both replies come from shared work, and the state snapshot observes only part of the output sent. Removing only the yield makes that regression fail because the first consumer poll completes the entire drain.

Validation: the focused regression and all 16 shared-group tests pass; the expected failure without the yield is retained. `just gate` and all normal commit/push hooks passed. The exact PR head has 104 successful hosted checks and one external-link skip. Independent source review found no ordering, encoder-election, or cancellation-invariant change.

This is a bounded executor-handoff correction. It does not establish a fleet-wide freshness or response-time guarantee. In the ordinary release candidate's 1000-peer, 400,000-prefix native cell with daemon and generator sharing two cores, 19 of 24 reads exceeded two seconds; all 12 stats calls and one neighbor call failed, and other neighbor replies contained marked-stale observations. Nine complete pairs covered the requested actual pre-commit interval. All 12 reloads and the full fleet remained intact. The preceding baseline had 23 over-budget reads and five stats failures, so these runs do not establish an availability improvement.

A separate instrumented diagnostic changed only the generator's runtime worker count from 24 to two while reusing identical daemon and CLI executables. All 24 reads then succeeded below 778 ms with complete policy totals, but all 12 neighbor responses still included marked-stale rows and only two pairs covered the required pre-commit interval. Generation completion and observer gaps also grew with two generator workers. This establishes sensitivity to the generator configuration, not equivalent collision pressure, a general performance improvement, or release qualification. The original failures remain retained. End-to-end attribution, phase-specific qualification, and the full soak remain separate open work.
