### PR TITLE
fix(repo): include license texts in published crates

### DIFF
--- a/crates/fsm/LICENSE-APACHE
+++ b/crates/fsm/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/fsm/LICENSE-MIT
+++ b/crates/fsm/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/rpki/LICENSE-APACHE
+++ b/crates/rpki/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/rpki/LICENSE-MIT
+++ b/crates/rpki/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/wire/LICENSE-APACHE
+++ b/crates/wire/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/wire/LICENSE-MIT
+++ b/crates/wire/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/docs/project/release-checklist.md
+++ b/docs/project/release-checklist.md
@@ -744,6 +744,10 @@ Before rolling any versions:
      selected by their own crate manifests and release steps; never align them
      to the daemon workspace bump. Retain both `path` and `version` so
      downstream publish dry-runs resolve from crates.io.
+   - [ ] Confirm each published library crate archive contains regular-file
+         `LICENSE-MIT` and `LICENSE-APACHE` entries whose contents match the
+         canonical repository-root license texts; the SPDX `MIT OR Apache-2.0`
+         metadata remains unchanged.
    - `crates/wire/Cargo.toml`: bump **only** if `crates/wire/src/` changed
      since the last wire publish (see semver rules in the next section).
      Land the wire bump in its **own commit** before the workspace bump so


### PR DESCRIPTION
Published library crate archives now carry the canonical MIT and Apache license texts alongside their manifests and READMEs.

The three independently published crates use relative links to the repository-root license texts, preserving the existing `MIT OR Apache-2.0` SPDX metadata and license terms. The maintained release checklist records the archive-content requirement.

Validation:

- Release-checklist path checker and 12 companion tests pass.
- `cargo package --locked --no-verify -p rustbgpd-wire -p rustbgpd-fsm -p rustbgpd-rpki` passes in an isolated target directory.
- All six archive entries are regular files and byte-identical to the repository-root license texts; packaged manifests retain `MIT OR Apache-2.0`.
- Normal commit and push hooks pass; Rust hooks were skipped because the change contains no Rust files.
