### PR TITLE
feat(release): add verified release installer

### DIFF
--- a/.github/workflows/release-install-contract.yml
+++ b/.github/workflows/release-install-contract.yml
@@ -26,6 +26,7 @@ on:
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
       - .github/workflows/release.yml
+      - packaging/install.sh
       - packaging/nfpm.yaml
       - scripts/build-packages.sh
       - scripts/check_release_install_contract.py
@@ -58,6 +59,7 @@ on:
       - examples/prometheus/rustbgpd-alerts_test.yml
       - tests/birdwatcher_adapter_smoke.rs
       - .github/workflows/release.yml
+      - packaging/install.sh
       - packaging/nfpm.yaml
       - scripts/build-packages.sh
       - scripts/check_release_install_contract.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,12 @@ jobs:
           echo "--- release-notes.md ---"
           cat release-notes.md
 
+      - name: Stage verified installer
+        # Publish the installer from the tagged checkout alongside the
+        # architecture-specific artifacts. It resolves one release tag before
+        # fetching an artifact and its matching checksum manifest.
+        run: cp packaging/install.sh artifacts/install.sh
+
       - name: Create GitHub Release
         # The only externally visible step in the workflow. Guarded on
         # the push event itself (not the dry_run input) so a dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Added a verified release installer that resolves one release tag, matches a
+  per-architecture checksum manifest, and supports explicit tags,
+  download-only, and tarball-prefix modes without starting a service.
+
 - The RIB logs one `post-commit first general query timing` record per
   committed export-policy transition that an operator read follows within
   ten seconds: the terminal commit poll's duration, the general queries and

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -40,6 +40,50 @@ note.
 
 ## Install
 
+### Verified installer
+
+The installer is available in this source checkout as
+[`packaging/install.sh`](../../packaging/install.sh). It will first be
+published as a release asset in v0.70.0; current published releases through
+v0.69.0 do not contain `install.sh`. It resolves `latest` once, then downloads
+the selected artifact and its matching per-architecture checksum manifest from
+that same tag. It refuses unknown architectures, non-glibc hosts, glibc below
+2.31, missing checksum rows, duplicate checksum rows, and checksum mismatches
+before installing.
+
+On Debian/Ubuntu it installs the verified native `.deb`; on RHEL, Rocky, and
+AlmaLinux 9+ it installs the verified native `.rpm`. The package keeps the
+existing non-replacing configuration behavior. The installer never enables or
+starts a service; edit the configuration and choose that step yourself.
+
+For a reproducible install from this checkout, inspect and run the installer
+with an explicit stable tag (`vMAJOR.MINOR.PATCH`):
+
+```sh
+less packaging/install.sh
+sh packaging/install.sh --tag v0.69.0
+```
+
+After v0.70.0 publishes the release asset, the same default path is available
+without a source checkout:
+
+```sh
+curl -fsSL https://github.com/lance0/rustbgpd/releases/latest/download/install.sh | sh
+```
+
+Other GNU/Linux distributions must use an explicit prefix or download-only
+mode. `--prefix` extracts the verified tarball's existing layout directly into
+an empty directory; it does not create users, write configuration, or install
+systemd units. `--download-only` writes the verified selected artifact and its
+manifest without installing either.
+
+```sh
+sh packaging/install.sh --tag v0.69.0 --prefix /opt/rustbgpd-0.69.0
+/opt/rustbgpd-0.69.0/rbgp doctor
+
+sh packaging/install.sh --tag v0.69.0 --download-only ./rustbgpd-v0.69.0
+```
+
 ### Pre-built binary tarball
 
 Tagged releases publish `rustbgpd-linux-amd64.tar.gz` and

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -43,6 +43,13 @@ rustbgpd --version && rbgp --version
 ```
 <!-- release-install-contract:tarball:end -->
 
+The verified installer currently lives in the source checkout at
+[`packaging/install.sh`](../../packaging/install.sh) and will first ship as a
+release asset in v0.70.0. Current published releases through v0.69.0 do not
+contain it, so use the tarball commands above today. The
+[deployment guide](../how-to/deployment.md#verified-installer) covers the
+installer's later release-asset path, explicit tags, and prefix mode.
+
 `rs-config-render` is the
 [IXP route-server config renderer](../../tools/rs-config-render/README.md);
 nothing below uses it, but it is in the same archive, so install it here

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# Download one rustbgpd release artifact, verify its published digest, and
+# install it only on a documented native-package path or an explicit prefix.
+set -eu
+
+REPOSITORY='https://github.com/lance0/rustbgpd'
+LATEST_URL="${REPOSITORY}/releases/latest"
+
+die() {
+    echo "rustbgpd installer: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [--tag vMAJOR.MINOR.PATCH] [--prefix DIR | --download-only DIR]
+
+Downloads one verified rustbgpd release artifact for this GNU/Linux host.
+Without a mode, Debian/Ubuntu installs the verified .deb and RHEL, Rocky, or
+AlmaLinux 9+ installs the verified .rpm. Other GNU/Linux distributions must
+use --prefix or --download-only. --prefix extracts the verified tarball's
+existing layout into an empty directory; it does not configure or start a
+service. --download-only writes the verified artifact and checksum manifest to
+DIR without installing anything.
+
+--tag accepts stable release tags only, such as v0.69.0.
+EOF
+}
+
+stable_tag() {
+    case "$1" in
+        v*) version=${1#v} ;;
+        *) return 1 ;;
+    esac
+    major=${version%%.*}
+    remainder=${version#*.}
+    [ "$remainder" != "$version" ] || return 1
+    minor=${remainder%%.*}
+    patch=${remainder#*.}
+    [ "$patch" != "$remainder" ] || return 1
+    case "$patch" in
+        *.*) return 1 ;;
+    esac
+    for part in "$major" "$minor" "$patch"; do
+        case "$part" in
+            ''|*[!0-9]*) return 1 ;;
+        esac
+    done
+}
+
+normalize_directory() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        -*) printf './%s\n' "$1" ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+tag=''
+prefix=''
+download_dir=''
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --tag)
+            [ "$#" -ge 2 ] || die '--tag needs a value'
+            [ -n "$2" ] || die '--tag needs a non-empty value'
+            tag=$2
+            shift 2
+            ;;
+        --prefix)
+            [ "$#" -ge 2 ] || die '--prefix needs a directory'
+            [ -n "$2" ] || die '--prefix needs a non-empty directory'
+            prefix=$(normalize_directory "$2")
+            shift 2
+            ;;
+        --download-only)
+            [ "$#" -ge 2 ] || die '--download-only needs a directory'
+            [ -n "$2" ] || die '--download-only needs a non-empty directory'
+            download_dir=$(normalize_directory "$2")
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -z "$prefix" ] || [ -z "$download_dir" ] \
+    || die '--prefix and --download-only cannot be combined'
+[ -z "$prefix" ] || [ ! -L "$prefix" ] \
+    || die "prefix must not be a symlink: $prefix"
+[ -z "$download_dir" ] || [ ! -L "$download_dir" ] \
+    || die "download destination must not be a symlink: $download_dir"
+
+case "$(uname -s)" in
+    Linux) ;;
+    *) die 'only GNU/Linux release artifacts are supported' ;;
+esac
+
+case "$(uname -m)" in
+    x86_64)
+        suffix='linux-amd64'
+        deb_arch='amd64'
+        rpm_arch='x86_64'
+        ;;
+    aarch64)
+        suffix='linux-arm64'
+        deb_arch='arm64'
+        rpm_arch='aarch64'
+        ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+esac
+
+glibc=$(getconf GNU_LIBC_VERSION 2>/dev/null || true)
+printf '%s\n' "$glibc" | awk '
+    $1 == "glibc" && $2 ~ /^[0-9]+\.[0-9]+$/ && NF == 2 {
+        split($2, version, ".")
+        exit !(version[1] > 2 || version[1] == 2 && version[2] >= 31)
+    }
+    { exit 1 }
+' \
+    || die 'requires GNU glibc 2.31 or newer'
+
+if [ -n "$tag" ]; then
+    stable_tag "$tag" || die "requires a stable release tag such as v0.69.0"
+else
+    resolved_url=$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$LATEST_URL") \
+        || die 'could not resolve the latest release tag'
+    expected_prefix="${REPOSITORY}/releases/tag/"
+    case "$resolved_url" in
+        "$expected_prefix"*) tag=${resolved_url#"$expected_prefix"} ;;
+        *) die "latest release resolved outside rustbgpd: $resolved_url" ;;
+    esac
+    stable_tag "$tag" || die "latest redirect returned a non-stable release tag"
+fi
+
+version=${tag#v}
+tarball="rustbgpd-${suffix}.tar.gz"
+artifact=$tarball
+install_kind='tarball'
+
+os_field() {
+    sed -n "s/^$1=//p" /etc/os-release 2>/dev/null | head -n 1 | tr -d '"'
+}
+
+if [ -z "$prefix" ]; then
+    os_id=$(os_field ID)
+    os_version=$(os_field VERSION_ID)
+    case "$os_id" in
+        debian|ubuntu)
+            artifact="rustbgpd_${version}_${deb_arch}.deb"
+            install_kind='deb'
+            if [ -z "$download_dir" ]; then
+                command -v apt-get >/dev/null 2>&1 \
+                    || die 'Debian/Ubuntu requires apt-get; use --prefix or --download-only'
+            fi
+            ;;
+        rhel|rocky|almalinux)
+            rhel_major=${os_version%%.*}
+            case "$rhel_major" in
+                ''|*[!0-9]*) die 'RHEL/Rocky/AlmaLinux version is not supported; use --prefix or --download-only' ;;
+            esac
+            [ "$rhel_major" -ge 9 ] \
+                || die 'RHEL/Rocky/AlmaLinux 9+ is required; use --prefix or --download-only'
+            artifact="rustbgpd-${version}-1.${rpm_arch}.rpm"
+            install_kind='rpm'
+            if [ -z "$download_dir" ]; then
+                command -v dnf >/dev/null 2>&1 \
+                    || die 'RHEL/Rocky/AlmaLinux requires dnf; use --prefix or --download-only'
+            fi
+            ;;
+        *)
+            if [ -z "$download_dir" ]; then
+                die 'this GNU/Linux distribution requires --prefix or --download-only'
+            fi
+            ;;
+    esac
+fi
+
+checksum="checksums-${suffix}.txt"
+base_url="${REPOSITORY}/releases/download/${tag}"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT HUP INT TERM
+
+curl -fsSL --retry 3 -o "$tmpdir/$checksum" "$base_url/$checksum" \
+    || die "could not download $checksum for $tag"
+curl -fsSL --retry 3 -o "$tmpdir/$artifact" "$base_url/$artifact" \
+    || die "could not download $artifact for $tag"
+
+match_count=$(awk -v file="$artifact" \
+    '$2 == file || $2 == "./" file { count++ } END { print count + 0 }' \
+    "$tmpdir/$checksum")
+[ "$match_count" -eq 1 ] \
+    || die "$checksum must contain exactly one digest for $artifact"
+awk -v file="$artifact" '$2 == file || $2 == "./" file { print }' \
+    "$tmpdir/$checksum" > "$tmpdir/checksum-row"
+(cd "$tmpdir" && sha256sum -c checksum-row) \
+    || die "checksum mismatch for $artifact"
+
+if [ -n "$download_dir" ]; then
+    mkdir -p "$download_dir"
+    if [ -e "$download_dir/$artifact" ] || [ -L "$download_dir/$artifact" ] \
+        || [ -e "$download_dir/$checksum" ] || [ -L "$download_dir/$checksum" ]; then
+        die "download destination already contains $artifact or $checksum"
+    fi
+    mv "$tmpdir/$artifact" "$tmpdir/$checksum" "$download_dir/"
+    echo "Verified $artifact and $checksum in $download_dir"
+    exit 0
+fi
+
+if [ -n "$prefix" ]; then
+    if [ -e "$prefix" ] || [ -L "$prefix" ]; then
+        [ -d "$prefix" ] || die "prefix is not a directory: $prefix"
+        [ -z "$(find "$prefix" -mindepth 1 -maxdepth 1 -print -quit)" ] \
+            || die "prefix must be empty: $prefix"
+    else
+        mkdir -p "$prefix"
+    fi
+    tar -xzf "$tmpdir/$tarball" -C "$prefix"
+    echo "Verified $tarball extracted into $prefix"
+    echo "Next: $prefix/rbgp doctor"
+    exit 0
+fi
+
+run_privileged() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        die 'root privileges or sudo are required for native package installation'
+    fi
+}
+
+case "$install_kind" in
+    deb) run_privileged apt-get install -y -o 'Dpkg::Options::=--force-confold' "$tmpdir/$artifact" < /dev/null ;;
+    rpm) run_privileged dnf install -y "$tmpdir/$artifact" < /dev/null ;;
+    *) die 'internal error: no native package selected' ;;
+esac
+echo 'Installed verified rustbgpd package. Edit its configuration, then run: rbgp doctor'

--- a/scripts/check_release_install_contract.py
+++ b/scripts/check_release_install_contract.py
@@ -43,6 +43,7 @@ SYSTEMD_TEMPLATE = "examples/systemd/rustbgpd@.service"
 SYSTEMD_CONTAINER_UNIT = "examples/systemd/rustbgpd-container.service"
 COMPOSE_FILE = "examples/docker-compose/docker-compose.yml"
 LICENSE_MAP = "LICENSES.md"
+INSTALLER = "packaging/install.sh"
 SYSTEMD_DIRECTIVES = {
     ("Unit", "StartLimitIntervalSec"): "10min",
     ("Unit", "StartLimitBurst"): "5",
@@ -478,6 +479,15 @@ def check(root: Path) -> list[str]:
             if clause not in license_map:
                 errors.append(f"license map: missing CDLA clause {clause!r}")
         release = read(".github/workflows/release.yml")
+        read(INSTALLER)
+        select_script(
+            release,
+            "installer release asset",
+            "cp packaging/install.sh artifacts/install.sh",
+        )
+        workflow = read(".github/workflows/release-install-contract.yml")
+        if workflow.count("      - packaging/install.sh") != 2:
+            errors.append("release install workflow must trigger for packaging/install.sh")
         build_packages = read("scripts/build-packages.sh")
         require_patterns(
             errors,
@@ -557,14 +567,13 @@ def check(root: Path) -> list[str]:
         if template_mapping not in mappings:
             errors.append(f"native systemd template mapping missing {template_mapping!r}")
 
-        contract = read(".github/workflows/release-install-contract.yml")
         select_script(
-            contract,
+            workflow,
             "container systemd syntax verification",
             "systemd-analyze verify examples/systemd/rustbgpd-container.service",
         )
         native = select_script(
-            contract,
+            workflow,
             "real native package assertions",
             'dpkg-deb -x "$deb" extracted/deb',
         )
@@ -604,7 +613,7 @@ def check(root: Path) -> list[str]:
             errors.append("RPM extraction must populate extracted/rpm, not stdout")
 
         image_command = "docker run --rm --entrypoint birdwatcher-adapter rustbgpd:release-install-contract --help"
-        select_script(contract, "production image adapter assertion", image_command)
+        select_script(workflow, "production image adapter assertion", image_command)
     except (OSError, ValueError) as error:
         errors.append(str(error))
     return errors

--- a/scripts/test_check_release_install_contract.py
+++ b/scripts/test_check_release_install_contract.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+import os
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -29,6 +31,7 @@ TAR_SIZE_ASSERT = (
 INPUTS = (
     WORKFLOW,
     RELEASE,
+    contract.INSTALLER,
     "packaging/nfpm.yaml",
     "scripts/build-packages.sh",
     "docs/grafana/rustbgpd-overview.json",
@@ -176,6 +179,18 @@ MUTATIONS = (
         TAR_SIZE_ASSERT,
         TAR_SIZE_ASSERT.replace("tar -xOzf", "echo 'tar -xOzf") + "'",
         "tarball active assertions",
+    ),
+    (
+        RELEASE,
+        "cp packaging/install.sh artifacts/install.sh",
+        "true",
+        "installer release asset",
+    ),
+    (
+        WORKFLOW,
+        "      - packaging/install.sh",
+        "      - packaging/removed-install.sh",
+        "release install workflow must trigger for packaging/install.sh",
     ),
     (
         contract.SYSTEMD_UNIT,
@@ -744,6 +759,301 @@ class ReleaseInstallContractTest(unittest.TestCase):
         self.assertTrue(
             any("tarball active assertions" in error for error in errors), errors
         )
+
+
+class VerifiedInstallerTest(unittest.TestCase):
+    """Exercise the released shell resolver against deterministic local assets."""
+
+    tag = "v0.69.0"
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.assets = self.root / "assets"
+        self.fakebin = self.root / "bin"
+        self.assets.mkdir()
+        self.fakebin.mkdir()
+        self.curl_log = self.root / "curl.log"
+        self.package_log = self.root / "package.log"
+        self.os_release = self.root / "os-release"
+        self.curl_log.touch()
+        self.package_log.touch()
+        self.set_os_release("debian", "12")
+        self.create_assets()
+        self.create_shims()
+
+    def set_os_release(self, distribution: str, version: str) -> None:
+        self.os_release.write_text(f"ID={distribution}\nVERSION_ID={version}\n")
+
+    def write_program(self, name: str, body: str) -> None:
+        path = self.fakebin / name
+        path.write_text(textwrap.dedent(body))
+        path.chmod(0o755)
+
+    def sha256(self, path: Path) -> str:
+        return subprocess.check_output(
+            ["sha256sum", path.name], cwd=self.assets, text=True
+        ).split()[0]
+
+    def create_assets(self) -> None:
+        payload = self.root / "payload"
+        (payload / "share").mkdir(parents=True)
+        (payload / "rbgp").write_text("#!/bin/sh\necho rbgp\n")
+        (payload / "rbgp").chmod(0o755)
+        (payload / "share" / "release-note").write_text("verified payload\n")
+
+        for suffix, deb_arch, rpm_arch in (
+            ("linux-amd64", "amd64", "x86_64"),
+            ("linux-arm64", "arm64", "aarch64"),
+        ):
+            tarball = f"rustbgpd-{suffix}.tar.gz"
+            subprocess.run(
+                ["tar", "-C", str(payload), "-czf", str(self.assets / tarball), "rbgp", "share"],
+                check=True,
+            )
+            deb = f"rustbgpd_0.69.0_{deb_arch}.deb"
+            rpm = f"rustbgpd-0.69.0-1.{rpm_arch}.rpm"
+            (self.assets / deb).write_text(f"{deb}\n")
+            (self.assets / rpm).write_text(f"{rpm}\n")
+            manifest = "\n".join(
+                (
+                    f"{self.sha256(self.assets / tarball)}  {tarball}",
+                    f"{self.sha256(self.assets / deb)}  ./{deb}",
+                    f"{self.sha256(self.assets / rpm)}  ./{rpm}",
+                )
+            )
+            (self.assets / f"checksums-{suffix}.txt").write_text(manifest + "\n")
+
+    def create_shims(self) -> None:
+        real_sed = shutil.which("sed")
+        self.assertIsNotNone(real_sed)
+        self.write_program(
+            "sed",
+            f"""\
+            #!/bin/sh
+            if [ "$#" -eq 3 ] && [ "$3" = /etc/os-release ]; then
+                exec "{real_sed}" "$1" "$2" "$FAKE_OS_RELEASE"
+            fi
+            exec "{real_sed}" "$@"
+            """,
+        )
+        self.write_program(
+            "curl",
+            """\
+            #!/bin/sh
+            set -eu
+            out=''
+            effective=false
+            url=''
+            while [ "$#" -gt 0 ]; do
+                case "$1" in
+                    -o) out=$2; shift 2 ;;
+                    -w) effective=true; shift 2 ;;
+                    *) url=$1; shift ;;
+                esac
+            done
+            printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
+            if [ "$url" = 'https://github.com/lance0/rustbgpd/releases/latest' ]; then
+                [ "$effective" = true ] || exit 1
+                printf '%s\\n' "${FAKE_LATEST_URL:-https://github.com/lance0/rustbgpd/releases/tag/v0.69.0}"
+                exit 0
+            fi
+            asset=${url##*/}
+            test -n "$out"
+            cp "$FAKE_RELEASE_DIR/$asset" "$out"
+            """,
+        )
+        self.write_program(
+            "uname",
+            """\
+            #!/bin/sh
+            case "$1" in
+                -s) printf '%s\\n' "${FAKE_UNAME_S:-Linux}" ;;
+                -m) printf '%s\\n' "${FAKE_UNAME_M:-x86_64}" ;;
+                *) exit 2 ;;
+            esac
+            """,
+        )
+        self.write_program(
+            "getconf",
+            """\
+            #!/bin/sh
+            test "$1" = GNU_LIBC_VERSION
+            printf '%s\\n' "${FAKE_GLIBC:-glibc 2.31}"
+            """,
+        )
+        self.write_program(
+            "sudo",
+            """\
+            #!/bin/sh
+            exec "$@"
+            """,
+        )
+        for manager in ("apt-get", "dnf"):
+            self.write_program(
+                manager,
+                """\
+                #!/bin/sh
+                printf '%s %s\\n' "$(basename "$0")" "$*" >> "$FAKE_PACKAGE_LOG"
+                """,
+            )
+
+    def run_installer(self, *args: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fakebin}:{env['PATH']}",
+                "FAKE_RELEASE_DIR": str(self.assets),
+                "FAKE_CURL_LOG": str(self.curl_log),
+                "FAKE_PACKAGE_LOG": str(self.package_log),
+                "FAKE_OS_RELEASE": str(self.os_release),
+            }
+        )
+        env.update(overrides)
+        return subprocess.run(
+            ["sh", str(ROOT / contract.INSTALLER), *args],
+            check=False,
+            text=True,
+            capture_output=True,
+            env=env,
+            cwd=self.root,
+        )
+
+    def test_latest_installs_the_verified_debian_amd64_deb(self) -> None:
+        result = self.run_installer()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "apt-get install -y -o Dpkg::Options::=--force-confold ",
+            self.package_log.read_text(),
+        )
+        self.assertIn("rustbgpd_0.69.0_amd64.deb", self.package_log.read_text())
+        self.assertIn("releases/latest", self.curl_log.read_text())
+        self.assertIn("releases/download/v0.69.0/", self.curl_log.read_text())
+
+    def test_rhel_family_installs_the_verified_rpm(self) -> None:
+        for distribution in ("rhel", "rocky", "almalinux"):
+            with self.subTest(distribution=distribution):
+                self.set_os_release(distribution, "9.4")
+                self.curl_log.write_text("")
+                self.package_log.write_text("")
+                result = self.run_installer("--tag", self.tag)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    self.package_log.read_text().split()[0],
+                    "dnf",
+                )
+                self.assertIn(
+                    "rustbgpd-0.69.0-1.x86_64.rpm",
+                    self.package_log.read_text(),
+                )
+
+    def test_explicit_tag_download_only_selects_arm64_package(self) -> None:
+        destination = self.root / "download"
+        result = self.run_installer(
+            "--tag", self.tag, "--download-only", str(destination), FAKE_UNAME_M="aarch64"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            {path.name for path in destination.iterdir()},
+            {"checksums-linux-arm64.txt", "rustbgpd_0.69.0_arm64.deb"},
+        )
+        self.assertNotIn("releases/latest", self.curl_log.read_text())
+        self.assertEqual(self.package_log.read_text(), "")
+
+    def test_prefix_extracts_the_verified_tarball_layout(self) -> None:
+        prefix = self.root / "prefix"
+        result = self.run_installer("--tag", self.tag, "--prefix", str(prefix))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((prefix / "rbgp").is_file())
+        self.assertEqual((prefix / "share" / "release-note").read_text(), "verified payload\n")
+        self.assertIn(f"Next: {prefix}/rbgp doctor", result.stdout)
+        self.assertEqual(self.package_log.read_text(), "")
+
+    def test_relative_directory_starting_with_dash_is_safe(self) -> None:
+        prefix = self.run_installer("--tag", self.tag, "--prefix", "-prefix")
+        self.assertEqual(prefix.returncode, 0, prefix.stderr)
+        self.assertTrue((self.root / "-prefix" / "rbgp").is_file())
+
+        download = self.run_installer(
+            "--tag", self.tag, "--download-only", "-download"
+        )
+        self.assertEqual(download.returncode, 0, download.stderr)
+        self.assertTrue((self.root / "-download" / "rustbgpd_0.69.0_amd64.deb").is_file())
+        self.assertEqual(self.package_log.read_text(), "")
+
+    def test_checksum_mismatch_stops_before_download_destination(self) -> None:
+        (self.assets / "rustbgpd_0.69.0_amd64.deb").write_text("tampered\n")
+        destination = self.root / "download"
+        result = self.run_installer("--tag", self.tag, "--download-only", str(destination))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("checksum mismatch", result.stderr)
+        self.assertFalse(destination.exists())
+        self.assertEqual(self.package_log.read_text(), "")
+
+    def test_duplicate_checksum_row_stops_before_download_destination(self) -> None:
+        manifest = self.assets / "checksums-linux-amd64.txt"
+        manifest.write_text(manifest.read_text() + manifest.read_text().splitlines()[1] + "\n")
+        destination = self.root / "download"
+        result = self.run_installer("--tag", self.tag, "--download-only", str(destination))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exactly one digest", result.stderr)
+        self.assertFalse(destination.exists())
+
+    def test_unknown_architecture_stops_before_download(self) -> None:
+        result = self.run_installer(FAKE_UNAME_M="ppc64le")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported architecture", result.stderr)
+        self.assertEqual(self.curl_log.read_text(), "")
+
+    def test_non_glibc_or_old_glibc_stops_before_download(self) -> None:
+        for glibc in ("musl 1.2", "glibc 2.30", "glibc .31", "glibc 3."):
+            with self.subTest(glibc=glibc):
+                result = self.run_installer(FAKE_GLIBC=glibc)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.curl_log.read_text(), "")
+
+    def test_empty_option_values_stop_before_package_invocation(self) -> None:
+        for option in ("--tag", "--prefix", "--download-only"):
+            with self.subTest(option=option):
+                self.curl_log.write_text("")
+                self.package_log.write_text("")
+                result = self.run_installer(option, "")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.curl_log.read_text(), "")
+                self.assertEqual(self.package_log.read_text(), "")
+
+    def test_dangling_destinations_stop_before_download(self) -> None:
+        for option in ("--prefix", "--download-only"):
+            with self.subTest(option=option):
+                destination = self.root / option.removeprefix("--")
+                destination.symlink_to(self.root / "missing")
+                self.curl_log.write_text("")
+                result = self.run_installer("--tag", self.tag, option, str(destination))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.curl_log.read_text(), "")
+                destination.unlink()
+
+    def test_unsupported_or_old_native_distro_stops_before_download(self) -> None:
+        for distribution, version in (("fedora", "40"), ("rhel", "8")):
+            with self.subTest(distribution=distribution, version=version):
+                self.set_os_release(distribution, version)
+                self.curl_log.write_text("")
+                self.package_log.write_text("")
+                result = self.run_installer("--tag", self.tag)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.curl_log.read_text(), "")
+                self.assertEqual(self.package_log.read_text(), "")
+
+    def test_non_stable_or_untrusted_tag_stops_before_artifact_download(self) -> None:
+        unsafe = self.run_installer("--tag", "v0.70.0-rc.1")
+        self.assertNotEqual(unsafe.returncode, 0)
+        self.assertEqual(self.curl_log.read_text(), "")
+
+        untrusted = self.run_installer(FAKE_LATEST_URL="https://example.invalid/tag/v0.69.0")
+        self.assertNotEqual(untrusted.returncode, 0)
+        self.assertIn("releases/latest", self.curl_log.read_text())
+        self.assertNotIn("releases/download/", self.curl_log.read_text())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `packaging/install.sh` as the v0.70.0 release installer. It resolves a stable tag once, selects the supported host asset, requires exactly one per-architecture checksum entry, and verifies before extraction or native installation.

The default path installs Debian/Ubuntu `.deb` or RHEL/Rocky/AlmaLinux 9+ `.rpm`; other GNU/Linux hosts must choose `--prefix` or `--download-only`. `--prefix` preserves the tarball layout, and native package installation neither overwrites an existing config nor starts or enables the service.

The release asset first ships with v0.70.0; current v0.69.0 and earlier instructions retain the manual tarball path.

Validation:

- `python3 scripts/test_check_release_install_contract.py`
- `python3 scripts/check_release_install_contract.py`
- `shellcheck packaging/install.sh`
- `just links`
- local v0.69.0 download-only and prefix extraction proof
- local Debian and Rocky 9 native-package proofs preserving an existing configuration and checking binary versions
- normal commit/push hooks: formatting, strict workspace Clippy, workspace library tests, and private-item rustdoc
