### PR TITLE
docs(api): classify checkliveness as read tier

### DIFF
--- a/docs/project/release-checklist.md
+++ b/docs/project/release-checklist.md
@@ -183,10 +183,11 @@ release:
       forgotten regeneration fails the build instead of drifting
       silently.
 - [ ] **No method sits at `read` unless it is pure liveness with zero
-      topology / route / policy / state disclosure.** The tier is
-      currently empty by design — anything read-only that exposes the
-      network belongs at `sensitive_read`. A new method landing at
-      `read` is the most likely under-tiering mistake; scrutinize it.
+      topology / route / policy / state disclosure.** `ControlService.CheckLiveness`
+      is the deliberate pure-liveness exception; it occupies this tier.
+      Anything else read-only that exposes topology, routes, policy, or state
+      belongs at `sensitive_read`. A new method landing at `read` is the most
+      likely under-tiering mistake; scrutinize it.
 - [ ] **Every event / explain / route-listing surface is
       `sensitive_read`+** — `WatchEvents`, `SubscribeFromEvent`,
       `List*Events`, `Explain*`, `List*Routes`, gNMI `Subscribe`. These


### PR DESCRIPTION
The release checklist still described the `read` authorization tier as empty, while `ControlService.CheckLiveness` is intentionally classified there for pure liveness without topology or state disclosure.

This updates the checklist to name that deliberate exception and keeps topology, route, policy, and state reads under `sensitive_read`. No runtime or authorization behavior changed.

Validation:

- release-checklist companion tests passed (12 tests)
- release-checklist path checker passed
- `just links` passed (2,254 OK, 0 errors)
- docs-only commit and push hooks passed; Rust hooks were skipped by path filters
