### PR TITLE
fix(cli): preserve flowspec component details in json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `rbgp --json flowspec` now includes raw `extended_communities` as numeric
   values, preserving their order and duplicates alongside the curated actions.
 
+- `rbgp --json flowspec` now includes ordered `component_details` records with
+  the API component type, prefix, value, and offset. The existing formatted
+  `components` array is unchanged.
+
 - gNMI neighbor snapshots now use the operator-read lane on TLS and Unix
   listeners and for dial-out subscriptions. `Get` and subscription snapshots
   can complete during policy waits that admit operator reads, retaining live

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -218,7 +218,9 @@ rbgp fib-table set edge --table-id 1000 --metric 200 --families ipv4_unicast,ipv
 `rbgp --json flowspec` includes `extended_communities` as raw unsigned 64-bit
 integers in response order, including duplicates and values without a curated
 action. The field is an empty array when the route has none; `actions` retains
-its formatted summaries.
+its formatted summaries. `components` retains its legacy formatted component summaries;
+`component_details` preserves each component's API type, prefix, value, and
+offset, including zero offsets and unknown types.
 
 For large accepted unicast listings, use `rbgp --json-lines rib`,
 `rbgp --json-lines rib received 192.0.2.1`, or

--- a/crates/cli/src/commands/flowspec.rs
+++ b/crates/cli/src/commands/flowspec.rs
@@ -78,6 +78,12 @@ pub async fn list(connection: Connection, family: Option<i32>, json: bool) -> Re
             .map(|route| {
                 serde_json::json!({
                     "components": route.components.iter().map(format_component).collect::<Vec<_>>(),
+                    "component_details": route.components.iter().map(|component| serde_json::json!({
+                        "type": component.r#type,
+                        "prefix": component.prefix,
+                        "value": component.value,
+                        "offset": component.offset,
+                    })).collect::<Vec<_>>(),
                     "actions": route.actions.iter().map(format_action).collect::<Vec<_>>(),
                     "peer_address": route.peer_address,
                     "afi_safi": output::format_family(route.afi_safi),

--- a/crates/cli/tests/flowspec_json.rs
+++ b/crates/cli/tests/flowspec_json.rs
@@ -12,24 +12,44 @@ use rustbgpd_api::proto;
 mod test_support;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flowspec_json_preserves_raw_extended_communities() {
+async fn flowspec_json_preserves_raw_extended_communities_and_component_details() {
     let server = test_support::spawn_mock_server(None).await;
     let raw = vec![0x800c_fde8_3f80_0000, u64::MAX, 0x800c_fde8_3f80_0000, 0];
     *server.state.list_flowspec_response.lock().await = proto::ListFlowSpecResponse {
         routes: vec![
             proto::FlowSpecRouteEntry {
-                components: vec![proto::FlowSpecComponent {
-                    r#type: 1,
-                    prefix: "192.0.2.0/24".into(),
-                    ..Default::default()
-                }],
+                components: vec![
+                    proto::FlowSpecComponent {
+                        r#type: 1,
+                        prefix: "2001:db8::/32".into(),
+                        offset: 0,
+                        ..Default::default()
+                    },
+                    proto::FlowSpecComponent {
+                        r#type: 2,
+                        prefix: "::1234:5678:9a00:0/104".into(),
+                        offset: 64,
+                        ..Default::default()
+                    },
+                    proto::FlowSpecComponent {
+                        r#type: 4,
+                        value: "=443".into(),
+                        ..Default::default()
+                    },
+                    proto::FlowSpecComponent {
+                        r#type: 99,
+                        value: "opaque".into(),
+                        offset: 17,
+                        ..Default::default()
+                    },
+                ],
                 actions: vec![proto::FlowSpecAction {
                     action: Some(proto::flow_spec_action::Action::TrafficRate(
                         proto::FlowSpecTrafficRate { rate: 0.0 },
                     )),
                 }],
                 peer_address: "192.0.2.1".into(),
-                afi_safi: proto::AddressFamily::Ipv4Flowspec.into(),
+                afi_safi: proto::AddressFamily::Ipv6Flowspec.into(),
                 as_path: vec![65001],
                 communities: vec![(65000 << 16) | 100],
                 extended_communities: raw.clone(),
@@ -51,9 +71,24 @@ async fn flowspec_json_preserves_raw_extended_communities() {
     assert_eq!(rows.as_array().unwrap().len(), 2);
     assert_eq!(rows[0]["extended_communities"], serde_json::json!(raw));
     assert_eq!(rows[1]["extended_communities"], serde_json::json!([]));
+    assert_eq!(rows[1]["component_details"], serde_json::json!([]));
     assert_eq!(
         rows[0]["components"],
-        serde_json::json!(["dest=192.0.2.0/24"])
+        serde_json::json!([
+            "dest=2001:db8::/32",
+            "src=::1234:5678:9a00:0/104",
+            "port==443",
+            "unknown=opaque",
+        ])
+    );
+    assert_eq!(
+        rows[0]["component_details"],
+        serde_json::json!([
+            {"type": 1, "prefix": "2001:db8::/32", "value": "", "offset": 0},
+            {"type": 2, "prefix": "::1234:5678:9a00:0/104", "value": "", "offset": 64},
+            {"type": 4, "prefix": "", "value": "=443", "offset": 0},
+            {"type": 99, "prefix": "", "value": "opaque", "offset": 17},
+        ])
     );
     assert_eq!(rows[0]["actions"], serde_json::json!(["drop"]));
     assert_eq!(rows[0]["peer_address"], "192.0.2.1");
@@ -71,7 +106,7 @@ async fn flowspec_json_preserves_raw_extended_communities() {
     assert!(output.status.success(), "{output:?}");
     assert_eq!(
         String::from_utf8(output.stdout).unwrap(),
-        "  match [dest=192.0.2.0/24] action [drop] from 192.0.2.1 (ipv4_flowspec)\n"
+        "  match [dest=2001:db8::/32, src=::1234:5678:9a00:0/104, port==443, unknown=opaque] action [drop] from 192.0.2.1 (ipv6_flowspec)\n"
     );
     server
         .state

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1797,6 +1797,11 @@ grpcurl -plaintext -import-path . -proto proto/rustbgpd.proto \
   localhost:50051 rustbgpd.v1.RibService/ListFlowSpecRoutes
 ```
 
+`rbgp --json flowspec` retains the legacy formatted `components` array and
+also emits ordered `component_details` records with the API component `type`,
+`prefix`, `value`, and `offset`. The explicit offset preserves the RFC 8956
+IPv6 prefix-match semantics, including zero and nonzero values.
+
 ### List EVPN routes
 
 `ListEvpnRoutes` retains its existing unpaginated best-route view. The additive


### PR DESCRIPTION
`rbgp --json flowspec` preserved only formatted component strings, dropping the RFC 8956 IPv6 prefix offset. This adds ordered `component_details` records with each component's type, prefix, value, and offset while retaining the existing `components` array and human output.

Validation:

- `cargo test -p rustbgpctl --test flowspec_json`
- `just gate`
