### PR TITLE
fix(transport): cancel abandoned replay admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,12 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Canceling outbound replay now releases the session while BMP admission,
+  enrollment, or RIB admission is blocked. Once the BMP queue accepts the
+  replay-begin event, ordinary mirrored EoRs remain suppressed even if enrollment
+  is abandoned, preventing a partial capture from appearing complete; BGP EoR
+  transmission is unchanged.
+
 - Shared update-group consumers yield at their bounded chunk checkpoints even
   when the encoder has already completed, allowing other tasks to enqueue
   session-state and import-counter reads during the drain. Encoder election,

--- a/crates/transport/src/session/replay.rs
+++ b/crates/transport/src/session/replay.rs
@@ -105,7 +105,7 @@ impl PeerSession {
     )]
     pub(super) async fn start_outbound_replay(
         &mut self,
-        response: oneshot::Sender<Result<(), PeerCommandError>>,
+        mut response: oneshot::Sender<Result<(), PeerCommandError>>,
     ) {
         if response.is_closed() {
             return;
@@ -153,7 +153,7 @@ impl PeerSession {
             scheduling: None,
             reply: None,
         });
-        let result = tokio::time::timeout_at(deadline, async {
+        let admission = tokio::time::timeout_at(deadline, async {
             bmp_tx
                 .send(BmpEvent::OutboundReplayBegin {
                     peer_info,
@@ -163,13 +163,16 @@ impl PeerSession {
                 .map_err(|_| {
                     PeerCommandError::ReplayUnavailable("BMP manager is unavailable".into())
                 })?;
+            // Begin may reset collector monitoring before its acknowledgement,
+            // even if enrollment later fails or the caller cancels. Ordinary
+            // BMP EoRs must not certify that abandoned capture.
+            self.replay_eor_suppressed = true;
             if !enrolled.await.unwrap_or(false) {
                 return Err(PeerCommandError::ReplayUnavailable(
                     "no eligible connected BMP collector or replay enrollment refused".into(),
                 ));
             }
-            self.replay_eor_suppressed = true;
-            if response.is_closed() || !replay.is_valid() {
+            if !replay.is_valid() {
                 return Err(PeerCommandError::ReplayUnavailable(
                     "replay scheduling canceled".into(),
                 ));
@@ -188,12 +191,17 @@ impl PeerSession {
                     PeerCommandError::ReplayUnavailable("RIB manager is unavailable".into())
                 })?;
             Ok(admitted)
-        })
-        .await
-        .unwrap_or(Err(PeerCommandError::TimedOut {
-            operation: "replay_outbound",
-            deadline: REPLAY_TIMEOUT,
-        }));
+        });
+        let result = tokio::select! {
+            biased;
+            () = response.closed() => Err(PeerCommandError::ReplayUnavailable(
+                "replay caller canceled before acknowledgement".into(),
+            )),
+            result = admission => result.unwrap_or(Err(PeerCommandError::TimedOut {
+                operation: "replay_outbound",
+                deadline: REPLAY_TIMEOUT,
+            })),
+        };
         match result {
             Ok(admitted) => {
                 if let Some(pending) = &mut self.pending_replay {

--- a/crates/transport/src/session/tests/replay.rs
+++ b/crates/transport/src/session/tests/replay.rs
@@ -2,6 +2,244 @@ use super::*;
 use crate::session::replay::{PendingReplay, ReplayProgress, poll_completion};
 use rustbgpd_bmp::BmpReplay;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplayAdmissionWait {
+    Bmp,
+    Enrollment,
+    Rib,
+}
+
+#[tokio::test(start_paused = true)]
+async fn replay_caller_cancellation_releases_bmp_admission() {
+    exercise_canceled_replay_admission(ReplayAdmissionWait::Bmp).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn replay_caller_cancellation_releases_enrollment_wait() {
+    exercise_canceled_replay_admission(ReplayAdmissionWait::Enrollment).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn replay_caller_cancellation_releases_rib_admission() {
+    exercise_canceled_replay_admission(ReplayAdmissionWait::Rib).await;
+}
+
+async fn enroll_replay_with_real_bmp_manager(
+    peer_up: BmpEvent,
+    begin: BmpEvent,
+) -> (
+    mpsc::Sender<rustbgpd_bmp::BmpControlEvent>,
+    tokio::task::JoinHandle<()>,
+    mpsc::Receiver<Bytes>,
+) {
+    use rustbgpd_bmp::{BmpControlEvent, BmpManager, BmpMonitorFilter, BmpVersion};
+
+    let (events, event_rx) = mpsc::channel(8);
+    let (control, control_rx) = mpsc::channel(8);
+    let (collector, mut collector_rx) = mpsc::channel(8);
+    let address = "127.0.0.1:11019".parse().unwrap();
+    let manager = BmpManager::new(
+        event_rx,
+        control_rx,
+        vec![(
+            address,
+            BmpMonitorFilter {
+                rib_in_pre: false,
+                rib_out_post: true,
+                ..BmpMonitorFilter::default()
+            },
+            BmpVersion::V3,
+        )],
+        BgpMetrics::new(),
+    );
+    let manager = tokio::spawn(manager.run());
+    let (bootstrap, initial) = oneshot::channel();
+    control
+        .send(BmpControlEvent::CollectorConnected {
+            collector_id: 0,
+            collector_addr: address,
+            sender: collector,
+            bootstrap,
+        })
+        .await
+        .unwrap();
+    let initial = initial.await.unwrap();
+    control
+        .send(BmpControlEvent::CollectorBootstrapComplete {
+            collector_id: 0,
+            generation: initial.generation,
+        })
+        .await
+        .unwrap();
+    // Let the manager consume its only queued control before publishing PeerUp.
+    while control.capacity() != control.max_capacity() {
+        tokio::task::yield_now().await;
+    }
+    events.send(peer_up).await.unwrap();
+    assert_eq!(collector_rx.recv().await.unwrap()[5], 3);
+    events.send(begin).await.unwrap();
+    assert_eq!(collector_rx.recv().await.unwrap()[5], 2);
+    assert_eq!(collector_rx.recv().await.unwrap()[5], 3);
+    (control, manager, collector_rx)
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "three real admission waits retain cancellation, query recovery, exact token and wire/BMP EoR evidence"
+)]
+async fn exercise_canceled_replay_admission(wait: ReplayAdmissionWait) {
+    use std::future::{Future, poll_fn};
+    use std::task::Poll;
+
+    let (mut session, mut old_rib_rx, mut old_bmp_rx) =
+        make_test_session_with_rib_and_bmp(65001, 65002);
+    session.config.bmp_rib_out = true;
+    let (client, mut server) = connected_stream_pair().await;
+    session.test_install_stream(client);
+    establish_test_session(&mut session, 65002).await;
+    read_single_bgp_message(&mut server).await;
+    read_single_bgp_message(&mut server).await;
+    while old_rib_rx.try_recv().is_ok() {}
+    while old_bmp_rx.try_recv().is_ok() {}
+    let peer_up = session.build_bmp_peer_up_event();
+    session.install_import_policy(Some(rustbgpd_policy::PolicyChain::new(vec![])));
+    let generation = session.import_policy_generation;
+    let (bmp_tx, mut bmp_rx) = mpsc::channel(1);
+    session.bmp_tx = Some(bmp_tx.clone());
+    if wait == ReplayAdmissionWait::Bmp {
+        bmp_tx
+            .try_send(BmpEvent::RouteMonitoring {
+                peer_info: session.build_bmp_peer_info(),
+                update_pdu: Bytes::from_static(b"held admission"),
+            })
+            .unwrap();
+    }
+    let (rib_tx, mut rib_rx) = mpsc::channel(1);
+    session.rib_tx = rib_tx.clone();
+    let (held, _held_reply) = oneshot::channel();
+    rib_tx
+        .try_send(RibUpdate::QueryLocRibCount { reply: held })
+        .unwrap();
+
+    let (reply, response) = oneshot::channel();
+    let mut scheduling = Box::pin(session.handle_command(PeerCommand::ReplayOutbound { reply }));
+    assert!(
+        poll_fn(|cx| Poll::Ready(scheduling.as_mut().poll(cx)))
+            .await
+            .is_pending()
+    );
+    let mut manager = None;
+    let token = if wait == ReplayAdmissionWait::Bmp {
+        None
+    } else {
+        let begin = bmp_rx
+            .try_recv()
+            .expect("Begin admitted before enrollment wait");
+        let BmpEvent::OutboundReplayBegin { replay, .. } = &begin else {
+            panic!("expected the operation's exact Begin token");
+        };
+        let token = Arc::clone(replay);
+        if wait == ReplayAdmissionWait::Rib {
+            manager = Some(enroll_replay_with_real_bmp_manager(peer_up, begin).await);
+            // Enrollment is acknowledged; this poll reaches the full RIB queue.
+            assert!(
+                poll_fn(|cx| Poll::Ready(scheduling.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+        }
+        Some(token)
+    };
+    drop(response);
+    let released = tokio::time::timeout(Duration::from_secs(2), scheduling.as_mut())
+        .await
+        .is_ok();
+    drop(scheduling);
+    let canceled =
+        session.pending_replay.is_none() && token.as_ref().is_none_or(|token| !token.is_valid());
+    let suppressed = session.replay_eor_suppressed;
+
+    // These real handlers must run before either bounded downstream queue is
+    // released. They read the installed session, not a cached/fabricated reply.
+    let (state_reply, state) = oneshot::channel();
+    assert!(
+        session
+            .handle_command(PeerCommand::QueryState { reply: state_reply })
+            .await
+            .is_continue()
+    );
+    let state = state.await.unwrap();
+    let (counter_reply, counter_result) = oneshot::channel();
+    assert!(
+        session
+            .handle_command(PeerCommand::QueryImportPolicyTermHits {
+                reply: counter_reply
+            })
+            .await
+            .is_continue()
+    );
+    let counters = counter_result.await.unwrap().unwrap();
+    assert_eq!(rib_tx.capacity(), 0);
+    session.cancel_outbound_replay(); // Reap the pending operation on the red control too.
+    if wait == ReplayAdmissionWait::Bmp {
+        assert!(matches!(
+            bmp_rx.try_recv().unwrap(),
+            BmpEvent::RouteMonitoring { .. }
+        ));
+    }
+    assert!(matches!(
+        rib_rx.try_recv().unwrap(),
+        RibUpdate::QueryLocRibCount { .. }
+    ));
+    tokio::task::yield_now().await;
+    let no_late_admission = bmp_rx.try_recv().is_err() && rib_rx.try_recv().is_err();
+
+    let eor = session
+        .export_encoder
+        .snapshot()
+        .build_end_of_rib(Afi::Ipv4, Safi::Unicast)
+        .unwrap();
+    session.enqueue_bulk(&Message::Update(eor)).unwrap();
+    // A paused-time timeout may leave the writer's independent KEEPALIVE in
+    // front of the bulk EoR. It does not certify or replace the replay marker.
+    let eor = loop {
+        let message = read_single_raw_bgp_message(&mut server).await;
+        if message[18] != 4 {
+            break message;
+        }
+    };
+    assert_eq!(eor[18], 2, "ordinary BGP UPDATE still reaches the peer");
+    assert_eq!(&eor[19..], &[0, 0, 0, 0], "empty IPv4 unicast EoR");
+    let mirrored = bmp_rx.try_recv().is_ok();
+    let writer = session.writer_join.take().unwrap();
+    writer.abort();
+    let _ = writer.await;
+    if let Some((control, manager, _collector)) = manager {
+        control
+            .send(rustbgpd_bmp::BmpControlEvent::Shutdown)
+            .await
+            .unwrap();
+        manager.await.unwrap();
+    }
+    assert!(
+        released,
+        "{wait:?}: canceled replay retained the session past the read budget"
+    );
+    assert!(canceled, "{wait:?}: exact replay token remains live");
+    assert_eq!(state.fsm_state, SessionState::Established);
+    assert_eq!(counters.generation, generation);
+    assert!(
+        no_late_admission,
+        "{wait:?}: canceled work admitted after capacity returned"
+    );
+    assert_eq!(
+        mirrored,
+        wait == ReplayAdmissionWait::Bmp,
+        "{wait:?}: ordinary BMP EoR mirroring must follow the Begin admission boundary"
+    );
+    assert_eq!(suppressed, wait != ReplayAdmissionWait::Bmp);
+}
+
 fn pending(session: &PeerSession, token: Arc<BmpReplay>) -> PendingReplay {
     PendingReplay {
         replay: token,


### PR DESCRIPTION
Dropping an outbound replay caller now cancels admission while the session is waiting for BMP queue capacity, collector enrollment, or RIB queue capacity. The session can resume state and import-counter reads without waiting for the replay admission deadline, and the canceled admission cannot queue replay work when capacity returns.

Latch BMP EoR suppression when the replay-begin event enters the BMP queue: collector monitoring may reset before enrollment is acknowledged. Ordinary mirrored EoRs must not certify an abandoned capture; BGP EoR transmission remains unchanged. The existing five-second admission deadline for a live caller is unchanged.

Validation:

- Three paused-time regressions cover blocked BMP admission, held enrollment, and blocked RIB admission through the session command handler, including subsequent live reads, exact-token cancellation, late admission, and BGP/BMP EoR behavior.
- The original implementation fails all three cancellation controls; restoring the old suppression boundary independently fails the enrollment EoR control.
- `just gate` and `just gate-rib` pass, along with normal commit and push hooks.
