### PR TITLE
fix(transport): discard canceled reads during shared output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,11 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   complete. Rejection or rollback fails that cycle before A/B alternation can
   turn it into a misleading later re-advertisement stall.
 
+- Canceled session diagnostics no longer hold later neighbor and import-counter
+  reads behind an unfinished shared update stream. Cancellation releases reads
+  already deferred by the session; queued mutations keep their FIFO position
+  even when their acknowledgement receiver has closed.
+
 ### Upgrade notes
 
 - Consumers of `GetPolicyStats` or `rbgp policy stats` should use the installed

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -20,6 +20,9 @@ between encoding slices, between bounded chunk batches, and while waiting for
 shared chunks. A queued mutation keeps its place before later reads and waits
 for the current envelope to finish. This does not impose a wall-clock bound on
 initial sorting, an individual encoding slice, or other session work.
+Abandoned read-only snapshots are discarded, including deferred diagnostics
+whose callers leave while shared chunks are pending. Losing a mutation's
+acknowledgement receiver does not cancel that mutation or let later reads pass it.
 
 The transport layer intercepts UPDATEs (parse, validate, apply policy)
 before forwarding to the RIB — the FSM sees only payloadless events.

--- a/crates/transport/src/handle.rs
+++ b/crates/transport/src/handle.rs
@@ -645,6 +645,34 @@ pub enum PeerCommand {
     },
 }
 
+impl PeerCommand {
+    /// Only abandoned snapshots may be discarded. A lost mutation acknowledgement
+    /// does not cancel the command or relinquish its place in the session FIFO.
+    pub(crate) fn is_canceled_read(&self) -> bool {
+        match self {
+            Self::QueryState { reply } => reply.is_closed(),
+            Self::QueryWarmCheckpointState { reply } => reply.is_closed(),
+            Self::ExplainImportPolicy { reply, .. } => reply.is_closed(),
+            Self::ListRejectedRoutes { reply } => reply.is_closed(),
+            Self::QueryImportPolicyTermHits { reply } => reply.is_closed(),
+            _ => false,
+        }
+    }
+
+    /// Wake shared-output consumers when their deferred snapshot is abandoned.
+    /// Commands outside the snapshot allowlist remain owned until execution.
+    pub(crate) async fn read_canceled(&mut self) {
+        match self {
+            Self::QueryState { reply } => reply.closed().await,
+            Self::QueryWarmCheckpointState { reply } => reply.closed().await,
+            Self::ExplainImportPolicy { reply, .. } => reply.closed().await,
+            Self::ListRejectedRoutes { reply } => reply.closed().await,
+            Self::QueryImportPolicyTermHits { reply } => reply.closed().await,
+            _ => std::future::pending().await,
+        }
+    }
+}
+
 /// Per-term hit-counter snapshot for one session's installed import
 /// chain (`PeerCommand::QueryImportPolicyTermHits`).
 #[derive(Debug, Clone)]

--- a/crates/transport/src/session/commands.rs
+++ b/crates/transport/src/session/commands.rs
@@ -1337,6 +1337,9 @@ impl PeerSession {
         reason = "command dispatch centralizes all external peer-session control paths"
     )]
     pub(super) async fn handle_command(&mut self, cmd: PeerCommand) -> ControlFlow<()> {
+        if cmd.is_canceled_read() {
+            return ControlFlow::Continue(());
+        }
         match cmd {
             PeerCommand::Start => {
                 self.stop_requested = false;

--- a/crates/transport/src/session/shared_group.rs
+++ b/crates/transport/src/session/shared_group.rs
@@ -418,9 +418,12 @@ pub(super) fn encode_shared_unicast_slice(
 }
 
 impl PeerSession {
-    /// Only small operator snapshots may interleave a shared envelope. Preserve
-    /// every other command and its FIFO successors until normal actor handling.
+    /// Only small operator snapshots may interleave a shared envelope. Discard
+    /// abandoned snapshots; preserve all other commands and their FIFO successors.
     fn handle_shared_group_command(&mut self, command: crate::PeerCommand) {
+        if command.is_canceled_read() {
+            return;
+        }
         match command {
             crate::PeerCommand::QueryState { reply } => self.answer_state_query(reply),
             crate::PeerCommand::QueryImportPolicyTermHits { reply } => {
@@ -432,6 +435,13 @@ impl PeerSession {
 
     /// One command per checkpoint bounds work under a continuous read stream.
     fn poll_shared_group_command(&mut self) {
+        if self
+            .deferred_command
+            .as_ref()
+            .is_some_and(crate::PeerCommand::is_canceled_read)
+        {
+            self.deferred_command = None;
+        }
         if self.deferred_command.is_none()
             && let Ok(command) = self.commands.try_recv()
         {
@@ -653,6 +663,12 @@ impl PeerSession {
                 None => {
                     tokio::select! {
                         biased;
+                        () = async {
+                            match self.deferred_command.as_mut() {
+                                Some(command) => command.read_canceled().await,
+                                None => std::future::pending().await,
+                            }
+                        } => self.deferred_command = None,
                         command = self.commands.recv(),
                             if commands_open && self.deferred_command.is_none() => {
                             match command {

--- a/crates/transport/src/session/tests/shared_group_encode.rs
+++ b/crates/transport/src/session/tests/shared_group_encode.rs
@@ -174,10 +174,6 @@ async fn shared_group_consumer_answers_import_query_before_stream_terminal() {
     );
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "real actor proof keeps cancellation timing, held stream, snapshot replies, and cleanup together"
-)]
 async fn assert_shared_group_canceled_read_releases_snapshots<T>(
     command: PeerCommand,
     response: oneshot::Receiver<T>,

--- a/crates/transport/src/session/tests/shared_group_encode.rs
+++ b/crates/transport/src/session/tests/shared_group_encode.rs
@@ -174,6 +174,163 @@ async fn shared_group_consumer_answers_import_query_before_stream_terminal() {
     );
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "real actor proof keeps cancellation timing, held stream, snapshot replies, and cleanup together"
+)]
+async fn assert_shared_group_canceled_read_releases_snapshots<T>(
+    command: PeerCommand,
+    response: oneshot::Receiver<T>,
+    cancel_after_deferral: bool,
+) {
+    use crate::{PeerHandle, SessionQueryOutcome};
+    use std::future::{Future, poll_fn};
+    use std::task::Poll;
+
+    let (mut member, commands, _rib_rx) = make_test_session_with_channels(65001, 65002, 64);
+    let (client, _wire) = connected_stream_pair().await;
+    member.test_install_stream(client);
+    member.config.route_server_client = true;
+    establish_test_session(&mut member, 65002).await;
+    member.install_import_policy(Some(PolicyChain::new(vec![Policy {
+        entries: vec![],
+        default_action: PolicyAction::Permit,
+    }])));
+    let generation = member.import_policy_generation;
+    let (typed, update, chunks) = shared_query_update(&member, &[make_route(100)]);
+    let outbound = member.outbound_tx.clone();
+    outbound.try_send(update).unwrap();
+    let outcome = {
+        let actor = member.run();
+        tokio::pin!(actor);
+        assert!(
+            poll_fn(|cx| Poll::Ready(actor.as_mut().poll(cx)))
+                .await
+                .is_pending()
+        );
+        assert_eq!(outbound.capacity(), outbound.max_capacity());
+        assert_eq!(typed.test_snapshot(), (0, None));
+
+        let mut response = Some(response);
+        if !cancel_after_deferral {
+            drop(response.take());
+        }
+        commands.try_send(command).unwrap();
+        let (reply, mut state) = oneshot::channel();
+        commands
+            .try_send(PeerCommand::QueryState { reply })
+            .unwrap();
+        let (reply, mut counters) = oneshot::channel();
+        commands
+            .try_send(PeerCommand::QueryImportPolicyTermHits { reply })
+            .unwrap();
+
+        if cancel_after_deferral {
+            assert!(
+                poll_fn(|cx| Poll::Ready(actor.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            assert_eq!(
+                commands.capacity(),
+                commands.max_capacity() - 2,
+                "live diagnostic is deferred and later snapshots stay queued"
+            );
+            assert!(matches!(
+                state.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+            assert!(matches!(
+                counters.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+            // No stream progress follows this drop: cancellation must wake the wait.
+            drop(response.take());
+        }
+
+        let outcome = tokio::select! {
+            result = tokio::time::timeout(Duration::from_secs(2), async {
+                (state.await, counters.await)
+            }) => result,
+            stopped = &mut actor => panic!("session stopped before snapshots: {stopped:?}"),
+        };
+        assert_eq!(typed.test_snapshot(), (0, None));
+
+        // Complete the same envelope and drive the actor past its terminal.
+        typed.test_publish(chunks);
+        typed.test_finish(super::shared_group::StreamTerminal::Complete);
+        let control = PeerHandle::query_import_policy_term_hits_with_deadline(
+            commands.clone(),
+            tokio::time::Instant::now() + Duration::from_secs(2),
+        );
+        let control = tokio::select! {
+            result = control => result,
+            stopped = &mut actor => panic!("session stopped before control: {stopped:?}"),
+        };
+        assert!(matches!(control, SessionQueryOutcome::Reply(Some(_))));
+        outcome
+    };
+    let writer = member.writer_join.take().unwrap();
+    writer.abort();
+    let _ = writer.await;
+    let (state, counters) = outcome.expect(
+        "canceled diagnostic must release live snapshots before the held stream's terminal",
+    );
+    assert_eq!(state.unwrap().fsm_state, SessionState::Established);
+    let counters = counters.unwrap().unwrap();
+    assert_eq!(counters.generation, generation);
+    assert_eq!(
+        counters.evals, 0,
+        "snapshots do not evaluate the import chain"
+    );
+    assert!(member.deferred_command.is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn shared_group_canceled_explain_releases_snapshots() {
+    for cancel_after_deferral in [false, true] {
+        let (reply, response) = oneshot::channel();
+        assert_shared_group_canceled_read_releases_snapshots(
+            PeerCommand::ExplainImportPolicy {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                prefix: Prefix::V4(Ipv4Prefix::new(Ipv4Addr::new(203, 0, 113, 0), 24)),
+                path_id: None,
+                reply,
+            },
+            response,
+            cancel_after_deferral,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn shared_group_canceled_rejected_routes_releases_snapshots() {
+    for cancel_after_deferral in [false, true] {
+        let (reply, response) = oneshot::channel();
+        assert_shared_group_canceled_read_releases_snapshots(
+            PeerCommand::ListRejectedRoutes { reply },
+            response,
+            cancel_after_deferral,
+        )
+        .await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn shared_group_canceled_warm_checkpoint_releases_snapshots() {
+    for cancel_after_deferral in [false, true] {
+        let (reply, response) = oneshot::channel();
+        assert_shared_group_canceled_read_releases_snapshots(
+            PeerCommand::QueryWarmCheckpointState { reply },
+            response,
+            cancel_after_deferral,
+        )
+        .await;
+    }
+}
+
 #[tokio::test]
 async fn shared_group_closed_command_channel_waits_without_self_waking() {
     use std::future::Future;
@@ -222,8 +379,7 @@ async fn shared_group_closed_command_channel_waits_without_self_waking() {
     clippy::too_many_lines,
     reason = "real actor test retains mutation FIFO, failed-stream fallback, and wire assertions together"
 )]
-#[tokio::test(start_paused = true)]
-async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
+async fn assert_shared_group_failed_stream_keeps_mutation_before_later_query(cancel_ack: bool) {
     use crate::{PeerHandle, SessionQueryOutcome};
     use std::future::{Future, poll_fn};
     use std::task::Poll;
@@ -255,7 +411,11 @@ async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
                 .is_pending()
         );
         assert_eq!(outbound.capacity(), outbound.max_capacity());
-        let (reply, mut mutation) = oneshot::channel();
+        let (reply, mutation) = oneshot::channel();
+        let mut mutation = Some(mutation);
+        if cancel_ack {
+            drop(mutation.take());
+        }
         commands
             .try_send(PeerCommand::UpdateImportPolicy {
                 policy: Some(Box::new(PolicyChain::new(vec![Policy {
@@ -285,10 +445,12 @@ async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
             commands.max_capacity() - 1,
             "only the barrier is taken; its successor stays queued"
         );
-        assert!(matches!(
-            mutation.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
-        ));
+        if let Some(mutation) = mutation.as_mut() {
+            assert!(matches!(
+                mutation.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+        }
         assert!(
             poll_fn(|cx| Poll::Ready(query.as_mut().poll(cx)))
                 .await
@@ -300,10 +462,12 @@ async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
             result = &mut query => result,
             stopped = &mut actor => panic!("session stopped before mutation/query: {stopped:?}"),
         };
-        mutation
-            .try_recv()
-            .expect("deferred mutation acknowledged")
-            .expect("mutation succeeds");
+        if let Some(mutation) = mutation.as_mut() {
+            mutation
+                .try_recv()
+                .expect("deferred mutation acknowledged")
+                .expect("mutation succeeds");
+        }
         let SessionQueryOutcome::Reply(Some(snapshot)) = result else {
             panic!("query after mutation must see its installed chain: {result:?}");
         };
@@ -329,6 +493,16 @@ async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
     let writer = member.writer_join.take().unwrap();
     writer.abort();
     let _ = writer.await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn shared_group_failed_stream_keeps_mutation_before_later_query() {
+    assert_shared_group_failed_stream_keeps_mutation_before_later_query(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn shared_group_failed_stream_keeps_closed_ack_mutation_before_later_query() {
+    assert_shared_group_failed_stream_keeps_mutation_before_later_query(true).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
An abandoned import-explain, rejected-route, or warm-checkpoint read could remain deferred behind an unfinished shared update stream, holding later neighbor and import-counter reads until their deadlines.

Discard canceled snapshots before dispatch and wake a waiting shared-stream consumer when its deferred snapshot is canceled. Live diagnostics still wait for the envelope to finish. Every mutation keeps its FIFO position even if its acknowledgement receiver closes; encoder election, writer handling, stream completion and request budgets are unchanged.

Validation: all 20 shared-group tests pass, including each diagnostic canceled before dequeue and after deferral, and open/closed-ack mutation FIFO controls with failed-stream fallback. Reverting the runtime correction or removing only the cancellation wake independently fails all three cancellation regressions. These are paused-time actor regressions, not native latency or soak qualification.

`just gate`, `just gate-rib`, and the normal commit/push checks pass at the published head.
