### PR TITLE
test(docs): fence curated cli and config examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,17 @@ names such as `add-mac-ip`; their existing paths remain compatible. Keep
 help examples close to the command definition and parse-test the displayed
 invocations. The detailed flag conventions live in `crates/cli/src/main.rs`.
 
+Maintained documentation may opt into the lightweight conformance fences with
+`<!-- rbgp-cli-conformance -->` or
+`<!-- rustbgpd-config-conformance -->`. The first parses marked `rbgp` argv
+through the real Clap tree; register each marked document and its total command
+count in `curated_documentation_commands_parse_with_the_real_cli` in
+`crates/cli/src/main.rs`. The second is currently the explicitly selected
+`rr-pair-day2.md` snippet in `marked_documentation_config_parses_with_the_real_schema`
+in `src/config/tests/mod.rs`. They check command and configuration syntax only,
+not daemon output, direction or policy intent, log literals, or protocol
+behavior.
+
 ### Postmortem artifacts
 
 Any postmortem doc that cites raw data — soak runs, scale tests,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4625,7 +4625,7 @@ mod tests {
             ("docs/tutorials/quickstart.md", 5),
             ("docs/cookbook/route-server.md", 3),
             ("docs/how-to/explain.md", 7),
-            ("docs/reference/operations.md", 2),
+            ("docs/reference/operations.md", 4),
         ];
 
         let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
@@ -4639,77 +4639,75 @@ mod tests {
                 .filter(|(_, line)| line.trim() == MARKER)
                 .map(|(index, _)| index)
                 .collect();
-            assert_eq!(
-                markers.len(),
-                1,
-                "{relative_path} must contain exactly one curated CLI block"
-            );
-            assert!(
-                lines
-                    .get(markers[0] + 1)
-                    .is_some_and(|line| line.trim().starts_with("```")),
-                "{relative_path} conformance marker must immediately precede its code fence"
-            );
-
-            let mut in_fence = false;
             let mut parsed = 0;
-            for (offset, line) in lines[(markers[0] + 1)..].iter().enumerate() {
-                let trimmed = line.trim();
-                if trimmed.starts_with("```") {
-                    if in_fence {
-                        break;
-                    }
-                    in_fence = true;
-                    continue;
-                }
-                if !in_fence {
-                    continue;
-                }
-
-                let command = trimmed.strip_prefix("$ ").unwrap_or(trimmed);
-                if !command.starts_with("rbgp ") {
-                    continue;
-                }
+            for marker in markers {
                 assert!(
-                    !command.ends_with('\\'),
-                    "{relative_path}:{} curated rbgp command must stay on one line",
-                    markers[0] + offset + 2
+                    lines
+                        .get(marker + 1)
+                        .is_some_and(|line| line.trim().starts_with("```")),
+                    "{relative_path} conformance marker must immediately precede its code fence"
                 );
-                let command = command
-                    .split_once(" #")
-                    .map_or(command, |(command, _)| command);
-                let piped_to_jq = command.contains(" | jq ");
-                // Shell comments and pipelines remain documentation; this gate
-                // parses only the rbgp argv and never executes either suffix.
-                let command = command
-                    .split_once(" |")
-                    .map_or(command, |(command, _)| command);
-                if piped_to_jq {
-                    assert!(
-                        command
-                            .split_whitespace()
-                            .any(|arg| arg == "--json" || arg == "-j"),
-                        "{relative_path}:{} pipes rbgp output to jq without selecting JSON",
-                        markers[0] + offset + 2
-                    );
-                }
-                let arguments: Vec<_> = command
-                    .split_whitespace()
-                    .map(|argument| match argument {
-                        "<draining-peer>" | "<receiving-peer>" => "192.0.2.1",
-                        _ if argument.starts_with('<') && argument.ends_with('>') => {
-                            panic!("{relative_path}: add an explicit normalization for {argument}")
+                let mut in_fence = false;
+                for (offset, line) in lines[(marker + 1)..].iter().enumerate() {
+                    let trimmed = line.trim();
+                    if trimmed.starts_with("```") {
+                        if in_fence {
+                            break;
                         }
-                        _ => argument,
-                    })
-                    .collect();
-                Cli::try_parse_from(arguments).unwrap_or_else(|error| {
-                    panic!(
-                        "{relative_path}:{} does not parse as documented:\n{command}\n{error}",
-                        markers[0] + offset + 2
-                    )
-                });
-                parsed += 1;
+                        in_fence = true;
+                        continue;
+                    }
+                    if !in_fence {
+                        continue;
+                    }
+
+                    let command = trimmed.strip_prefix("$ ").unwrap_or(trimmed);
+                    if !command.starts_with("rbgp ") {
+                        continue;
+                    }
+                    assert!(
+                        !command.ends_with('\\'),
+                        "{relative_path}:{} curated rbgp command must stay on one line",
+                        marker + offset + 2
+                    );
+                    let command = command
+                        .split_once(" #")
+                        .map_or(command, |(command, _)| command);
+                    let piped_to_jq = command.contains(" | jq ");
+                    // Shell comments and pipelines remain documentation; this gate
+                    // parses only the rbgp argv and never executes either suffix.
+                    let command = command
+                        .split_once(" |")
+                        .map_or(command, |(command, _)| command);
+                    if piped_to_jq {
+                        assert!(
+                            command
+                                .split_whitespace()
+                                .any(|arg| arg == "--json" || arg == "-j"),
+                            "{relative_path}:{} pipes rbgp output to jq without selecting JSON",
+                            marker + offset + 2
+                        );
+                    }
+                    let arguments: Vec<_> = command
+                        .split_whitespace()
+                        .map(|argument| match argument {
+                            "<draining-peer>" | "<receiving-peer>" => "192.0.2.1",
+                            _ if argument.starts_with('<') && argument.ends_with('>') => {
+                                panic!(
+                                    "{relative_path}: add an explicit normalization for {argument}"
+                                )
+                            }
+                            _ => argument,
+                        })
+                        .collect();
+                    Cli::try_parse_from(arguments).unwrap_or_else(|error| {
+                        panic!(
+                            "{relative_path}:{} does not parse as documented:\n{command}\n{error}",
+                            marker + offset + 2
+                        )
+                    });
+                    parsed += 1;
+                }
             }
             assert_eq!(
                 parsed, *expected_commands,

--- a/docs/cookbook/rr-pair-day2.md
+++ b/docs/cookbook/rr-pair-day2.md
@@ -17,6 +17,7 @@ retains routes for the advertised restart window (RFC 4724), then
 demotes to LLGR_STALE (RFC 9494) if `llgr_stale_time > 0`. Check the
 peer-group template carries what you think it does:
 
+<!-- rustbgpd-config-conformance -->
 ```toml
 [peer_groups.rr-clients]
 graceful_restart = true

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -2565,6 +2565,7 @@ for it.
 
 ### Check session status
 
+<!-- rbgp-cli-conformance -->
 ```bash
 rbgp neighbor          # summary table (alias: rbgp summary)
 rbgp neighbor --wide   # adds Source, MsgRcvd, MsgSent, Flaps, RRC, Slow, State/PfxRcd

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -111,6 +111,44 @@ fn valid_config_parses() {
     assert_eq!(config.neighbors[0].remote_asn, 65002);
 }
 
+#[test]
+fn marked_documentation_config_parses_with_the_real_schema() {
+    const MARKER: &str = "<!-- rustbgpd-config-conformance -->";
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let contents = fs::read_to_string(repository.join("docs/cookbook/rr-pair-day2.md"))
+        .expect("failed to read marked config example");
+    let lines: Vec<_> = contents.lines().collect();
+    let markers: Vec<_> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (line.trim() == MARKER).then_some(index))
+        .collect();
+    assert_eq!(
+        markers.len(),
+        1,
+        "config example must contain exactly one marker"
+    );
+    let marker = markers[0];
+    assert!(
+        lines
+            .get(marker + 1)
+            .is_some_and(|line| line.trim() == "```toml"),
+        "config marker must immediately precede its TOML fence"
+    );
+    let start = marker + 2;
+    let end = lines[start..]
+        .iter()
+        .position(|line| line.trim() == "```")
+        .map(|offset| start + offset)
+        .expect("marked config example must close before the next fence");
+    let snippet = lines[start..end].join("\n");
+    let config = parse(&format!("{}\n{}", valid_toml(), snippet)).unwrap();
+    let group = config.peer_groups.get("rr-clients").unwrap();
+    assert_eq!(group.graceful_restart, Some(true));
+    assert_eq!(group.gr_stale_routes_time, Some(120));
+    assert_eq!(group.llgr_stale_time, Some(300));
+}
+
 fn route_server_example_config() -> Config {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/route-server/config.toml");
     Config::load_with_diagnostics(path.to_str().expect("route-server example path is UTF-8"))


### PR DESCRIPTION
The documentation conformance checks now cover two previously unguarded drift paths:

- multiple explicitly marked CLI blocks per document, including the maintained neighbor inventory in `docs/reference/operations.md`
- one explicitly marked peer-group TOML snippet parsed through the real config schema and validator

The contributor guide documents marker registration and the syntax/schema-only boundary. Existing curated examples remain unchanged; no runtime behavior changed.

Validation:

- focused CLI and config tests passed
- both negative controls failed as expected and passed again after restoration
- `rustfmt --check` and `git diff --check` passed
- normal commit and push hooks passed `cargo fmt`, strict Clippy, workspace library tests, and private-item rustdoc
